### PR TITLE
Fix Issue #112

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/calibration.py
+++ b/src/compressed_tensors/quantization/lifecycle/calibration.py
@@ -36,8 +36,8 @@ def set_module_for_calibration(module: Module, quantize_weights_upfront: bool = 
     apply to full model with `model.apply(set_module_for_calibration)`
 
     :param module: module to set for calibration
-    :param quantize_weights_upfront: whether to automatically run weight quantization at the
-    start of calibration
+    :param quantize_weights_upfront: whether to automatically
+       run weight quantization at thestart of calibration
     """
     if not getattr(module, "quantization_scheme", None):
         # no quantization scheme nothing to do

--- a/src/compressed_tensors/quantization/lifecycle/calibration.py
+++ b/src/compressed_tensors/quantization/lifecycle/calibration.py
@@ -37,7 +37,7 @@ def set_module_for_calibration(module: Module, quantize_weights_upfront: bool = 
 
     :param module: module to set for calibration
     :param quantize_weights_upfront: whether to automatically
-       run weight quantization at thestart of calibration
+       run weight quantization at the start of calibration
     """
     if not getattr(module, "quantization_scheme", None):
         # no quantization scheme nothing to do


### PR DESCRIPTION
Fix for https://github.com/neuralmagic/compressed-tensors/issues/112

Bug:
```
When I try to use regular expression in the "ignore" field of GPTQModifier it fails to recognize the appropriate models.

Example:
ignore: ["lm_head", “re:.*gate”]
Mixtral-7x8B-Instruct-v0.1

Some layers that were to be ignored were not found in the model: {'re:.*gate'}
```

The logic properly ignores the regex matches. The log raises because the logic to check if the regex was ignored was incorrect. PR fixes this bug.

Note: If not ignored, the module will have ` module.quantization_scheme`

