### PR TITLE
[compressor] Add packed int8 support

### DIFF
--- a/src/compressed_tensors/compressors/base.py
+++ b/src/compressed_tensors/compressors/base.py
@@ -45,7 +45,7 @@ class Compressor(RegistryMixin):
         raise NotImplementedError()
 
     def decompress(
-        self, path_to_model_or_tensors: str, device: str = "cpu"
+        self, path_to_model_or_tensors: str, device: str = "cpu", **kwargs
     ) -> Generator[Tuple[str, Tensor], None, None]:
         """
         Reads a compressed state dict located at path_to_model_or_tensors

--- a/src/compressed_tensors/compressors/marlin_24.py
+++ b/src/compressed_tensors/compressors/marlin_24.py
@@ -107,7 +107,7 @@ class Marlin24Compressor(Compressor):
     def compress(
         self,
         model_state: Dict[str, Tensor],
-        model_quant_args: Dict[str, QuantizationArgs],
+        names_to_scheme: Dict[str, QuantizationArgs],
         **kwargs,
     ) -> Dict[str, Tensor]:
         """
@@ -115,11 +115,11 @@ class Marlin24Compressor(Compressor):
         with the Marlin24 kernel
 
         :param model_state: state dict of uncompressed model
-        :param model_quant_args: quantization args for each quantized weight, needed for
+        :param names_to_scheme: quantization args for each quantized weight, needed for
            quantize function to calculate bit depth
         :return: compressed state dict
         """
-        self.validate_quant_compatability(model_quant_args)
+        self.validate_quant_compatability(names_to_scheme)
 
         compressed_dict = {}
         weight_suffix = ".weight"
@@ -139,7 +139,7 @@ class Marlin24Compressor(Compressor):
                     value = value.to(torch.float16)
 
                     # quantize weight, keeping it as a float16 for now
-                    quant_args = model_quant_args[prefix]
+                    quant_args = names_to_scheme[prefix]
                     value = quantize(
                         x=value, scale=scale, zero_point=zp, args=quant_args
                     )

--- a/src/compressed_tensors/compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressor.py
@@ -231,7 +231,7 @@ class ModelCompressor:
         quantized_modules_to_args = map_modules_to_quant_args(model)
         if self.quantization_compressor is not None:
             compressed_state_dict = self.quantization_compressor.compress(
-                state_dict, model_quant_args=quantized_modules_to_args
+                state_dict, names_to_scheme=quantized_modules_to_args
             )
 
         if self.sparsity_compressor is not None:

--- a/src/compressed_tensors/compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressor.py
@@ -28,7 +28,7 @@ from compressed_tensors.base import (
     SPARSITY_CONFIG_NAME,
 )
 from compressed_tensors.compressors import Compressor
-from compressed_tensors.config import CompressionFormat, SparsityCompressionConfig
+from compressed_tensors.config import SparsityCompressionConfig
 from compressed_tensors.quantization import (
     QuantizationConfig,
     QuantizationStatus,
@@ -262,15 +262,9 @@ class ModelCompressor:
         if self.quantization_compressor is not None:
             names_to_scheme = apply_quantization_config(model, self.quantization_config)
             load_pretrained_quantization(model, model_path)
-            if (
-                self.quantization_config.format
-                == CompressionFormat.pack_quantized.value
-            ):
-                dense_gen = self.quantization_compressor.decompress(
-                    model_path, names_to_scheme=names_to_scheme
-                )
-            else:
-                dense_gen = self.quantization_compressor.decompress(model_path)
+            dense_gen = self.quantization_compressor.decompress(
+                model_path, names_to_scheme=names_to_scheme
+            )
             self._replace_weights(dense_gen, model)
 
             def update_status(module):

--- a/src/compressed_tensors/compressors/naive_quantized.py
+++ b/src/compressed_tensors/compressors/naive_quantized.py
@@ -49,14 +49,14 @@ class QuantizationCompressor(Compressor):
     def compress(
         self,
         model_state: Dict[str, Tensor],
-        model_quant_args: Dict[str, QuantizationArgs],
+        names_to_scheme: Dict[str, QuantizationArgs],
         **kwargs,
     ) -> Dict[str, Tensor]:
         """
         Compresses a dense state dict
 
         :param model_state: state dict of uncompressed model
