### PR TITLE
Group Index Quantization Support

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -227,7 +227,6 @@ def _process_quantization(
 
                 start = group_index * group_size
                 end = start + group_size
-
                 if do_quantize:
                     output[:, start: end] = _quantize(
                         x[:, start: end],
@@ -238,7 +237,6 @@ def _process_quantization(
                         args,
                         dtype=dtype,
                     )
-
                 if do_dequantize:
                     input = output[:, start: end] if do_quantize else x[:, start: end]
                     output[:, start: end] = _dequantize(input, sc, zp)

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -203,9 +203,9 @@ def _process_quantization(
                 )
 
         # support column-order (default) quantization as well as other orderings
-        # such as activation ordering
-        column_order = g_idx is None or -1 in g_idx
-        if column_order:
+        # such as activation ordering. Below checks if g_idx has been initialized
+        is_column_order = g_idx is None or -1 in g_idx
+        if is_column_order:
             num_groups = int(ceil(columns / group_size))
             group_sizes = torch.full((num_groups,), group_size, dtype=torch.int)
 
@@ -239,7 +239,7 @@ def _process_quantization(
                 input = output[:, start:end] if do_quantize else x[:, start:end]
                 output[:, start:end] = _dequantize(input, sc, zp)
 
-        if not column_order:
+        if not is_column_order:
             output = safe_permute(output, torch.argsort(perm), dim=1)
 
     else:  # covers channel, token and tensor strategies

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -39,10 +39,6 @@ __all__ = [
 ]
 
 
-# these datatypes are missing implementations for the `index_put` operation
-EXPERIMENTAL_DTYPES = [torch.float8_e4m3fn]
-
-
 @torch.no_grad()
 def quantize(
     x: torch.Tensor,

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -208,15 +208,14 @@ def _process_quantization(
         """
         if there is no out-of-order grouping
             do slicing (fastest)
-            TODO: maybe speedup from vectorization w.r.t. groups
 
-        if the data type supports put_index:
+        if the data type supports _put_index:
             do masking (faster)
-            TODO: maybe speedup from vectorization w.r.t. groups
 
-        if the data type does not support put_index:
+        if the data type does not support _put_index:
             do iteration (slower)
-            cannot be vectorized
+
+        TODO: investigate potential speedup from full vectorization w.r.t. groups
         """
 
         # g_idx is initialized to -1

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -202,8 +202,10 @@ def _process_quantization(
                     f"by the given group_size {group_size}"
                 )
 
-        in_order = g_idx is None or -1 in g_idx
-        if in_order:
+        # support column-order (default) quantization as well as other orderings
+        # such as activation ordering
+        column_order = g_idx is None or -1 in g_idx
+        if column_order:
             num_groups = int(ceil(columns / group_size))
             group_sizes = torch.full((num_groups,), group_size, dtype=torch.int)
 
@@ -237,7 +239,7 @@ def _process_quantization(
                 input = output[:, start:end] if do_quantize else x[:, start:end]
                 output[:, start:end] = _dequantize(input, sc, zp)
 
-        if not in_order:
+        if not column_order:
             output = safe_permute(output, torch.argsort(perm), dim=1)
 
     else:  # covers channel, token and tensor strategies

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -26,6 +26,7 @@ from compressed_tensors.quantization.quant_args import (
 from compressed_tensors.quantization.quant_config import QuantizationStatus
 from compressed_tensors.quantization.quant_scheme import QuantizationScheme
 from compressed_tensors.utils import update_parameter_data
+from compressed_tensors.quantization.lifecycle.helpers import safe_permute
 from torch.nn import Module
 
 
@@ -98,6 +99,7 @@ def dequantize(
     """
     Dequantize a quantized input tensor x_q based on the strategy specified in args. If
     args is not provided, the strategy will be inferred.
+
     :param x: quantized input tensor
     :param scale: scale tensor
     :param zero_point: zero point tensor
@@ -130,11 +132,11 @@ def dequantize(
         x=x_q,
         scale=scale,
         zero_point=zero_point,
+        g_idx=g_idx,
         args=args,
         do_quantize=False,
         do_dequantize=True,
         dtype=dtype,
-        g_idx=g_idx,
     )
 
 
@@ -164,10 +166,10 @@ def fake_quantize(
         x=x,
         scale=scale,
         zero_point=zero_point,
+        g_idx=g_idx,
         args=args,
         do_quantize=True,
         do_dequantize=True,
-        g_idx=g_idx,
     )
 
 
@@ -188,8 +190,8 @@ def _process_quantization(
     if args.strategy == QuantizationStrategy.GROUP:
         output_dtype = dtype if dtype is not None else x.dtype
         output = torch.zeros_like(x).to(output_dtype)
+        columns = x.shape[1]
 
-        # TODO: fix genetric assumption about the tensor size for computing group
         # TODO: make validation step for inputs
 
         while scale.ndim < 2:
@@ -197,7 +199,6 @@ def _process_quantization(
             scale = scale.unsqueeze(1)
             zero_point = zero_point.unsqueeze(1) if zero_point is not None else None
 
-        columns = x.shape[1]
         if columns >= group_size:
             if columns % group_size != 0:
                 raise ValueError(
@@ -205,100 +206,47 @@ def _process_quantization(
                     f"by the given group_size {group_size}"
                 )
 
-        """
-        if there is no out-of-order grouping
-            do slicing (fastest)
-
-        if the data type supports _put_index:
-            do masking (faster)
-
-        if the data type does not support _put_index:
-            do iteration (slower)
-
-        TODO: investigate potential speedup from full vectorization w.r.t. groups
-        """
-
-        # g_idx is initialized to -1
-        if g_idx is None or -1 in g_idx:
-            # quantize slices
-            for group_index in range(ceil(columns / group_size)):
-                sc = scale[:, group_index].view(-1, 1)
-                zp = (
-                    zero_point[:, group_index].view(-1, 1)
-                    if zero_point is not None
-                    else None
-                )
-
-                start = group_index * group_size
-                end = start + group_size
-                if do_quantize:
-                    output[:, start:end] = _quantize(
-                        x[:, start:end],
-                        sc,
-                        zp,
-                        q_min,
-                        q_max,
-                        args,
-                        dtype=dtype,
-                    )
-                if do_dequantize:
-                    input = output[:, start:end] if do_quantize else x[:, start:end]
-                    output[:, start:end] = _dequantize(input, sc, zp)
-
-        elif output_dtype not in EXPERIMENTAL_DTYPES:
-            # quantize according to mask
-            for group_index in range(ceil(columns / group_size)):
-                # scale.shape should be [nchan, ndim]
-                # sc.shape should be [nchan, 1] after unsqueeze
-                sc = scale[:, group_index].view(-1, 1)
-                zp = (
-                    zero_point[:, group_index].view(-1, 1)
-                    if zero_point is not None
-                    else None
-                )
-
-                group_mask = g_idx == group_index
-                if do_quantize:
-                    output[:, group_mask] = _quantize(
-                        x[:, group_mask],
-                        sc,
-                        zp,
-                        q_min,
-                        q_max,
-                        args,
-                        dtype=dtype,
-                    )
-                if do_dequantize:
-                    input = output[:, group_mask] if do_quantize else x[:, group_mask]
-                    output[:, group_mask] = _dequantize(input, sc, zp)
+        in_order = g_idx is None or -1 in g_idx
+        if in_order:
+            num_groups = int(ceil(columns / group_size))
+            group_sizes = torch.full((num_groups, ), group_size, dtype=torch.int)
 
         else:
-            # quantize channels iteratively
-            for column_index in range(columns):
-                group_index = g_idx[column_index]
+            group_indices, group_sizes = torch.unique(g_idx, return_counts=True)
+            group_sizes = group_sizes[torch.argsort(group_indices)]
 
-                sc = scale[:, group_index].squeeze(1)
-                zp = (
-                    zero_point[:, group_index].squeeze(1)
-                    if zero_point is not None
-                    else None
+            perm = torch.argsort(g_idx)
+            x = safe_permute(x, perm, dim=1)
+
+        # TODO: experiment with vectorizing for loop for performance
+        end = 0
+        for index, group_count in enumerate(group_sizes):
+            sc = scale[:, index].view(-1, 1)
+            zp = (
+                zero_point[:, index].view(-1, 1)
+                if zero_point is not None
+                else None
+            )
+
+            start = end
+            end = start + group_count
+            if do_quantize:
+                output[:, start:end] = _quantize(
+                    x[:, start:end],
+                    sc,
+                    zp,
+                    q_min,
+                    q_max,
+                    args,
+                    dtype=dtype,
                 )
 
-                if do_quantize:
-                    output[:, column_index] = _quantize(
-                        x[:, column_index],
-                        sc,
-                        zp,
-                        q_min,
-                        q_max,
-                        args,
-                        dtype=dtype,
-                    )
-                if do_dequantize:
-                    input = (
-                        output[:, column_index] if do_quantize else x[:, column_index]
-                    )
-                    output[:, column_index] = _dequantize(input, sc, zp)
+            if do_dequantize:
+                input = output[:, start:end] if do_quantize else x[:, start:end]
+                output[:, start:end] = _dequantize(input, sc, zp)
+
+        if not in_order:
+            output = safe_permute(output, torch.argsort(perm), dim=1)
 
     else:  # covers channel, token and tensor strategies
         if do_quantize:
@@ -385,10 +333,13 @@ def maybe_calibrate_or_quantize(
         # skip quantization
         return value
 
+    g_idx = getattr(module, "weight_g_idx", None)
+
     if args.dynamic:
         # dynamic quantization - get scale and zero point directly from observer
         observer = getattr(module, f"{base_name}_observer")
-        scale, zero_point = observer(value)
+
+        scale, zero_point = observer(value, g_idx=g_idx)
     else:
         # static quantization - get previous scale and zero point from layer
         scale = getattr(module, f"{base_name}_scale")
@@ -401,13 +352,13 @@ def maybe_calibrate_or_quantize(
             # calibration mode - get new quant params from observer
             observer = getattr(module, f"{base_name}_observer")
 
-            updated_scale, updated_zero_point = observer(value)
+            updated_scale, updated_zero_point = observer(value, g_idx=g_idx)
 
             # update scale and zero point
             update_parameter_data(module, updated_scale, f"{base_name}_scale")
             update_parameter_data(module, updated_zero_point, f"{base_name}_zero_point")
 
-    return fake_quantize(value, scale, zero_point, args)
+    return fake_quantize(value, scale, zero_point, args, g_idx=g_idx)
 
 
 @torch.no_grad()

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -244,6 +244,7 @@ def _process_quantization(
                     output[:, start: end] = _dequantize(input, sc, zp)
 
         elif output_dtype not in EXPERIMENTAL_DTYPES:
+            # quantize according to mask
             for group_index in range(ceil(columns / group_size)):
                 # scale.shape should be [nchan, ndim]
                 # sc.shape should be [nchan, 1] after unsqueeze
@@ -266,8 +267,7 @@ def _process_quantization(
                     output[:, group_mask] = _dequantize(input, sc, zp)
 
         else:
-            # for dtypes which do not implement `index_put`, must quantize and
-            # put each channel's data separately (slower)
+            # quantize channels iteratively
             for column_index in range(columns):
                 group_index = g_idx[column_index]
 

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -334,7 +334,7 @@ def maybe_calibrate_or_quantize(
     if args.dynamic:
         # dynamic quantization - get scale and zero point directly from observer
         observer = getattr(module, f"{base_name}_observer")
-        scale, zero_point = observer(value, g_idx=g_idx)
+        scale, zero_point = observer(value)
     else:
         # static quantization - get previous scale and zero point from layer
         scale = getattr(module, f"{base_name}_scale")
@@ -347,7 +347,7 @@ def maybe_calibrate_or_quantize(
             # calibration mode - get new quant params from observer
             observer = getattr(module, f"{base_name}_observer")
 
-            updated_scale, updated_zero_point = observer(value, g_idx=g_idx)
+            updated_scale, updated_zero_point = observer(value)
 
             # update scale and zero point
             update_parameter_data(module, updated_scale, f"{base_name}_scale")

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -188,9 +188,7 @@ def _process_quantization(
         output_dtype = dtype if dtype is not None else x.dtype
         output = torch.zeros_like(x).to(output_dtype)
 
-        # TODO: vectorize the for loop
         # TODO: fix genetric assumption about the tensor size for computing group
-
         # TODO: make validation step for inputs
 
         while scale.ndim < 2:
@@ -209,12 +207,15 @@ def _process_quantization(
         """
         if there is no out-of-order grouping
             do slicing (fastest)
+            TODO: maybe speedup from vectorization w.r.t. groups
 
         if the data type supports put_index:
             do masking (faster)
+            TODO: maybe speedup from vectorization w.r.t. groups
 
         if the data type does not support put_index:
             do iteration (slower)
+            cannot be vectorized
         """
 
         # g_idx is initialized to -1

--- a/src/compressed_tensors/quantization/lifecycle/helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/helpers.py
@@ -75,8 +75,7 @@ def safe_permute(value: torch.Tensor, perm: torch.Tensor, dim: int = 0) -> torch
         return _fallback_permute(value, perm, dim)
     
     try:
-        # Attempt to use advanced indexing
-        return value[tuple(slice(None) * dim + [perm])]
+        return value[tuple([slice(None)] * dim + [perm])]
     except RuntimeError:
         # Mark dtype as experimental if advanced indexing fails
         _EXPERIMENTAL_DTYPES.add(dtype_tuple)
@@ -92,9 +91,9 @@ def _fallback_permute(value: torch.Tensor, perm: torch.Tensor, dim: int) -> torc
     :param dim: dimension along which to apply permutation
     :return: permuted value
     """
-    value_ret = torch.zeros_like(value, device=value.device)
-    orig_slices = [slice(None)] * dim
-    perm_slices = [slice(None)] * dim
+    value_ret = value.clone()  # cannot use zeros_like b/c of missing impl.
+    orig_slices = [slice(None)] * (dim + 1)
+    perm_slices = [slice(None)] * (dim + 1)
 
     for index, perm_index in enumerate(perm):
         orig_slices[dim] = index

--- a/src/compressed_tensors/quantization/lifecycle/helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/helpers.py
@@ -31,42 +31,18 @@ __all__ = [
 EXPERIMENTAL_DTYPES = [torch.float8_e4m3fn]
 
 
-def update_layer_weight_quant_params(
-    layer: Module,
-    weight: Optional[torch.Tensor] = None,
-    g_idx: Optional[torch.Tensor] = None,
-    reset_obs: bool = False,
-):
-    """
-    Update quantization parameters on layer
+def update_layer_weight_quant_params(layer: Module):
+    weight = getattr(layer, "weight", None)
 
-    :param layer: input layer
-    :param weight: weight to update quant params with, defaults to layer weight
-    :param g_idx: optional mapping from column index to group index
-    :param reset_obs: reset the observer before calculating quant params,
-        defaults to False
-    """
-    attached_weight = getattr(layer, "weight", None)
-
-    if weight is None:
-        weight = attached_weight
     scale = getattr(layer, "weight_scale", None)
     zero_point = getattr(layer, "weight_zero_point", None)
-    if g_idx is None:
-        g_idx = getattr(layer, "weight_g_idx", None)
     observer = getattr(layer, "weight_observer", None)
 
     if weight is None or observer is None or scale is None or zero_point is None:
         # scale, zp, or observer not calibratable or weight not available
         return
-
-    if reset_obs:
-        observer.reset()
-
-    if attached_weight is not None:
-        weight = weight.to(attached_weight.dtype)
-
-    updated_scale, updated_zero_point = observer(weight, g_idx=g_idx)
+    
+    updated_scale, updated_zero_point = observer(weight)
 
     # update scale and zero point
     device = next(layer.parameters()).device

--- a/src/compressed_tensors/quantization/lifecycle/helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/helpers.py
@@ -57,7 +57,6 @@ def disable_quantization(module: Module):
     module.quantization_enabled = False
 
 
-# these datatypes are missing implementations for the `index_put` operation
 def safe_permute(value: torch.Tensor, perm: torch.Tensor, dim: int = 0) -> torch.Tensor:
     """
     Perform out-of-place permutation without using torch.Tensor.index_put_,

--- a/src/compressed_tensors/quantization/lifecycle/helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/helpers.py
@@ -32,7 +32,6 @@ EXPERIMENTAL_DTYPES = [torch.float8_e4m3fn]
 
 def update_layer_weight_quant_params(layer: Module):
     weight = getattr(layer, "weight", None)
-
     scale = getattr(layer, "weight_scale", None)
     zero_point = getattr(layer, "weight_zero_point", None)
     observer = getattr(layer, "weight_observer", None)

--- a/src/compressed_tensors/quantization/lifecycle/helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/helpers.py
@@ -70,10 +70,10 @@ def safe_permute(value: torch.Tensor, perm: torch.Tensor, dim: int = 0) -> torch
     :return: permuted value
     """
     dtype_tuple = (value.dtype, value.device)
-    
+
     if dtype_tuple in _EXPERIMENTAL_DTYPES:
         return _fallback_permute(value, perm, dim)
-    
+
     try:
         return value[tuple([slice(None)] * dim + [perm])]
     except RuntimeError:
@@ -82,10 +82,12 @@ def safe_permute(value: torch.Tensor, perm: torch.Tensor, dim: int = 0) -> torch
         return _fallback_permute(value, perm, dim)
 
 
-def _fallback_permute(value: torch.Tensor, perm: torch.Tensor, dim: int) -> torch.Tensor:
+def _fallback_permute(
+    value: torch.Tensor, perm: torch.Tensor, dim: int
+) -> torch.Tensor:
     """
     Fallback permutation method for experimental dtypes.
-    
+
     :param value: tensor to permute
     :param perm: permutation map
     :param dim: dimension along which to apply permutation
@@ -99,5 +101,5 @@ def _fallback_permute(value: torch.Tensor, perm: torch.Tensor, dim: int) -> torc
         orig_slices[dim] = index
         perm_slices[dim] = perm_index
         value_ret[tuple(orig_slices)] = value[tuple(perm_slices)]
-    
+
     return value_ret

--- a/src/compressed_tensors/quantization/lifecycle/helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/helpers.py
@@ -16,8 +16,6 @@
 Miscelaneous helpers for the quantization lifecycle
 """
 
-from typing import Optional
-
 import torch
 from torch.nn import Module
 
@@ -41,7 +39,7 @@ def update_layer_weight_quant_params(layer: Module):
     if weight is None or observer is None or scale is None or zero_point is None:
         # scale, zp, or observer not calibratable or weight not available
         return
-    
+
     updated_scale, updated_zero_point = observer(weight)
 
     # update scale and zero point

--- a/src/compressed_tensors/quantization/lifecycle/helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/helpers.py
@@ -26,6 +26,7 @@ __all__ = [
     "disable_quantization",
 ]
 
+# these datatypes are missing implementations for the `index_put` operation
 EXPERIMENTAL_DTYPES = [torch.float8_e4m3fn]
 
 

--- a/tests/test_quantization/lifecycle/test_helpers.py
+++ b/tests/test_quantization/lifecycle/test_helpers.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+import torch
+
+from compressed_tensors.quantization.lifecycle.helpers import safe_permute, _EXPERIMENTAL_DTYPE
+
+
+@pytest.mark.parametrize(
+    "dtype,device,exp_experimental",
+    [
+        (torch.int8, torch.device("cpu"), False),
+        (torch.int16, torch.device("cpu"), False),
+        (torch.int32, torch.device("cpu"), False),
+        (torch.int64, torch.device("cpu"), False),
+        (torch.float16, torch.device("cpu"), False),
+        (torch.float32, torch.device("cpu"), False),
+        (torch.float64, torch.device("cpu"), False),
+        (torch.float8_e4m3fn, torch.device("cpu"), True),
+    ]
+)
+def test_safe_permute(dtype: torch.dtype, device: str, exp_experimental: bool):
+    # some dtypes do not support arange initialization
+    tensor = torch.tensor([0, 1, 2, 3], dtype=dtype, device=device)
+    perm = torch.tensor([3, 1, 0, 2])
+    expected = torch.tensor([3, 1, 0, 2], dtype=dtype, device=device)
+    
+    result = safe_permute(tensor, perm, dim=0)
+    
+    print(_EXPERIMENTAL_DTYPE)
+    assert _EXPERIMENTAL_DTYPE[(dtype, device)] == exp_experimental
+    assert all(result == expected)

--- a/tests/test_quantization/lifecycle/test_helpers.py
+++ b/tests/test_quantization/lifecycle/test_helpers.py
@@ -15,8 +15,10 @@
 
 import pytest
 import torch
-
-from compressed_tensors.quantization.lifecycle.helpers import safe_permute, _EXPERIMENTAL_DTYPE
+from compressed_tensors.quantization.lifecycle.helpers import (
+    _EXPERIMENTAL_DTYPES,
+    safe_permute,
+)
 
 
 @pytest.mark.parametrize(
@@ -30,16 +32,16 @@ from compressed_tensors.quantization.lifecycle.helpers import safe_permute, _EXP
         (torch.float32, torch.device("cpu"), False),
         (torch.float64, torch.device("cpu"), False),
         (torch.float8_e4m3fn, torch.device("cpu"), True),
-    ]
+    ],
 )
 def test_safe_permute(dtype: torch.dtype, device: str, exp_experimental: bool):
     # some dtypes do not support arange initialization
     tensor = torch.tensor([0, 1, 2, 3], dtype=dtype, device=device)
     perm = torch.tensor([3, 1, 0, 2])
     expected = torch.tensor([3, 1, 0, 2], dtype=dtype, device=device)
-    
+
     result = safe_permute(tensor, perm, dim=0)
-    
-    print(_EXPERIMENTAL_DTYPE)
-    assert _EXPERIMENTAL_DTYPE[(dtype, device)] == exp_experimental
+
+    if exp_experimental:
+        assert (dtype, device) in _EXPERIMENTAL_DTYPES
     assert all(result == expected)


### PR DESCRIPTION
This PR is a precursor to #97 which adds support for out-of-order group quantization specified by `g_idx`.
* Weights are permuted before and after quantization to account for new group quantization parameters
    * Note that some datatypes such as `torch.float8_e4m3fn` do not implement `index_put_` and therefore must be permuted manually (this also prohibits group masking implementations
* `g_idx` is passed to quantization operations

The group quantization cases tested are
1. in-order group quantization, which is the case which has already been implemented
2. out-of-order group quantization with dtypes which support index_put_ operations
3. out-of-order group quantization with dtypes which do not support index_put_ operations

A follow-up PR could explore the potential performance/code simplicity benefits of fully vectorized operations, which would require more memory and preprocessing but be more parallelizable