### PR TITLE
follow up, better tests

### DIFF
--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -239,10 +239,9 @@ def test_apply_quantization_status(caplog, ignore, should_raise_warning):
     from transformers import AutoModelForCausalLM
 
     # load a dense, unquantized tiny llama model
-    device = "cuda:0"
     model_name = "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T"
     model = AutoModelForCausalLM.from_pretrained(
-        model_name, device_map=device, torch_dtype="auto"
+        model_name, device_map="cpu", torch_dtype="auto"
     )
 
     quantization_config_dict = {

--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -270,6 +270,6 @@ def test_apply_quantization_status(caplog, ignore, should_raise_warning):
     with caplog.at_level(logging.WARNING):
         apply_quantization_config(model, config)
         if should_raise_warning:
-            assert "Some layers that were to be ignored were " in caplog.text
+            assert len(caplog.text) > 0
         else:
-            assert "Some layers that were to be ignored were " not in caplog.text
+            assert len(caplog.text) == 0

--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -273,4 +273,3 @@ def test_apply_quantization_status(caplog, ignore, should_raise_warning):
             assert "Some layers that were to be ignored were " in caplog.text
         else:
             assert "Some layers that were to be ignored were " not in caplog.text
-

--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -266,9 +266,11 @@ def test_apply_quantization_status(caplog, ignore, should_raise_warning):
     config = QuantizationConfig(**quantization_config_dict)
     config.quantization_status = QuantizationStatus.CALIBRATION
 
-    if should_raise_warning:
-        # mismatch in the ignore key of quantization_config_dict
-        with caplog.at_level(logging.WARNING):
-            apply_quantization_config(model, config)
-    else:
+    # mismatch in the ignore key of quantization_config_dict
+    with caplog.at_level(logging.WARNING):
         apply_quantization_config(model, config)
+        if should_raise_warning:
+            assert "Some layers that were to be ignored were " in caplog.text
+        else:
+            assert "Some layers that were to be ignored were " not in caplog.text
+


### PR DESCRIPTION
Followup to https://github.com/neuralmagic/compressed-tensors/pull/126,
previous test do not check if the warning was raised properly with respect to pytest