### PR TITLE
Fix incorrect loading of dtype

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ from compressed_tensors import save_compressed_model, load_compressed, BitmaskCo
 from transformers import AutoModelForCausalLM
 
 model_name = "neuralmagic/llama2.c-stories110M-pruned50"
-model = AutoModelForCausalLM.from_pretrained(model_name)
+model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype="auto")
 
 original_state_dict = model.state_dict()
 
@@ -90,7 +90,7 @@ We can use compressed-tensors to run basic post training quantization (PTQ) and 
 
 ```python
 model_name = "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T"
-model = AutoModelForCausalLM.from_pretrained(model_name, device_map="cuda:0")
+model = AutoModelForCausalLM.from_pretrained(model_name, device_map="cuda:0", torch_dtype="auto")
 
 config = QuantizationConfig.parse_file("./examples/bit_packing/int4_config.json")
 config.quantization_status = QuantizationStatus.CALIBRATION

--- a/examples/bit_packing/ex_quantize_and_pack.py
+++ b/examples/bit_packing/ex_quantize_and_pack.py
@@ -38,7 +38,7 @@ pad_to_max_length = False
 output_dir = "./llama1.1b_new_quant_out_test_packing"
 device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
-model = AutoModelForCausalLM.from_pretrained(model_name, device_map=device)
+model = AutoModelForCausalLM.from_pretrained(model_name, device_map=device, torch_dtype="auto")
 model.eval()  # no grad or updates needed for base model
 config = QuantizationConfig.parse_file(config_file)
 

--- a/examples/bitmask_compression.ipynb
+++ b/examples/bitmask_compression.ipynb
@@ -71,7 +71,7 @@
    "source": [
     "# load a tiny, pruned llama2 model\n",
     "model_name = \"neuralmagic/llama2.c-stories110M-pruned50\"\n",
-    "model = AutoModelForCausalLM.from_pretrained(model_name)\n",
+    "model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=\"auto\")\n",
     "model"
    ]
   },

--- a/examples/llama_1.1b/ex_config_quantization.py
+++ b/examples/llama_1.1b/ex_config_quantization.py
@@ -37,7 +37,7 @@ pad_to_max_length = False
 output_dir = "./llama1.1b_new_quant_out"
 device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
-model = AutoModelForCausalLM.from_pretrained(model_name, device_map=device)
+model = AutoModelForCausalLM.from_pretrained(model_name, device_map=device, torch_dtype="auto")
 model.eval()  # no grad or updates needed for base model
 config = QuantizationConfig.parse_file(config_file)
 
@@ -83,5 +83,5 @@ model.apply(freeze_module_quantization)
 from sparseml.transformers.sparsification.compressed_tensors_utils import (
     modify_save_pretrained,
 )
-modify_save_pretrained(model) 
+modify_save_pretrained(model)
 model.save_pretrained(output_dir)

--- a/examples/llama_1.1b/ex_sparseml_quantization.py
+++ b/examples/llama_1.1b/ex_sparseml_quantization.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,7 +28,7 @@ pad_to_max_length = False
 output_dir = "./llama1.1b_old_quant_out"
 device = "cuda:0" if torch.cuda_is_available() else "cpu"
 
-model = SparseAutoModelForCausalLM.from_pretrained(model_name, device_map=device)
+model = SparseAutoModelForCausalLM.from_pretrained(model_name, device_map=device, torch_dtype="auto")
 
 tokenizer = AutoTokenizer.from_pretrained(model_name)
 data_args = DataTrainingArguments(

--- a/examples/quantize_and_pack_int4.ipynb
+++ b/examples/quantize_and_pack_int4.ipynb
@@ -23,9 +23,9 @@
     "import os\n",
     "from tqdm import tqdm\n",
     "from compressed_tensors.quantization import (\n",
-    "    QuantizationConfig, \n",
-    "    QuantizationStatus, \n",
-    "    apply_quantization_config, \n",
+    "    QuantizationConfig,\n",
+    "    QuantizationStatus,\n",
+    "    apply_quantization_config,\n",
     "    freeze_module_quantization,\n",
     "    compress_quantized_weights\n",
     ")\n",
@@ -45,7 +45,7 @@
     "# load a dense, unquantized tiny llama model\n",
     "device = \"cuda:0\"\n",
     "model_name = \"TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T\"\n",
-    "model = AutoModelForCausalLM.from_pretrained(model_name, device_map=device)\n",
+    "model = AutoModelForCausalLM.from_pretrained(model_name, device_map=device, torch_dtype=\"auto\")\n",
     "model"
    ]
   },
@@ -172,7 +172,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# convert quantized weights to integers \n",
+    "# convert quantized weights to integers\n",
     "model.apply(compress_quantized_weights)\n",
     "\n",
     "state_dict = model.state_dict()\n",

--- a/src/compressed_tensors/README.md
+++ b/src/compressed_tensors/README.md
@@ -7,7 +7,7 @@
 
 ## SafeTensors File Format
 
-For each parameter in the uncompressed state_dict, we store the following attributes 
+For each parameter in the uncompressed state_dict, we store the following attributes
 needed for decompression in the compressed state_dict:
 
 * compressed tensor
@@ -44,7 +44,7 @@ Config information gets stored in the HF config file
 }
 ```
 
