### PR TITLE
Remove version restriction on transformers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def _setup_packages() -> List:
     )
     
 def _setup_install_requires() -> List:
-    return ["torch>=1.7.0", "transformers<4.41", "pydantic<2.7"]
+    return ["torch>=1.7.0", "transformers", "pydantic<2.7"]
 
 def _setup_extras() -> Dict:
     return {"dev": ["black==22.12.0", "isort==5.8.0", "wheel>=0.36.2", "flake8>=3.8.3", "pytest>=6.0.0", "nbconvert>=7.16.3"]}


### PR DESCRIPTION
Allow any future versions of transformers since we are just using it for `AutoConfig` at the moment and would like to support new models.