### PR TITLE
Remove g_idx arg on observer

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/helpers.py
@@ -64,7 +64,7 @@ def update_layer_weight_quant_params(
     if attached_weight is not None:
         weight = weight.to(attached_weight.dtype)
 
-    updated_scale, updated_zero_point = observer(weight, g_idx=g_idx)
+    updated_scale, updated_zero_point = observer(weight)
 
     # update scale and zero point
     device = next(layer.parameters()).device


### PR DESCRIPTION
Fixes mistake where g_idx was passed to the observer prior to that argument being implemented. Will be implemented in #97 