-        :param model_quant_args: quantization args for each quantized weight, needed for
+        :param names_to_scheme: quantization args for each quantized weight, needed for
         quantize function to calculate bit depth
         :return: compressed state dict
         """
@@ -73,7 +73,7 @@ class QuantizationCompressor(Compressor):
                 zp = model_state.get(merge_names(prefix, "weight_zero_point"), None)
                 if scale is not None and zp is not None:
                     # weight is quantized, compress it
-                    quant_args = model_quant_args[prefix]
+                    quant_args = names_to_scheme[prefix]
                     if can_quantize(value, quant_args):
                         # only quantize if not already quantized
                         value = quantize(

--- a/src/compressed_tensors/compressors/pack_quantized.py
+++ b/src/compressed_tensors/compressors/pack_quantized.py
@@ -90,7 +90,7 @@ class PackedQuantizationCompressor(Compressor):
                             args=quant_args,
                             dtype=torch.int8,
                         )
-                    if model_quant_args.num_bits == 4:
+                    if model_quant_args.get("num_bits") == 4:
                         value = pack_4bit_ints(value.cpu())
                     else:
                         value = pack_8bit_ints(value.cpu())

--- a/src/compressed_tensors/compressors/pack_quantized.py
+++ b/src/compressed_tensors/compressors/pack_quantized.py
@@ -56,14 +56,14 @@ class PackedQuantizationCompressor(Compressor):
     def compress(
         self,
         model_state: Dict[str, Tensor],
-        model_quant_args: Dict[str, QuantizationArgs],
+        names_to_scheme: Dict[str, QuantizationArgs],
         **kwargs,
     ) -> Dict[str, Tensor]:
         """
         Compresses a dense state dict
 
         :param model_state: state dict of uncompressed model
