### PR TITLE
Restrict NumPy Version <2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def _setup_packages() -> List:
     )
     
 def _setup_install_requires() -> List:
-    return ["torch>=1.7.0", "transformers", "pydantic>=2.0"]
+    return ["torch>=1.7.0", "numpy>=1.17.0,<2.0", "transformers", "pydantic>=2.0"]
 
 def _setup_extras() -> Dict:
     return {"dev": ["black==22.12.0", "isort==5.8.0", "wheel>=0.36.2", "flake8>=3.8.3", "pytest>=6.0.0", "nbconvert>=7.16.3"]}


### PR DESCRIPTION
NumPy 2.0 released on June 16th, it broke some dependencies in SparseML. For the 1.8 release, I think its best we just restrict the version to < 2.0