### PR TITLE
Rename Quant Method

### DIFF
--- a/examples/bit_packing/int4_config.json
+++ b/examples/bit_packing/int4_config.json
@@ -1,5 +1,5 @@
 {
-	"quant_method": "compressed-tensors",
+	"quant_method": "compressed_tensors",
 	"format": "pack-quantized",
 	"global_compression_ratio": null,
 	"config_groups": {

--- a/examples/llama_1.1b/example_quant_config.json
+++ b/examples/llama_1.1b/example_quant_config.json
@@ -1,5 +1,5 @@
 {
-	"quant_method": "compressed-tensors",
+	"quant_method": "compressed_tensors",
 	"format": "fakequant",
 	"global_compression_ratio": null,
 	"config_groups": {

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -103,7 +103,7 @@ LIFECYCLE_ORDER = [
     QuantizationStatus.COMPRESSED,
 ]
 
-DEFAULT_QUANTIZATION_METHOD = "compressed-tensors"
+DEFAULT_QUANTIZATION_METHOD = "compressed_tensors"
 DEFAULT_QUANTIZATION_FORMAT = "fakequant"
 
 

--- a/tests/test_compressors/test_model_compressor.py
+++ b/tests/test_compressors/test_model_compressor.py
@@ -43,7 +43,7 @@ def quantization_config():
         "format": "pack-quantized",
         "global_compression_ratio": 1.891791164021256,
         "ignore": ["lm_head"],
-        "quant_method": "compressed-tensors",
+        "quant_method": "compressed_tensors",
         "quantization_status": "frozen",
     }
 

--- a/tests/test_quantization/lifecycle/test_dynamic_lifecycle.py
+++ b/tests/test_quantization/lifecycle/test_dynamic_lifecycle.py
@@ -90,7 +90,7 @@ def get_tinyllama_model():
 
 def get_sample_dynamic_tinyllama_quant_config():
     config_dict = {
-        "quant_method": "compressed-tensors",
+        "quant_method": "compressed_tensors",
         "format": "fakequant",
         "quantization_status": "calibration",
         "global_compression_ratio": None,

--- a/tests/test_quantization/lifecycle/test_kv_cache.py
+++ b/tests/test_quantization/lifecycle/test_kv_cache.py
@@ -23,7 +23,7 @@ from transformers import AutoModelForCausalLM
 
 
 config = {
-    "quant_method": "compressed-tensors",
+    "quant_method": "compressed_tensors",
     "format": "fakequant",
     "kv_cache_scheme": {
         "num_bits": 8,


### PR DESCRIPTION
For HfQuantizer compatibility. We don't use the `quantization_method` attribute anywhere in our codebase, so this change didn't break any examples or tests