-        :param model_quant_args: quantization args for each quantized weight, needed for
+        :param names_to_scheme: quantization args for each quantized weight, needed for
         quantize function to calculate bit depth
         :return: compressed state dict
         """
@@ -81,7 +81,7 @@ class PackedQuantizationCompressor(Compressor):
                 shape = torch.tensor(value.shape)
                 if scale is not None and zp is not None:
                     # weight is quantized, compress it
-                    quant_args = model_quant_args[prefix]
+                    quant_args = names_to_scheme[prefix]
                     if can_quantize(value, quant_args):
                         # convert weight to an int if not already compressed
                         value = quantize(

--- a/src/compressed_tensors/compressors/pack_quantized.py
+++ b/src/compressed_tensors/compressors/pack_quantized.py
@@ -90,10 +90,10 @@ class PackedQuantizationCompressor(Compressor):
                             args=quant_args,
                             dtype=torch.int8,
                         )
-                    if model_quant_args.get("num_bits") == 4:
-                        value = pack_4bit_ints(value.cpu())
-                    else:
+                    if model_quant_args.get("num_bits") == 8:
                         value = pack_8bit_ints(value.cpu())
+                    else:
+                        value = pack_4bit_ints(value.cpu())
                     compressed_dict[merge_names(prefix, "weight_shape")] = shape
                     compressed_dict[merge_names(prefix, "weight_packed")] = value
                     continue

--- a/src/compressed_tensors/compressors/pack_quantized.py
+++ b/src/compressed_tensors/compressors/pack_quantized.py
@@ -90,7 +90,8 @@ class PackedQuantizationCompressor(Compressor):
                             args=quant_args,
                             dtype=torch.int8,
                         )
-                    if model_quant_args.get("num_bits") == 8:
+
+                    if quant_args.num_bits == 8:
                         value = pack_8bit_ints(value.cpu())
                     else:
                         value = pack_4bit_ints(value.cpu())

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from typing import Optional
 
 from transformers import AutoConfig

--- a/tests/test_compressors/test_fp8_quant.py
+++ b/tests/test_compressors/test_fp8_quant.py
@@ -79,7 +79,7 @@ def test_quant_format(strategy, group_size, sc, zp):
     compressor = FloatQuantizationCompressor(config=quant_config)
     quantized_modules_to_args = {"dummy": quant_config.config_groups["group_1"].weights}
     compressed_state_dict = compressor.compress(
-        dense_state_dict, model_quant_args=quantized_modules_to_args
+        dense_state_dict, names_to_scheme=quantized_modules_to_args
     )
 
     # state_dict params should be the same, minus the zero_point if symmetric
@@ -118,7 +118,7 @@ def test_reload_match(strategy, group_size, tmp_path):
         "dummy": quant_config.config_groups["group_1"].weights,
     }
     compressed_state_dict = compressor.compress(
-        model.state_dict(), model_quant_args=quantized_modules_to_args
+        model.state_dict(), names_to_scheme=quantized_modules_to_args
     )
     save_file(compressed_state_dict, tmp_path / "model.safetensors")
     reconstructed_dense_gen = compressor.decompress(tmp_path)

--- a/tests/test_compressors/test_int_quant.py
+++ b/tests/test_compressors/test_int_quant.py
@@ -74,7 +74,7 @@ def test_quant_format(strategy, symmetric, group_size, sc, zp):
     compressor = IntQuantizationCompressor(config=quant_config)
     quantized_modules_to_args = {"dummy": quant_config.config_groups["group_1"].weights}
     compressed_state_dict = compressor.compress(
-        dense_state_dict, model_quant_args=quantized_modules_to_args
+        dense_state_dict, names_to_scheme=quantized_modules_to_args
     )
 
     # state_dict params should be the same, minus the zero_point if symmetric
@@ -125,7 +125,7 @@ def test_reload_match(strategy, group_size, sc, zp, tmp_path):
         "dummy2": quant_config.config_groups["group_1"].weights,
     }
     compressed_state_dict = compressor.compress(
-        dense_state_dict, model_quant_args=quantized_modules_to_args
+        dense_state_dict, names_to_scheme=quantized_modules_to_args
     )
     save_file(compressed_state_dict, tmp_path / "model.safetensors")
     reconstructed_dense_gen = compressor.decompress(tmp_path)

--- a/tests/test_compressors/test_pack_quant.py
+++ b/tests/test_compressors/test_pack_quant.py
@@ -115,6 +115,10 @@ def test_reload_match(tmp_path):
         "dummy2.weight_scale": torch.tensor(0.02, dtype=torch.float32),
         "dummy2.weight_zero_point": torch.tensor(15, dtype=torch.int8),
     }
+    names_to_scheme = {
+        "dummy": QuantizationArgs(num_bits=4),
+        "dummy2": QuantizationArgs(num_bits=4),
+    }
     quant_config = get_dummy_quant_config()
 
     compressor = PackedQuantizationCompressor(config=quant_config)
@@ -126,7 +130,9 @@ def test_reload_match(tmp_path):
         dense_state_dict, model_quant_args=quantized_modules_to_args
     )
     save_file(compressed_state_dict, tmp_path / "model.safetensors")
-    reconstructed_dense_gen = compressor.decompress(tmp_path)
+    reconstructed_dense_gen = compressor.decompress(
+        tmp_path, names_to_scheme=names_to_scheme
+    )
     reconstructed_dense = {}
     for name, value in reconstructed_dense_gen:
         reconstructed_dense[name] = value

--- a/tests/test_compressors/test_pack_quant.py
+++ b/tests/test_compressors/test_pack_quant.py
@@ -116,7 +116,7 @@ def test_reload_match(tmp_path, num_bits):
         "dummy2.weight_scale": torch.tensor(0.02, dtype=torch.float32),
         "dummy2.weight_zero_point": torch.tensor(15, dtype=torch.int8),
     }
-    print("num bits", num_bits)
+
     names_to_scheme = {
         "dummy": QuantizationArgs(num_bits=num_bits),
         "dummy2": QuantizationArgs(num_bits=num_bits),

--- a/tests/test_compressors/test_pack_quant.py
+++ b/tests/test_compressors/test_pack_quant.py
@@ -67,7 +67,7 @@ def test_quant_format(shape):
     compressor = PackedQuantizationCompressor(config=quant_config)
     quantized_modules_to_args = {"dummy": quant_config.config_groups["group_1"].weights}
     compressed_state_dict = compressor.compress(
-        dense_state_dict, model_quant_args=quantized_modules_to_args
+        dense_state_dict, names_to_scheme=quantized_modules_to_args
     )
 
     # compressed state_dict adds one entry for shape
@@ -129,7 +129,7 @@ def test_reload_match(tmp_path, num_bits):
         "dummy2": quant_config.config_groups["group_1"].weights,
     }
     compressed_state_dict = compressor.compress(
-        dense_state_dict, model_quant_args=quantized_modules_to_args
+        dense_state_dict, names_to_scheme=quantized_modules_to_args
     )
     save_file(compressed_state_dict, tmp_path / "model.safetensors")
     reconstructed_dense_gen = compressor.decompress(


### PR DESCRIPTION
# Summary

- Add the ability to pack int8 tensors into int32 packed weights
- This will allow the w8a16 models to run with the gpt_marlin kernels in vllm 

# Testing:

- Tested using the following recipe/script
```python
import torch

from sparseml.transformers import SparseAutoModelForCausalLM, oneshot


# define a sparseml recipe for GPTQ W8A8 quantization
recipe = """
quant_stage:
    quant_modifiers:
        GPTQModifier:
            sequential_update: false
            ignore: ["lm_head"]
            config_groups:
                group_0:
                    weights:
                        num_bits: 8
                        type: "int"
                        symmetric: true
                        strategy: "channel"
                    targets: ["Linear"]
