### PR TITLE
Fix per_token slowdown

### DIFF
--- a/src/compressed_tensors/quantization/observers/base.py
+++ b/src/compressed_tensors/quantization/observers/base.py
@@ -111,20 +111,5 @@ class Observer(Module, RegistryMixin):
         return self._scale, self._zero_point
 
     def get_qparams_along_dim(self, observed, dim: int):
-        # TODO: add documentation that specifies the shape must
-        #   be padded with 1-dims so the scales are along the right channel
-        # TODO: generalize the logic for reduce_dims
-        scales, zero_points = [], []
-
-        # TODO: make a more generic way to get the channel
-        num_dims = observed.shape[dim]
-
-        for dim_idx in range(num_dims):
-            scale, zero_point = self.calculate_qparams(
-                observed.select(dim=dim, index=dim_idx)
-            )
-
-            scales.append(scale)
-            zero_points.append(zero_point)
-        # breakpoint()
-        return torch.stack(scales), torch.stack(zero_points)
+        reduce_dims = tuple(idx for idx in range(observed.ndim) if idx != dim)
+        return self.calculate_qparams(observed, reduce_dims=reduce_dims)

--- a/src/compressed_tensors/quantization/observers/min_max.py
+++ b/src/compressed_tensors/quantization/observers/min_max.py
@@ -74,7 +74,3 @@ class MovingAverageMinMaxObserver(Observer):
             )
 
         return calculate_qparams(self.min_val, self.max_val, self.quantization_args)
-
-    def get_qparams_along_dim(self, observed, dim: int):
-        reduce_dims = tuple(idx for idx in range(observed.ndim) if idx != dim)
-        return self.calculate_qparams(observed, reduce_dims=reduce_dims)

--- a/tests/test_quantization/test_configs/test_strategies.py
+++ b/tests/test_quantization/test_configs/test_strategies.py
@@ -22,7 +22,6 @@ from compressed_tensors.quantization import (
     QuantizationStrategy,
     apply_quantization_config,
 )
-from compressed_tensors.quantization.lifecycle.forward import fake_quantize
 from torch.nn import Linear
 
 


### PR DESCRIPTION
We had vectorized the scale and zeropoint calculations for the minmax observer, but the memoryless observer was still using the un-vectorized code. Moved the `get_qparams_along_dim` to the base observer class so all observers use it, and resolved some shape issues. 

With this change the token,channel and tensor strategies can all use the same logic for calling quant/dequant so this simplified the forward pass code a lot too

### Testing
Running a llama1.1b model with w8a8 dynamic per token:

Before change: 10 sec/iteration
After change: 4.5 iterations/sec

A huge speedup!