### PR TITLE
Activation Ordering Strategies

### DIFF
--- a/src/compressed_tensors/compressors/base.py
+++ b/src/compressed_tensors/compressors/base.py
@@ -108,6 +108,7 @@ class Compressor(RegistryMixin):
                 prefix = name[: -(len(weight_suffix))]
                 scale = model_state.get(merge_names(prefix, "weight_scale"), None)
                 zp = model_state.get(merge_names(prefix, "weight_zero_point"), None)
+                g_idx = model_state.get(merge_names(prefix, "weight_g_idx"), None)
                 if scale is not None:
                     # weight is quantized, compress it
                     quant_args = names_to_scheme[prefix]
@@ -115,6 +116,7 @@ class Compressor(RegistryMixin):
                         weight=value,
                         scale=scale,
                         zero_point=zp,
+                        g_idx=g_idx,
                         quantization_args=quant_args,
                         device="cpu",
                     )

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -21,6 +21,7 @@ from compressed_tensors.quantization.lifecycle.forward import (
     wrap_module_forward_quantized,
 )
 from compressed_tensors.quantization.quant_args import (
+    ActivationOrderingStrategy,
     QuantizationArgs,
     QuantizationStrategy,
 )
@@ -180,7 +181,7 @@ def _initialize_scale_zero_point_observer(
         module.register_parameter(f"{base_name}_zero_point", init_zero_point)
 
     # initialize with empty for actorder, to be populated by GPTQ or state_dict
-    if quantization_args.actorder:
+    if quantization_args.actorder != ActivationOrderingStrategy.OFF:
         g_idx_shape = (weight_shape[1],)
         g_idx_dtype = torch.int
         init_g_idx = Parameter(

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -21,7 +21,7 @@ from compressed_tensors.quantization.lifecycle.forward import (
     wrap_module_forward_quantized,
 )
 from compressed_tensors.quantization.quant_args import (
-    ActivationOrderingStrategy,
+    ActivationOrdering,
     QuantizationArgs,
     QuantizationStrategy,
 )
@@ -181,7 +181,7 @@ def _initialize_scale_zero_point_observer(
         module.register_parameter(f"{base_name}_zero_point", init_zero_point)
 
     # only grouped activation ordering has g_idx
-    if quantization_args.actorder == ActivationOrderingStrategy.GROUP:
+    if quantization_args.actorder == ActivationOrdering.GROUP:
         g_idx_shape = (weight_shape[1],)
         g_idx_dtype = torch.int
         init_g_idx = Parameter(

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -180,8 +180,8 @@ def _initialize_scale_zero_point_observer(
         )
         module.register_parameter(f"{base_name}_zero_point", init_zero_point)
 
-    # initialize with empty for actorder, to be populated by GPTQ or state_dict
-    if quantization_args.actorder != ActivationOrderingStrategy.OFF:
+    # only grouped activation ordering has g_idx
+    if quantization_args.actorder == ActivationOrderingStrategy.GROUP:
         g_idx_shape = (weight_shape[1],)
         g_idx_dtype = torch.int
         init_g_idx = Parameter(

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 import torch
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -25,6 +25,7 @@ __all__ = [
     "QuantizationStrategy",
     "QuantizationArgs",
     "round_to_quantized_type",
+    "ActivationOrderingStrategy",
 ]
 
 FP8_DTYPE = torch.float8_e4m3fn
@@ -51,6 +52,22 @@ class QuantizationStrategy(str, Enum):
     TOKEN = "token"
 
 
+class ActivationOrderingStrategy(str, Enum):
+    """
+    Enum storing strategies for activation ordering
+
+    On := defaults to weight
+    Grouped := reorder groups
+    Weight := only reorder weight, not groups
+    Off := do not reorder by activations
+    """
+
+    ON = "true"
+    GROUP = "group"
+    WEIGHT = "weight"
+    OFF = "false"
+
+
 class QuantizationArgs(BaseModel, use_enum_values=True):
     """
     User facing arguments used to define a quantization config for weights or
@@ -73,13 +90,13 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
     """
 
     num_bits: int = 8
-    type: QuantizationType = QuantizationType.INT.value
+    type: QuantizationType = QuantizationType.INT
     symmetric: bool = True
     group_size: Optional[int] = None
     strategy: Optional[QuantizationStrategy] = None
     block_structure: Optional[str] = None
     dynamic: bool = False
-    actorder: bool = False
+    actorder: Union[ActivationOrderingStrategy, bool] = ActivationOrderingStrategy.OFF
     observer: str = Field(
         default="minmax",
         description=(
@@ -108,8 +125,15 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
 
         return Observer.load_from_registry(self.observer, quantization_args=self)
 
+    @field_validator("type", mode="before")
+    def validate_type(cls, value) -> QuantizationType:
+        if isinstance(value, str):
+            return QuantizationType(value.lower())
+
+        return value
+
     @field_validator("group_size", mode="before")
-    def validate_group(cls, value) -> int:
+    def validate_group(cls, value) -> Union[int, None]:
         if value is None:
             return value
 
@@ -121,18 +145,36 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
 
         return value
 
-    @model_validator(mode="before")
-    def validate_strategy(values) -> Dict[str, Any]:
-        model_fields = QuantizationArgs.model_fields
-        strategy = values.get("strategy", model_fields["strategy"].default)
-        group_size = values.get("group_size", model_fields["group_size"].default)
-        actorder = values.get("actorder", model_fields["actorder"].default)
+    @field_validator("strategy", mode="before")
+    def validate_strategy(cls, value) -> Union[QuantizationStrategy, None]:
+        if isinstance(value, str):
+            return QuantizationStrategy(value.lower())
 
-        if strategy is not None:
-            strategy = QuantizationStrategy(strategy.lower())
+        return value
 
-        else:
-            # use group_size to determinine strategy if not given explicity
+    @field_validator("actorder", mode="before")
+    def validate_actorder(cls, value) -> ActivationOrderingStrategy:
+        if isinstance(value, bool):
+            value = str(value)
+
+        if isinstance(value, str):
+            value = ActivationOrderingStrategy(value.lower())
+
+        # default to weight
+        if value == ActivationOrderingStrategy.ON:
+            value = ActivationOrderingStrategy.WEIGHT
+
+        return value
+
+    @model_validator(mode="after")
+    def validate_model_after(model: "QuantizationArgs") -> Dict[str, Any]:
+        # extract user-passed values from dictionary
+        strategy = model.strategy
+        group_size = model.group_size
+        actorder = model.actorder
+
+        # infer strategy
+        if strategy is None:
             if group_size is None:
                 strategy = QuantizationStrategy.TENSOR
             elif group_size > 0:
@@ -145,6 +187,7 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
                     "strategy='group' and group_size = -1 for 'channel'"
                 )
 
+        # validate strategy and group
         if strategy == QuantizationStrategy.GROUP:
             if group_size is None or group_size <= 0:
                 raise ValueError(
@@ -152,14 +195,19 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
                     "set to a positive value"
                 )
 
-        if actorder and strategy != QuantizationStrategy.GROUP:
+        # validate activation ordering and strategy
+        if (
+            actorder != ActivationOrderingStrategy.OFF
+            and strategy != QuantizationStrategy.GROUP
+        ):
             raise ValueError(
-                "Group quantization must be specified in order to apply "
+                "Group quantization strategy must be specified in order to apply "
                 "activation ordering"
             )
 
-        values["strategy"] = strategy
-        return values
+        # write back modified values
+        model.strategy = strategy
+        return model
 
     def pytorch_dtype(self) -> torch.dtype:
         if self.type == QuantizationType.FLOAT:

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -57,7 +57,7 @@ class ActivationOrderingStrategy(str, Enum):
     Enum storing strategies for activation ordering
 
     Weight := only reorder weight, not groups (default)
-    Grouped := reorder groups
+    Grouped := reorder groups and weight
     Off := do not reorder by activations
     """
 

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -56,14 +56,13 @@ class ActivationOrderingStrategy(str, Enum):
     """
     Enum storing strategies for activation ordering
 
-    On := defaults to weight
+    Weight := only reorder weight, not groups (default)
     Grouped := reorder groups
-    Weight := only reorder weight, not groups
     Off := do not reorder by activations
     """
 
-    GROUP = "group"
     WEIGHT = "weight"
+    GROUP = "group"
     OFF = "off"
 
 

--- a/tests/test_compressors/test_pack_quant.py
+++ b/tests/test_compressors/test_pack_quant.py
@@ -33,12 +33,12 @@ from compressed_tensors.quantization import (
     apply_quantization_status,
 )
 from compressed_tensors.quantization.lifecycle.forward import fake_quantize
-from compressed_tensors.quantization.quant_args import ActivationOrderingStrategy
+from compressed_tensors.quantization.quant_args import ActivationOrdering
 from safetensors.torch import save_file
 from torch.nn.modules import Linear, Sequential
 
 
-def get_dummy_quant_config(num_bits=4, strategy=None, group_size=None, actorder=False):
+def get_dummy_quant_config(num_bits=4, strategy=None, group_size=None, actorder=None):
     config_groups = {
         "group_1": QuantizationScheme(
             targets=["Linear"],
@@ -200,9 +200,9 @@ def test_reload_match(tmp_path, num_bits):
 @pytest.mark.parametrize(
     "actorder",
     [
-        ActivationOrderingStrategy.GROUP,
-        ActivationOrderingStrategy.WEIGHT,
-        ActivationOrderingStrategy.OFF,
+        ActivationOrdering.GROUP,
+        ActivationOrdering.WEIGHT,
+        None,
     ],
 )
 def test_actorder_reload_match(actorder, tmp_path):
@@ -221,7 +221,7 @@ def test_actorder_reload_match(actorder, tmp_path):
     apply_quantization_status(model, QuantizationStatus.FROZEN)
 
     # apply gptq
-    if actorder == ActivationOrderingStrategy.GROUP:
+    if actorder == ActivationOrdering.GROUP:
         init_g_idx = make_dummy_g_idx(512, group_size)
         model.dummy.register_parameter("weight_g_idx", init_g_idx)
 

--- a/tests/test_compressors/test_pack_quant.py
+++ b/tests/test_compressors/test_pack_quant.py
@@ -33,11 +33,12 @@ from compressed_tensors.quantization import (
     apply_quantization_status,
 )
 from compressed_tensors.quantization.lifecycle.forward import fake_quantize
+from compressed_tensors.quantization.quant_args import ActivationOrderingStrategy
 from safetensors.torch import save_file
 from torch.nn.modules import Linear, Sequential
 
 
-def get_dummy_quant_config(num_bits=4, strategy=None, group_size=None):
+def get_dummy_quant_config(num_bits=4, strategy=None, group_size=None, actorder=False):
     config_groups = {
         "group_1": QuantizationScheme(
             targets=["Linear"],
@@ -45,21 +46,19 @@ def get_dummy_quant_config(num_bits=4, strategy=None, group_size=None):
                 num_bits=num_bits,
                 strategy=strategy,
                 group_size=group_size,
+                actorder=actorder,
             ),
         ),
     }
-    ignore = ["lm_head"]
-    quant_config = QuantizationConfig(
-        config_groups=config_groups,
-        ignore=ignore,
-    )
-
-    return quant_config
+    return QuantizationConfig(config_groups=config_groups)
 
 
 def make_dummy_g_idx(columns: int, group_size: int) -> torch.Tensor:
     perm = torch.randperm(columns)
-    return torch.tensor([index // group_size for index in range(columns)])[perm]
+    return torch.nn.Parameter(
+        (torch.arange(columns, dtype=torch.int) // group_size)[perm],
+        requires_grad=False,
+    )
 
 
 @pytest.mark.parametrize(
@@ -199,29 +198,34 @@ def test_reload_match(tmp_path, num_bits):
 
 
 @pytest.mark.parametrize(
-    "apply_gptq",
-    [True, False],
+    "actorder",
+    [
+        ActivationOrderingStrategy.GROUP,
+        ActivationOrderingStrategy.WEIGHT,
+        ActivationOrderingStrategy.OFF,
+    ],
 )
-def test_actorder_reload_match(apply_gptq, tmp_path):
-    model = Sequential(
-        OrderedDict(
-            [
-                ("dummy", Linear(512, 1024, bias=None)),
-            ]
-        )
-    )
+def test_actorder_reload_match(actorder, tmp_path):
+    model = Sequential(OrderedDict([("dummy", Linear(512, 1024, bias=None))]))
     group_size = 128
-    quant_config = get_dummy_quant_config(strategy="group", group_size=group_size)
+    quant_config = get_dummy_quant_config(
+        strategy="group", group_size=group_size, actorder=actorder
+    )
     apply_quantization_config(model, quant_config)
+
+    # run calibration
     apply_quantization_status(model, QuantizationStatus.CALIBRATION)
-
-    if apply_gptq:
-        model.dummy.weight_g_idx = make_dummy_g_idx(512, group_size)
-
     for _ in range(16):
         inputs = torch.rand((512, 512))
         _ = model(inputs)
+    apply_quantization_status(model, QuantizationStatus.FROZEN)
 
+    # apply gptq
+    if actorder == ActivationOrderingStrategy.GROUP:
+        init_g_idx = make_dummy_g_idx(512, group_size)
+        model.dummy.register_parameter("weight_g_idx", init_g_idx)
+
+    # compress
     compressor = PackedQuantizationCompressor(config=quant_config)
     quantized_modules_to_args = {
         "dummy": quant_config.config_groups["group_1"].weights,
@@ -230,6 +234,8 @@ def test_actorder_reload_match(apply_gptq, tmp_path):
         model.state_dict(), names_to_scheme=quantized_modules_to_args
     )
     save_file(compressed_state_dict, tmp_path / "model.safetensors")
+
+    # decompress
     reconstructed_dense_gen = compressor.decompress(
         tmp_path, names_to_scheme=quantized_modules_to_args
     )
@@ -241,6 +247,7 @@ def test_actorder_reload_match(apply_gptq, tmp_path):
         model.dummy.weight,
         scale=model.dummy.weight_scale,
         zero_point=model.dummy.weight_zero_point,
+        g_idx=getattr(model.dummy, "weight_g_idx", None),
         args=quantized_modules_to_args["dummy"],
     )
     assert torch.equal(fake_quant_dummy, reconstructed_dense["dummy.weight"])

--- a/tests/test_quantization/test_quant_args.py
+++ b/tests/test_quantization/test_quant_args.py
@@ -14,7 +14,7 @@
 
 import pytest
 from compressed_tensors.quantization import (
-    ActivationOrderingStrategy,
+    ActivationOrdering,
     QuantizationArgs,
     QuantizationStrategy,
     QuantizationType,
@@ -64,16 +64,15 @@ def test_enums():
     assert QuantizationArgs(
         type=QuantizationType.INT,
         strategy=QuantizationStrategy.GROUP,
-        actorder=ActivationOrderingStrategy.WEIGHT,
+        actorder=ActivationOrdering.WEIGHT,
         group_size=1,
     ) == QuantizationArgs(type="InT", strategy="GROUP", actorder="weight", group_size=1)
 
 
 def test_actorder():
     # test group inference with actorder
-    args = QuantizationArgs(group_size=128, actorder=True)
+    args = QuantizationArgs(group_size=128, actorder=ActivationOrdering.GROUP)
     assert args.strategy == QuantizationStrategy.GROUP
-    assert args.actorder
 
     # test invalid pairings
     with pytest.raises(ValueError):
@@ -86,12 +85,9 @@ def test_actorder():
     # test boolean defaulting
     assert (
         QuantizationArgs(group_size=1, actorder=True).actorder
-        == ActivationOrderingStrategy.WEIGHT
+        == ActivationOrdering.WEIGHT
     )
-    assert (
-        QuantizationArgs(group_size=1, actorder=False).actorder
-        == ActivationOrderingStrategy.OFF
-    )
+    assert QuantizationArgs(group_size=1, actorder=False).actorder is None
 
 
 def test_invalid():

--- a/tests/test_quantization/test_quant_args.py
+++ b/tests/test_quantization/test_quant_args.py
@@ -41,7 +41,7 @@ def test_group():
     assert group.group_size == kwargs["group_size"]
 
     with pytest.raises(ValueError):
-        _ = QuantizationArgs(strategy=QuantizationStrategy.GROUP, group_size=-1)
+        QuantizationArgs(strategy=QuantizationStrategy.GROUP, group_size=-1)
 
 
 def test_block():
@@ -77,11 +77,11 @@ def test_actorder():
 
     # test invalid pairings
     with pytest.raises(ValueError):
-        _ = QuantizationArgs(group_size=None, actorder=True)
+        QuantizationArgs(group_size=None, actorder=True)
     with pytest.raises(ValueError):
-        _ = QuantizationArgs(group_size=-1, actorder=True)
+        QuantizationArgs(group_size=-1, actorder=True)
     with pytest.raises(ValueError):
-        _ = QuantizationArgs(strategy="tensor", actorder=True)
+        QuantizationArgs(strategy="tensor", actorder=True)
 
     # test boolean defaulting
     assert (
@@ -96,8 +96,8 @@ def test_actorder():
 
 def test_invalid():
     with pytest.raises(ValidationError):
-        _ = QuantizationArgs(type="invalid")
+        QuantizationArgs(type="invalid")
     with pytest.raises(ValidationError):
-        _ = QuantizationArgs(strategy="invalid")
+        QuantizationArgs(strategy="invalid")
     with pytest.raises(ValidationError):
-        _ = QuantizationArgs(strategy=QuantizationStrategy.GROUP)
+        QuantizationArgs(strategy=QuantizationStrategy.GROUP)

--- a/tests/test_quantization/test_quant_args.py
+++ b/tests/test_quantization/test_quant_args.py
@@ -83,14 +83,14 @@ def test_actorder():
     with pytest.raises(ValueError):
         _ = QuantizationArgs(strategy="tensor", actorder=True)
 
-    # test defaulting
+    # test boolean defaulting
     assert (
         QuantizationArgs(group_size=1, actorder=True).actorder
         == ActivationOrderingStrategy.WEIGHT
     )
     assert (
-        QuantizationArgs(group_size=1, actorder=ActivationOrderingStrategy.ON).actorder
-        == ActivationOrderingStrategy.WEIGHT
+        QuantizationArgs(group_size=1, actorder=False).actorder
+        == ActivationOrderingStrategy.OFF
     )
 
 

--- a/tests/test_quantization/test_quant_args.py
+++ b/tests/test_quantization/test_quant_args.py
@@ -76,18 +76,18 @@ def test_actorder():
 
     # test invalid pairings
     with pytest.raises(ValueError):
-        QuantizationArgs(group_size=None, actorder=True)
+        QuantizationArgs(group_size=None, actorder="weight")
     with pytest.raises(ValueError):
-        QuantizationArgs(group_size=-1, actorder=True)
+        QuantizationArgs(group_size=-1, actorder="weight")
     with pytest.raises(ValueError):
-        QuantizationArgs(strategy="tensor", actorder=True)
+        QuantizationArgs(strategy="tensor", actorder="weight")
 
     # test boolean defaulting
     assert (
-        QuantizationArgs(group_size=1, actorder=True).actorder
+        QuantizationArgs(group_size=1, actorder="weight").actorder
         == ActivationOrdering.WEIGHT
     )
-    assert QuantizationArgs(group_size=1, actorder=False).actorder is None
+    assert QuantizationArgs(group_size=1, actorder=None).actorder is None
 
 
 def test_invalid():


### PR DESCRIPTION
## Purpose ##
* Precursor to https://github.com/vllm-project/llm-compressor/pull/121
* Add additional activation ordering strategies
* Preserve use of booleans as arguments
* Fix bug with weight_g_idx compression

## Changes ##
* Use ActivationOrderingStrategy type to validate actorder argument
* Default to weight-only activation ordering
* Use field validators to cast to enum types, move validator to after field_validators
* Modify/add tests for new activation orderings

## Testing ##
* Added/modified unit tests
* Tested e2e with https://github.com/vllm-project/llm-compressor/pull/121 (see tests)