-## Saving/Loading Interface 
+## Saving/Loading Interface
 
 Loading in a compressed model requires no interface changes
 
@@ -56,12 +56,13 @@ model_path = "/PATH/TO/COMPRESSED_MODEL"
 
 model = SparseAutoModelForCausalLM.from_pretrained(
     model_name_or_path=model_path,
+    torch_dtype="auto",
     **model_kwargs,
 )
 ```
 
 Saving a compressed model with an explicitly provided compression config. The config
-is saved to the model's `config.json` file. **Note:** the model must have been 
+is saved to the model's `config.json` file. **Note:** the model must have been
 initialized with SparseAutoModelForCausalLM.from_pretrained()
 
 ```python
@@ -85,7 +86,7 @@ model.save_pretrained(
 )
 ```
 
-Saving a model in the dense format. If the model has at least 5% global sparsity a 
+Saving a model in the dense format. If the model has at least 5% global sparsity a
 sparsity config will still be included in `config.json` with format `dense_sparsity`
 
 ```python
@@ -95,7 +96,7 @@ model.save_pretrained(
 ```
 
 Saving a model in the dense format, bypassing the sparsity config calculation. When the
-`skip_compression_stats` flag is set, no sparsity config will be written to 
+`skip_compression_stats` flag is set, no sparsity config will be written to
 `config.json`
 
 ```python
@@ -107,11 +108,11 @@ model.save_pretrained(
 
 ## Enable Compression During One-Shot and Sparse Finetunining
 Models that are saved in a supported compressed format on disk will automatically be
-decompressed when loaded as input to `sparseml.transformers.oneshot` or 
+decompressed when loaded as input to `sparseml.transformers.oneshot` or
 `sparseml.transformers.train`
 
-To enable compression on save after oneshot or finetuning simply add the 
-`save_compressed=True` argument to `sparseml.transformers.oneshot` or 
+To enable compression on save after oneshot or finetuning simply add the
+`save_compressed=True` argument to `sparseml.transformers.oneshot` or
 `sparseml.transformers.train`
 
 ```python
@@ -128,7 +129,7 @@ train(
 
 ## Example Code
 
-Loads a 60% sparse model, compresses it using the inferred bitmask compression, then 
+Loads a 60% sparse model, compresses it using the inferred bitmask compression, then
 reloads the compressed model.
 
 ```python
@@ -142,7 +143,7 @@ RECIPE = "zoo:llama2-7b-open_platypus_orca_llama2_pretrain-pruned60"
 
 torch.cuda.set_device(0)
 with measure_cuda_memory() as m:
-    model = SparseAutoModelForCausalLM.from_pretrained(MODEL_PATH, device_map="cuda:0")
+    model = SparseAutoModelForCausalLM.from_pretrained(MODEL_PATH, device_map="cuda:0", torch_dtype="auto")
 print(f"Load dense model peak GPU {m.overall_peak_memory / float(2**30):.4f} GB")
 
 sparsity_config = getattr(model,"sparsity_config", None)
@@ -154,7 +155,7 @@ print(f"Save compressed model peak GPU {m.overall_peak_memory / float(2**30):.4f
 torch.cuda.set_device(1)
 with measure_cuda_memory() as m:
     model_again = SparseAutoModelForCausalLM.from_pretrained(
-        OUTPUT_PATH, device_map="cuda:1"
+        OUTPUT_PATH, device_map="cuda:1", torch_dtype="auto"
     )
 print(f"Load compressed model peak GPU {m.overall_peak_memory / float(2**30):.4f} GB")
 sparsity_config = getattr(model_again,"sparsity_config", None)

--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -130,7 +130,8 @@ def _test_layer_quantization_status(
 
 def get_tinyllama_model():
     return AutoModelForCausalLM.from_pretrained(
-        "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T"
+        "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T",
+        torch_dtype="auto",
     )
 
 

--- a/tests/test_quantization/lifecycle/test_dynamic_lifecycle.py
+++ b/tests/test_quantization/lifecycle/test_dynamic_lifecycle.py
@@ -83,7 +83,8 @@ def _test_layer_dynamic_quantization_status(
 
 def get_tinyllama_model():
     return AutoModelForCausalLM.from_pretrained(
-        "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T"
+        "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T",
+        torch_dtype="auto",
     )
 
 

--- a/tests/test_utils/test_helpers.py
+++ b/tests/test_utils/test_helpers.py
@@ -31,7 +31,7 @@ def tensors():
 @pytest.fixture
 def llama_model(tmp_path):
     model_name = "neuralmagic/llama2.c-stories110M-pruned50"
-    model = AutoModelForCausalLM.from_pretrained(model_name, cache_dir=tmp_path)
+    model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype="auto", cache_dir=tmp_path)
     yield model
 
 


### PR DESCRIPTION
Loading models with `AutoModelForCausalLM` or `SparseAutoModelForCausalLM` without explicitly specifying `torch_dtype="auto"` loads the weights into `fp32` and ignores `torch_dtype` entry from `config.json`. This is the default behavior of HF-transformers which we want to override so that conversion to compressed-tensors preserves the dtype of the original model.