### PR TITLE
Allow creating compressor when `trust_remote_code=True`

### DIFF
--- a/src/compressed_tensors/compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressor.py
@@ -81,6 +81,7 @@ class ModelCompressor:
     def from_pretrained(
         cls,
         pretrained_model_name_or_path: str,
+        **kwargs,
     ) -> Optional["ModelCompressor"]:
         """
         Given a path to a model config, extract the sparsity and/or quantization
@@ -89,7 +90,7 @@ class ModelCompressor:
         :param pretrained_model_name_or_path: path to model config on disk or HF hub
         :return: compressor for the extracted configs
         """
-        config = AutoConfig.from_pretrained(pretrained_model_name_or_path)
+        config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **kwargs)
         compression_config = getattr(config, COMPRESSION_CONFIG_NAME, None)
         return cls.from_compression_config(compression_config)
 


### PR DESCRIPTION
This code:

```python
from compressed_tensors import ModelCompressor
compressor = ModelCompressor.from_pretrained("microsoft/Phi-3-mini-128k-instruct",trust_remote_code=True)
```

Failed before:

```bash
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/root/compressed-tensors/.venv/lib/python3.10/site-packages/transformers/models/auto/configuration_auto.py", line 983, in from_pretrained
    return config_class.from_dict(config_dict, **unused_kwargs)
  File "/root/compressed-tensors/.venv/lib/python3.10/site-packages/transformers/configuration_utils.py", line 772, in from_dict
    config = cls(**config_dict)
  File "/root/compressed-tensors/.venv/lib/python3.10/site-packages/transformers/models/phi3/configuration_phi3.py", line 158, in __init__
    self._rope_scaling_validation()
  File "/root/compressed-tensors/.venv/lib/python3.10/site-packages/transformers/models/phi3/configuration_phi3.py", line 185, in _rope_scaling_validation
    raise ValueError(f"`rope_scaling`'s type field must be one of ['su', 'yarn'], got {rope_scaling_type}")
ValueError: `rope_scaling`'s type field must be one of ['su', 'yarn'], got longrope
```
After the diff, we can properly initialize the config (and thus the compressor, although in this example it will be None) with `trust_remote_code=True`
