### PR TITLE
[BugFix] Update code to be compatible with py38

### DIFF
--- a/src/compressed_tensors/compressors/sparse_bitmask.py
+++ b/src/compressed_tensors/compressors/sparse_bitmask.py
@@ -67,7 +67,7 @@ class BitmaskCompressor(ModelCompressor):
                         f"found an existing entry for {key}. The existing entry will "
                         "be replaced."
                     )
-            compressed_dict |= bitmask_dict
+            compressed_dict.update(bitmask_dict)
 
         return compressed_dict
 


### PR DESCRIPTION
In one of the places we use shorthand operator `|=` to combine two dicts, this led to a py38 test failure as this syntax was introduced in python 3.9; Fix is to use `dict.update(...)` over `|=` 

Use `dict.update(...)` over `|=` as it was added in `py39`


Test plan: re-ran failing test with `py38` and it works:
```bash
(.venv) ➜  sparseml git:(main) pytest tests/sparseml/transformers/sparsification/test_compress_tensor_utils.py::test_sparse_model_reload
======================================================================= test session starts ========================================================================
platform linux -- Python 3.10.12, pytest-8.2.0, pluggy-1.5.0
rootdir: /root/projects/sparseml
configfile: pyproject.toml
plugins: mock-3.14.0, hydra-core-1.3.2, rerunfailures-14.0
collected 5 items                                                                                                                                                  

tests/sparseml/transformers/sparsification/test_compress_tensor_utils.py .....                                                                               [100%]

========================================================================= warnings summary =========================================================================
```