### PR TITLE
Fixed Grouped Quantization Reload

### DIFF
--- a/tests/test_compressors/test_int_quant.py
+++ b/tests/test_compressors/test_int_quant.py
@@ -97,8 +97,8 @@ def test_quant_format(strategy, symmetric, group_size, sc, zp):
         [
             QuantizationStrategy.GROUP,
             128,
-            torch.rand((300, 8, 1)) * 0.01,
-            torch.zeros((300, 8, 1), dtype=torch.int8),
+            torch.rand((300, 8)) * 0.01,
+            torch.zeros((300, 8), dtype=torch.int8),
         ],
         [
             QuantizationStrategy.CHANNEL,


### PR DESCRIPTION
Fixing two issues that came up during testing for grouped decompression:
* scale/zp dimmension had changed from 3 to 2, updating tests and strategy inference code accordingly
* weight dtype was changing from what model was initialized with during fake_quantization. Updated forward pass to always use the dtype of the original weight during fake_quant