### PR TITLE
quatization lifecycle - disable forward pass override + helper for weight quant param updates

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/__init__.py
+++ b/src/compressed_tensors/quantization/lifecycle/__init__.py
@@ -21,4 +21,4 @@ from .frozen import *
 from .initialize import *
 from .compressed import *
 from .apply import *
-from .enable import *
+from .helpers import *

--- a/src/compressed_tensors/quantization/lifecycle/enable.py
+++ b/src/compressed_tensors/quantization/lifecycle/enable.py
@@ -12,13 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# flake8: noqa
-# isort: skip_file
+"""
+Enable/Disable compressed-tensors quantization from being used during
+model forward passes
+"""
 
-from .calibration import *
-from .forward import *
-from .frozen import *
-from .initialize import *
-from .compressed import *
-from .apply import *
-from .enable import *
+
+from torch.nn import Module
+
+
+__all__ = [
+    "enable_quantization",
+    "disable_quantization",
+]
+
+
+def enable_quantization(module: Module):
+    module.quantization_enabled = True
+
+
+def disable_quantization(module: Module):
+    module.quantization_enabled = False

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -245,6 +245,11 @@ def wrap_module_forward_quantized(module: Module, scheme: QuantizationScheme):
 
     @wraps(forward_func_orig)  # ensures docstring, names, etc are propagated
     def wrapped_forward(self, *args, **kwargs):
+        if not getattr(module, "quantization_enabled", True):
+            # quantization is disabled on forward passes, return baseline
+            # forward call
+            return forward_func_orig.__get__(module, module.__class__)(*args, **kwargs)
+
         input_ = args[0]
 
         if scheme.input_activations is not None:

--- a/tests/test_quantization/lifecycle/test_enabled.py
+++ b/tests/test_quantization/lifecycle/test_enabled.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from copy import deepcopy
+
+import torch
+from compressed_tensors.quantization import (
+    QuantizationConfig,
+    apply_quantization_config,
+    disable_quantization,
+    enable_quantization,
+)
+from torch.nn import Linear
+
+
+def test_quantization_enabled_disabled():
+    inp = torch.randn(16)
+    model = Linear(16, 16)
+    quantized_model = deepcopy(model)
+    apply_quantization_config(
+        model=quantized_model,
+        config=QuantizationConfig(
+            config_groups=dict(W4A16=["Linear"]),
+            quantization_status="calibration",
+        ),
+    )
+
+    # run one calibration pass
+    quantized_model(inp)
+
+    model_output = model(inp)
+    quantized_model_output = quantized_model(inp)
+
+    # quantized and non quantized outputs should be different
+    assert not torch.all(model_output == quantized_model_output)
+
+    # disable quantization
+    quantized_model.apply(disable_quantization)
+    # check that quantized model now matches model output
+    assert torch.all(model_output == quantized_model(inp))
+
+    # re-enable quantization
+    quantized_model.apply(enable_quantization)
+    # check that quantized model matches original quantized output
+    assert torch.all(quantized_model_output == quantized_model(inp))


### PR DESCRIPTION
adds `enable_quantization` and `disable_quantization`, which modifies a layer's new `quantization_enabled` property. if set to False, then no overrides of the forward pass will be in affect when running.  In practices applying this to a model `model.apply(disable_quantization)` reverts the model to its original run state.

also adds a small helper function that updates a layer's weight scale and zero point based on the current weight values

practical use of this will be for llm-compressor implemetation of GPTQ which requires pre-initialization of scales and zero points but should not use these values during initial hessian calibration

quantization is by default enabled

unit test included

@Satrat note that this will be incompatible with run_compressed (although not a compatibility that should really be needed)