### PR TITLE
Add FP8 Dynamic Scheme for Latest Llama3.1 Meta Models and Fix W4A8 Representation

### DIFF
--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -165,7 +165,7 @@ W4A8 = dict(
     input_activations=QuantizationArgs(
         num_bits=8,
         type=QuantizationType.INT,
-        strategy=QuantizationStrategy.TENSOR,
+        strategy=QuantizationStrategy.TOKEN,
         symmetric=True,
         dynamic=True,
     ),
@@ -189,6 +189,24 @@ FP8 = dict(
     ),
 )
 
+# FP8 weights and FP8 dynamic activations quantization
+FP8_DYNAMIC = dict(
+    weights=QuantizationArgs(
+        num_bits=8,
+        type=QuantizationType.FLOAT,
+        strategy=QuantizationStrategy.CHANNEL,
+        symmetric=True,
+        dynamic=False,
+    ),
+    input_activations=QuantizationArgs(
+        num_bits=8,
+        type=QuantizationType.FLOAT,
+        strategy=QuantizationStrategy.TOKEN,
+        symmetric=True,
+        dynamic=True,
+    ),
+)
+
 PRESET_SCHEMES = {
     # Integer weight only schemes
     "W8A16": W8A16,
@@ -198,4 +216,5 @@ PRESET_SCHEMES = {
     "W4A8": W4A8,
     # Float weight and activation schemes
     "FP8": FP8,
+    "FP8_DYNAMIC": FP8_DYNAMIC,
 }


### PR DESCRIPTION
## Summary

Introduces a new FP8 dynamic quantization scheme for the latest Llama 3.1 models from Meta and addresses an issue with the W4A8 representation by setting dynamic token level for activations.

## Details
- FP8 Dynamic Scheme: Added a new FP8 dynamic quantization scheme to support the latest Llama3.1 models. This scheme applies dynamic quantization to the input activations.
- W4A8 Representation Fix: Fixed an issue with the W4A8 representation by changing the strategy for activations to dynamic, ensuring more accurate quantization.

## Test Plan
- Comprehensive tests to be added for these schemes at a later date
- Falling back on current CI to ensure nothing is broken