### PR TITLE
Remove Symmetric Zero Point in Compressed Outputs

### DIFF
--- a/tests/test_compressors/test_pack_quant.py
+++ b/tests/test_compressors/test_pack_quant.py
@@ -71,7 +71,8 @@ def test_quant_format(shape):
     )
 
     # compressed state_dict adds one entry for shape
-    assert len(dense_state_dict) + 1 == len(compressed_state_dict)
+    # but removes the zero points since we are symmetric
+    assert len(dense_state_dict) == len(compressed_state_dict)
 
     # check compressed and packed
     assert compressed_state_dict["dummy.weight"].dtype == torch.int32
@@ -84,7 +85,6 @@ def test_quant_format(shape):
 
     assert torch.equal(compressed_state_dict["dummy.weight_shape"], torch.tensor(shape))
     assert compressed_state_dict["dummy.weight_scale"].dtype == torch.float32
-    assert compressed_state_dict["dummy.weight_zero_point"].dtype == torch.int32
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Requested by @dsikka, including the zero point in the state dict when the quantization is symmetric complicates the loading process in vLLM. On the compressed-tensors side, we now only save the zero point to the state_dict if it contains non-zeros (not symmetric). On reload in SparseML, the zero_point tensor will be recreated during decompression


### Testing 
Updated unit tests for the compressors to ensure the zero_point is removed from the state_dict in symmetric mode. The reload unit test already confirms we correctly recreate the zero_point during decompression