### PR TITLE
Support quantizing only the kv cache

### DIFF
--- a/src/compressed_tensors/compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressor.py
@@ -257,6 +257,9 @@ class ModelCompressor:
             v_proj_has_quant_output = 0
             for name, module in model.named_modules():
                 if not hasattr(module, "quantization_scheme"):
+                    # We still want to count non-quantized q_proj
+                    if name.endswith(".q_proj"):
+                        q_proj_has_no_quant_output += 1
                     continue
                 out_act = module.quantization_scheme.output_activations
                 if name.endswith(".q_proj") and out_act is None:

--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -110,6 +110,7 @@ def is_preset_scheme(name: str) -> bool:
     """
     return name.upper() in PRESET_SCHEMES
 
+UNQUANTIZED = dict()
 
 # 8 bit integer weights and 8 bit activations quantization
 W8A8 = dict(
@@ -208,6 +209,8 @@ FP8_DYNAMIC = dict(
 )
 
 PRESET_SCHEMES = {
+    # Unquantized (no-op)
+    "UNQUANTIZED": UNQUANTIZED,
     # Integer weight only schemes
     "W8A16": W8A16,
     "W4A16": W4A16,

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -181,7 +181,7 @@ def calculate_compression_ratio(model: Module) -> float:
         for parameter in model.parameters():
             uncompressed_bits = get_torch_bit_depth(parameter)
             compressed_bits = uncompressed_bits
-            if is_module_quantized(submodule):
+            if is_module_quantized(submodule) and submodule.quantization_scheme.weights:
                 compressed_bits = submodule.quantization_scheme.weights.num_bits
 
             num_weights = parameter.numel()


### PR DESCRIPTION
I wanted the ability to make calibrated kv cache scales without needing to quantize the weights or activations of any layers. There were some issues when making a QuantizationModifier without any inputs or weights QuantizationSchemes.

Here is the minimal recipe example I used for testing. It is still a bit verbose, so I would like to eventually reduce it to just the `kv_cache_scheme`:
```python
from llmcompressor.transformers import oneshot

recipe = """
quant_stage:
    quant_modifiers:
        QuantizationModifier:
            config_groups:
                group_0:
                    targets: []
            kv_cache_scheme:
                num_bits: 8
                type: float
                strategy: tensor
                dynamic: false
                symmetric: true
