### PR TITLE
Move safe_permute, update layer helper arguments

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -17,7 +17,6 @@ from math import ceil
 from typing import Optional
 
 import torch
-from compressed_tensors.quantization.lifecycle.helpers import safe_permute
 from compressed_tensors.quantization.observers.helpers import calculate_range
 from compressed_tensors.quantization.quant_args import (
     QuantizationArgs,
@@ -26,7 +25,7 @@ from compressed_tensors.quantization.quant_args import (
 )
 from compressed_tensors.quantization.quant_config import QuantizationStatus
 from compressed_tensors.quantization.quant_scheme import QuantizationScheme
-from compressed_tensors.utils import update_parameter_data
+from compressed_tensors.utils import safe_permute, update_parameter_data
 from torch.nn import Module
 
 

--- a/src/compressed_tensors/quantization/observers/base.py
+++ b/src/compressed_tensors/quantization/observers/base.py
@@ -171,3 +171,11 @@ class Observer(Module, RegistryMixin):
         # observed_tokens (batch_size * sequence_length)
         observed_tokens, _ = batch_tensor.shape
         self._num_observed_tokens += observed_tokens
+
+    def reset(self):
+        """
+        Reset the state of the observer
+        """
+        self._num_observed_tokens = None
+        self._scale = None
+        self._zero_point = None

--- a/src/compressed_tensors/quantization/observers/helpers.py
+++ b/src/compressed_tensors/quantization/observers/helpers.py
@@ -38,9 +38,9 @@ def get_observer_token_count(module: torch.nn.Module) -> Counter:
     token_counts = Counter()
     for name, module in module.named_modules():
         if name.endswith(".input_observer"):
-            token_counts[name.replace(".input_observer", "")] = (
-                module._num_observed_tokens
-            )
+            token_counts[
+                name.replace(".input_observer", "")
+            ] = module._num_observed_tokens
     return token_counts
 
 

--- a/src/compressed_tensors/quantization/observers/min_max.py
+++ b/src/compressed_tensors/quantization/observers/min_max.py
@@ -94,3 +94,11 @@ class MovingAverageMinMaxObserver(Observer):
         return self.calculate_qparams(
             observed, reduce_dims=reduce_dims, tensor_id=tensor_id
         )
+
+    def reset(self):
+        """
+        Reset the state of the observer, including min and maximum values
+        """
+        super().reset()
+        self.min_val = {}
+        self.max_val = {}

--- a/src/compressed_tensors/quantization/observers/mse.py
+++ b/src/compressed_tensors/quantization/observers/mse.py
@@ -152,3 +152,11 @@ class MovingAverageMSEObserver(Observer):
         return self.calculate_qparams(
             observed, reduce_dims=reduce_dims, tensor_id=tensor_id
         )
+
+    def reset(self):
+        """
+        Reset the state of the observer, including min and maximum values
+        """
+        super().reset()
+        self.min_val = {}
+        self.max_val = {}

--- a/src/compressed_tensors/utils/__init__.py
+++ b/src/compressed_tensors/utils/__init__.py
@@ -16,5 +16,6 @@
 from .helpers import *
 from .offload import *
 from .permutations_24 import *
+from .permute import *
 from .safetensors_load import *
 from .semi_structured_conversions import *

--- a/src/compressed_tensors/utils/permute.py
+++ b/src/compressed_tensors/utils/permute.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Set, Tuple
+
+import torch
+
+
+__all__ = ["safe_permute"]
+
+
+# these datatypes are missing implementations required for standard permutation
+_EXPERIMENTAL_DTYPES: Set[Tuple[torch.dtype, torch.device]] = set()
+
+
+def safe_permute(value: torch.Tensor, perm: torch.Tensor, dim: int = 0) -> torch.Tensor:
+    """
+    Perform out-of-place permutation without using torch.Tensor.index_put_,
+    whose implementation is missing for datatypes such as `torch.float8_e4m3fn`
+
+    :param value: tensor to permute
+    :param perm: permutation map
+    :param dim: dimension along which to apply permutation
+    :return: permuted value
+    """
+    dtype_tuple = (value.dtype, value.device)
+
+    if dtype_tuple in _EXPERIMENTAL_DTYPES:
+        return _fallback_permute(value, perm, dim)
+
+    try:
+        return value[tuple([slice(None)] * dim + [perm])]
+    except RuntimeError:
+        # Mark dtype as experimental if advanced indexing fails
+        _EXPERIMENTAL_DTYPES.add(dtype_tuple)
+        return _fallback_permute(value, perm, dim)
+
+
+def _fallback_permute(
+    value: torch.Tensor, perm: torch.Tensor, dim: int
+) -> torch.Tensor:
+    """
+    Fallback permutation method for experimental dtypes.
+
+    :param value: tensor to permute
+    :param perm: permutation map
+    :param dim: dimension along which to apply permutation
+    :return: permuted value
+    """
+    value_ret = value.clone()  # cannot use zeros_like b/c of missing impl.
+    orig_slices = [slice(None)] * (dim + 1)
+    perm_slices = [slice(None)] * (dim + 1)
+
+    for index, perm_index in enumerate(perm):
+        orig_slices[dim] = index
+        perm_slices[dim] = perm_index
+        value_ret[tuple(orig_slices)] = value[tuple(perm_slices)]
+
+    return value_ret

--- a/tests/test_quantization/lifecycle/test_helpers.py
+++ b/tests/test_quantization/lifecycle/test_helpers.py
@@ -15,10 +15,8 @@
 
 import pytest
 import torch
-from compressed_tensors.utils import (
-    _EXPERIMENTAL_DTYPES,
-    safe_permute,
-)
+from compressed_tensors.utils import safe_permute
+from compressed_tensors.utils.permute import _EXPERIMENTAL_DTYPES
 
 
 @pytest.mark.parametrize(

--- a/tests/test_quantization/lifecycle/test_helpers.py
+++ b/tests/test_quantization/lifecycle/test_helpers.py
@@ -15,7 +15,7 @@
 
 import pytest
 import torch
-from compressed_tensors.quantization.lifecycle.helpers import (
+from compressed_tensors.utils import (
     _EXPERIMENTAL_DTYPES,
     safe_permute,
 )


### PR DESCRIPTION
* Move the `safe_permute` to utils for easier access by #97 
* Add arguments to `update_layer_weight_quant_params` for use by #97
* Implement `reset` method on observers (will be tested in #97)