### PR TITLE
Move kv cache scales from k/v_proj.output_scale to self_attn.k/v_scale

### DIFF
--- a/src/compressed_tensors/compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressor.py
@@ -240,14 +240,44 @@ class ModelCompressor:
                 compressed_state_dict
             )
 
-        # HACK: Post-process step for kv cache scales to take the k/v_proj
-        # module `output_scale` parameters, and store them in the parent
-        # attention module as `k_scale` and `v_scale`
+        # HACK (mgoin): Post-process step for kv cache scales to take the
+        # k/v_proj module `output_scale` parameters, and store them in the
+        # parent attention module as `k_scale` and `v_scale`
         #
         # Example:
         #  Replace `model.layers.0.self_attn.k_proj.output_scale`
         #  with    `model.layers.0.self_attn.k_scale`
         if self.quantization_config.kv_cache_scheme is not None:
+            # HACK (mgoin): We assume the quantized modules in question
+            # will be k_proj and v_proj since those are the default targets.
+            # We check that both of these modules have output activation
+            # quantization, and additionally check that q_proj doesn't.
+            q_proj_has_no_quant_output = 0
+            k_proj_has_quant_output = 0
+            v_proj_has_quant_output = 0
+            for name, module in model.named_modules():
+                if not hasattr(module, "quantization_scheme"):
+                    continue
+                out_act = module.quantization_scheme.output_activations
+                if name.endswith(".q_proj") and out_act is None:
+                    q_proj_has_no_quant_output += 1
+                elif name.endswith(".k_proj") and out_act is not None:
+                    k_proj_has_quant_output += 1
+                elif name.endswith(".v_proj") and out_act is not None:
+                    v_proj_has_quant_output += 1
+
+            assert (
+                q_proj_has_no_quant_output > 0
+                and k_proj_has_quant_output > 0
+                and v_proj_has_quant_output > 0
+            )
+            assert (
+                q_proj_has_no_quant_output
+                == k_proj_has_quant_output
+                == v_proj_has_quant_output
+            )
+
+            # Move all .k/v_proj.output_scale parameters to .k/v_scale
             working_state_dict = {}
             for key in compressed_state_dict.keys():
                 if key.endswith(".k_proj.output_scale"):


### PR DESCRIPTION
Temporary fix to the serialized checkpoint format for quantized kv cache scales. 

The current issue is that storing the scales directly on the output of Linear modules doesn’t exactly match up the its usage in attention implementation. In vLLM the kv scales are members of the Attention class, rather than its Linear submodules. So rather than `model.layers.0.self_attn.k_proj.output_scale` we should use `model.layers.0.self_attn.k_scale`


Example script used to talk about differences in this PR:
```python
from llmcompressor.transformers import oneshot

recipe = """
quant_stage:
    quant_modifiers:
        QuantizationModifier:
            kv_cache_scheme:
                num_bits: 8
                type: float
                strategy: tensor
                dynamic: false
                symmetric: true
"""

oneshot(
    model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
    dataset="open_platypus",
    recipe=recipe,
    output_dir="TinyLlama-1.1B-Chat-v1.0-KV",
    num_calibration_samples=16,
)
```

Before this PR, we would save the kv cache scales as `output_scale` tensors on the k_proj and v_proj Linear modules:
```
model.layers.0.mlp.down_proj.input_scale
model.layers.0.mlp.down_proj.weight
model.layers.0.mlp.down_proj.weight_scale
model.layers.0.mlp.gate_proj.input_scale
model.layers.0.mlp.gate_proj.weight
model.layers.0.mlp.gate_proj.weight_scale
model.layers.0.mlp.up_proj.input_scale
model.layers.0.mlp.up_proj.weight
model.layers.0.mlp.up_proj.weight_scale
model.layers.0.self_attn.k_proj.input_scale
model.layers.0.self_attn.k_proj.output_scale <<<
model.layers.0.self_attn.k_proj.weight
model.layers.0.self_attn.k_proj.weight_scale
model.layers.0.self_attn.o_proj.input_scale
model.layers.0.self_attn.o_proj.weight
model.layers.0.self_attn.o_proj.weight_scale
model.layers.0.self_attn.q_proj.input_scale
model.layers.0.self_attn.q_proj.weight
model.layers.0.self_attn.q_proj.weight_scale
model.layers.0.self_attn.v_proj.input_scale
model.layers.0.self_attn.v_proj.output_scale <<<
model.layers.0.self_attn.v_proj.weight
model.layers.0.self_attn.v_proj.weight_scale
```

Now we have those scales rewritten to be `k_scale` or `v_scale` on the Attention parent module of those Linear modules:
```
model.layers.0.mlp.down_proj.input_scale
model.layers.0.mlp.down_proj.weight
model.layers.0.mlp.down_proj.weight_scale
model.layers.0.mlp.gate_proj.input_scale
model.layers.0.mlp.gate_proj.weight
model.layers.0.mlp.gate_proj.weight_scale
model.layers.0.mlp.up_proj.input_scale
model.layers.0.mlp.up_proj.weight
model.layers.0.mlp.up_proj.weight_scale
model.layers.0.self_attn.k_proj.input_scale
model.layers.0.self_attn.k_proj.weight
model.layers.0.self_attn.k_proj.weight_scale
model.layers.0.self_attn.k_scale             <<<
model.layers.0.self_attn.o_proj.input_scale
model.layers.0.self_attn.o_proj.weight
model.layers.0.self_attn.o_proj.weight_scale
model.layers.0.self_attn.q_proj.input_scale
model.layers.0.self_attn.q_proj.weight
model.layers.0.self_attn.q_proj.weight_scale
model.layers.0.self_attn.v_proj.input_scale
model.layers.0.self_attn.v_proj.weight
model.layers.0.self_attn.v_proj.weight_scale
model.layers.0.self_attn.v_scale             <<<
```