### PR TITLE
Bug Fix for Calibration Setup

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -200,7 +200,14 @@ def apply_quantization_status(model: Module, status: QuantizationStatus):
         model.apply(initialize_module_for_quantization)
 
     if current_status < status >= QuantizationStatus.CALIBRATION > current_status:
-        model.apply(set_module_for_calibration)
+        # only quantize weights up front when our end goal state is calibration,
+        # weight quantization parameters are already loaded for frozen/compressed
+        quantize_weights_upfront = status == QuantizationStatus.CALIBRATION
+        model.apply(
+            lambda module: set_module_for_calibration(
+                module, quantize_weights_upfront=quantize_weights_upfront
+            )
+        )
     if current_status < status >= QuantizationStatus.FROZEN > current_status:
         model.apply(freeze_module_quantization)
 

--- a/src/compressed_tensors/quantization/lifecycle/calibration.py
+++ b/src/compressed_tensors/quantization/lifecycle/calibration.py
@@ -28,7 +28,7 @@ __all__ = [
 _LOGGER = logging.getLogger(__name__)
 
 
-def set_module_for_calibration(module: Module):
+def set_module_for_calibration(module: Module, quantize_weights_upfront: bool = True):
     """
     marks a layer as ready for calibration which activates observers
     to update scales and zero points on each forward pass
@@ -36,6 +36,8 @@ def set_module_for_calibration(module: Module):
     apply to full model with `model.apply(set_module_for_calibration)`
 
     :param module: module to set for calibration
+    :param quantize_weights_upfront: whether to automatically run weight quantization at the
+    start of calibration
     """
     if not getattr(module, "quantization_scheme", None):
         # no quantization scheme nothing to do
@@ -49,7 +51,7 @@ def set_module_for_calibration(module: Module):
             "to re-calibrate a frozen module"
         )
 
-    if module.quantization_scheme.weights is not None:
+    if quantize_weights_upfront and module.quantization_scheme.weights is not None:
         # set weight scale and zero_point up front, calibration data doesn't affect it
         observer = module.weight_observer
 


### PR DESCRIPTION
When loading an already quantized model, we step through the sequence of quantization stages: `intiailized -> calibration -> frozen`. When setting modules to the calibration stage, we were recalculating the weight scale and zero point. This computation isn't needed, as the scale/zp get loaded in from the state_dict. This calculation should only happen if our end state is calibration.

Adding an additional argument that turns off weight calculations when loading in a frozen model to fix the issue. Confirmed this bypasses the computation in a manual test, and all the llm-compressor tests still pass

(We should get this in for the release, as this ends up being costly for large models)