"""

# setting device_map to auto to spread the model evenly across all available GPUs
# load the model in as bfloat16 to save on memory and compute
model_stub = "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T"
model = SparseAutoModelForCausalLM.from_pretrained(
    model_stub, torch_dtype=torch.bfloat16, device_map="auto"
)

# uses SparseML's built-in preprocessing for ultra chat
dataset = "ultrachat-200k"

# save location of quantized model out
output_dir = "./output_llama1b_w8a16_channel_compressed"

# set dataset config parameters
splits = {"calibration": "train_gen[:5%]"}
max_seq_length = 512
pad_to_max_length = False
num_calibration_samples = 512

# apply recipe to the model and save quantized output in an int4 packed format
oneshot(
    model=model,
    dataset=dataset,
    recipe=recipe,
    output_dir=output_dir,
    splits=splits,
    max_seq_length=max_seq_length,
    pad_to_max_length=pad_to_max_length,
    num_calibration_samples=num_calibration_samples,
    save_compressed=True,
)

model.save_pretrained(output_dir, quantization_format="pack-quantized")
```

#### The produced model was then tested and ran in vllm without issue

```python

from vllm import LLM, SamplingParams
import torch

# Sample prompts.
prompts = [
    "Hello, my name is",
    "The capital of France is",
    "The president of the United States is",
    "The Boston Bruins are"
]
# Create a sampling params object.
sampling_params = SamplingParams(temperature=1, top_p=1)


llm = LLM(model="/root/output_llama1b_w8a16_channel_compressed")
outputs = llm.generate(prompts, sampling_params)
# Print the outputs.
for output in outputs:
    prompt = output.prompt
    generated_text = output.outputs[0].text
    print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")

```
#### Output:

```bash
Prompt: 'Hello, my name is', Generated text: ' PR Business Incubator Mohammed, and I am studying English and Computer Science'
Prompt: 'The capital of France is', Generated text: " Paris, but it's a city with plenty of blue-collar people"
Prompt: 'The president of the United States is', Generated text: ': evangelicals are influential in the political process; Gallup finds that'
Prompt: 'The Boston Bruins are', Generated text: " among the NHL's hottest teams as of late. They'"
```