"""

oneshot(
    model="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
    dataset="open_platypus",
    recipe=recipe,
    output_dir="TinyLlama-1.1B-Chat-v1.0-KV",
    num_calibration_samples=16,
)
```

However this seems to fail when loading in vLLM due to mismatched quant configs between qkv - this should not actually be true because in the final state we have nothing registered to k/v_proj:
```
  File "/home/mgoin/code/vllm/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py", line 286, in get_scheme
    if should_ignore_layer(layer_name, ignore=self.ignore):
  File "/home/mgoin/code/vllm/vllm/model_executor/layers/quantization/compressed_tensors/utils.py", line 126, in should_ignore_layer
    raise ValueError(f"Found a different quantization schemes for "
ValueError: Found a different quantization schemes for ['q_proj', 'k_proj', 'v_proj'] in model.layers.0.self_attn.qkv_proj. vLLM requires all to use the same scheme.
```

This resulted in the following compression_config, which is more verbose than I would like with the ignored layers
```yaml
  "compression_config": {
    "config_groups": {},
    "format": "naive-quantized",
    "global_compression_ratio": 1.0,
    "ignore": [
      "model.layers.0.self_attn.q_proj",
      "model.layers.0.self_attn.o_proj",
      "model.layers.0.mlp.gate_proj",
      "model.layers.0.mlp.up_proj",
      "model.layers.0.mlp.down_proj",
      "model.layers.1.self_attn.q_proj",
      "model.layers.1.self_attn.o_proj",
      "model.layers.1.mlp.gate_proj",
      "model.layers.1.mlp.up_proj",
      "model.layers.1.mlp.down_proj",
      "model.layers.2.self_attn.q_proj",
      "model.layers.2.self_attn.o_proj",
      "model.layers.2.mlp.gate_proj",
      "model.layers.2.mlp.up_proj",
      "model.layers.2.mlp.down_proj",
      "model.layers.3.self_attn.q_proj",
      "model.layers.3.self_attn.o_proj",
      "model.layers.3.mlp.gate_proj",
      "model.layers.3.mlp.up_proj",
      "model.layers.3.mlp.down_proj",
      "model.layers.4.self_attn.q_proj",
      "model.layers.4.self_attn.o_proj",
      "model.layers.4.mlp.gate_proj",
      "model.layers.4.mlp.up_proj",
      "model.layers.4.mlp.down_proj",
      "model.layers.5.self_attn.q_proj",
      "model.layers.5.self_attn.o_proj",
      "model.layers.5.mlp.gate_proj",
      "model.layers.5.mlp.up_proj",
      "model.layers.5.mlp.down_proj",
      "model.layers.6.self_attn.q_proj",
      "model.layers.6.self_attn.o_proj",
      "model.layers.6.mlp.gate_proj",
      "model.layers.6.mlp.up_proj",
      "model.layers.6.mlp.down_proj",
      "model.layers.7.self_attn.q_proj",
      "model.layers.7.self_attn.o_proj",
      "model.layers.7.mlp.gate_proj",
      "model.layers.7.mlp.up_proj",
      "model.layers.7.mlp.down_proj",
      "model.layers.8.self_attn.q_proj",
      "model.layers.8.self_attn.o_proj",
      "model.layers.8.mlp.gate_proj",
      "model.layers.8.mlp.up_proj",
      "model.layers.8.mlp.down_proj",
      "model.layers.9.self_attn.q_proj",
      "model.layers.9.self_attn.o_proj",
      "model.layers.9.mlp.gate_proj",
      "model.layers.9.mlp.up_proj",
      "model.layers.9.mlp.down_proj",
      "model.layers.10.self_attn.q_proj",
      "model.layers.10.self_attn.o_proj",
      "model.layers.10.mlp.gate_proj",
      "model.layers.10.mlp.up_proj",
      "model.layers.10.mlp.down_proj",
      "model.layers.11.self_attn.q_proj",
      "model.layers.11.self_attn.o_proj",
      "model.layers.11.mlp.gate_proj",
      "model.layers.11.mlp.up_proj",
      "model.layers.11.mlp.down_proj",
      "model.layers.12.self_attn.q_proj",
      "model.layers.12.self_attn.o_proj",
      "model.layers.12.mlp.gate_proj",
      "model.layers.12.mlp.up_proj",
      "model.layers.12.mlp.down_proj",
      "model.layers.13.self_attn.q_proj",
      "model.layers.13.self_attn.o_proj",
      "model.layers.13.mlp.gate_proj",
      "model.layers.13.mlp.up_proj",
      "model.layers.13.mlp.down_proj",
      "model.layers.14.self_attn.q_proj",
      "model.layers.14.self_attn.o_proj",
      "model.layers.14.mlp.gate_proj",
      "model.layers.14.mlp.up_proj",
      "model.layers.14.mlp.down_proj",
      "model.layers.15.self_attn.q_proj",
      "model.layers.15.self_attn.o_proj",
      "model.layers.15.mlp.gate_proj",
      "model.layers.15.mlp.up_proj",
      "model.layers.15.mlp.down_proj",
      "model.layers.16.self_attn.q_proj",
      "model.layers.16.self_attn.o_proj",
      "model.layers.16.mlp.gate_proj",
      "model.layers.16.mlp.up_proj",
      "model.layers.16.mlp.down_proj",
      "model.layers.17.self_attn.q_proj",
      "model.layers.17.self_attn.o_proj",
      "model.layers.17.mlp.gate_proj",
      "model.layers.17.mlp.up_proj",
      "model.layers.17.mlp.down_proj",
      "model.layers.18.self_attn.q_proj",
      "model.layers.18.self_attn.o_proj",
      "model.layers.18.mlp.gate_proj",
      "model.layers.18.mlp.up_proj",
      "model.layers.18.mlp.down_proj",
      "model.layers.19.self_attn.q_proj",
      "model.layers.19.self_attn.o_proj",
      "model.layers.19.mlp.gate_proj",
      "model.layers.19.mlp.up_proj",
      "model.layers.19.mlp.down_proj",
      "model.layers.20.self_attn.q_proj",
      "model.layers.20.self_attn.o_proj",
      "model.layers.20.mlp.gate_proj",
      "model.layers.20.mlp.up_proj",
      "model.layers.20.mlp.down_proj",
      "model.layers.21.self_attn.q_proj",
      "model.layers.21.self_attn.o_proj",
      "model.layers.21.mlp.gate_proj",
      "model.layers.21.mlp.up_proj",
      "model.layers.21.mlp.down_proj",
      "lm_head"
    ],
    "kv_cache_scheme": {
      "block_structure": null,
      "dynamic": false,
      "group_size": null,
      "num_bits": 8,
      "observer": "minmax",
      "observer_kwargs": {},
      "strategy": "tensor",
      "symmetric": true,
      "type": "float"
    },
    "quant_method": "compressed-tensors",
    "quantization_status": "frozen"
  },
  ```