### PR TITLE
Do not mutate config by `apply_quantization_config`

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -15,6 +15,7 @@
 import logging
 import re
 from collections import OrderedDict
+from copy import deepcopy
 from typing import Dict, Iterable, List, Optional
 from typing import OrderedDict as OrderedDictType
 from typing import Union
@@ -109,6 +110,11 @@ def apply_quantization_config(model: Module, config: QuantizationConfig) -> Dict
     :param model: model to apply quantization config to
     :param config: quantization config
     """
+    # remove reference to the original `config`
+    # argument. This function can mutate it, and we'd
+    # like to keep the original `config` as it is.
+    _config = config
+    config = deepcopy(_config)
     # build mapping of targets to schemes for easier matching
     # use ordered dict to preserve target ordering in config
     target_to_scheme = OrderedDict()

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -113,8 +113,7 @@ def apply_quantization_config(model: Module, config: QuantizationConfig) -> Dict
     # remove reference to the original `config`
     # argument. This function can mutate it, and we'd
     # like to keep the original `config` as it is.
-    _config = config
-    config = deepcopy(_config)
+    config = deepcopy(config)
     # build mapping of targets to schemes for easier matching
     # use ordered dict to preserve target ordering in config
     target_to_scheme = OrderedDict()


### PR DESCRIPTION
In the examples like `examples/bit_packing/ex_quantize_and_pack.py` we call the `apply_quantization_config`. It changes in-place its config argument by adding `kv_cache` quantization group to the quantization group dictionary. This is desirable for the general logic, but should not be applied to the original `config` object, since it will be further appended to the model's `config.json`