### PR TITLE
Fix Execution Device Helper Fn

### DIFF
--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -40,7 +40,13 @@ def get_execution_device(module: Module) -> torch.device:
     """
     if is_module_offloaded(module):
         return module._hf_hook.execution_device
-    return next(module.parameters()).device
+    device = next(module.parameters()).device
+
+    # offload only gets set for leaf modules, fallback to checking for device type
+    if device.type == "meta":
+        return module._hf_hook.execution_device
+
+    return device
 
 
 def get_offloaded_device(module: Module) -> torch.device:


### PR DESCRIPTION
This helper fn was failing when a non-leaf module was passed in. Adding a second case to return the correct execution device when the weights of the module are on the meta device. Required for https://github.com/vllm-project/llm-compressor/pull/47 to work with device offloading