### PR TITLE
get rid of None and default values

### DIFF
--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -212,6 +212,17 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
         else:
             raise ValueError(f"Invalid quantization type {self.type}")
 
+    def remove_defaults(self):
+        defaults = self.__fields__
+        result = {}
+        for field, value in dict(self).items():
+            if field == "observer_kwargs" and len(value) == 0:
+                continue
+            default = defaults[field].default
+            if value != default and value is not None:
+                result[field] = value
+        return result
+
 
 def round_to_quantized_type(
     tensor: torch.Tensor, args: QuantizationArgs

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -250,3 +250,28 @@ class QuantizationConfig(BaseModel):
                     return True
 
         return False
+
+    def remove_defaults(self):
+        defaults = self.__fields__
+        result = {}
+        for field, value in dict(self).items():
+            if value is None:
+                continue
+            if field == "config_groups":
+                outer_value = value
+                value = {}
+                for config_key, config_value in outer_value.items():
+                    config_value = config_value.remove_defaults()
+                    value[config_key] = config_value
+
+            if field == "ignore" and len(value) == 0:
+                continue
+            # Handle nested Pydantic models
+            if isinstance(value, BaseModel):
+                value = value.remove_defaults()
+
+            # # Compare the value with the default value
+            # default = defaults[field].default
+            # if value != default and value is not None:
+            result[field] = value
+        return result

--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -75,6 +75,22 @@ class QuantizationScheme(BaseModel):
             output_activations=output_activations,
         )
 
+    def remove_defaults(self):
+        result = {}
+        for field, value in dict(self).items():
+            if field == "targets" and len(value) == 0:
+                continue
+            if value == None:
+                continue
+
+            if isinstance(value, BaseModel):
+                value = value.remove_defaults()
+
+            # Include non-default or non-empty values
+            if value not in [None, []]:
+                result[field] = value
+        return result
+
 
 """
 Pre-Set Quantization Scheme Args
@@ -109,6 +125,7 @@ def is_preset_scheme(name: str) -> bool:
     :return: True if the name is a preset scheme name
     """
     return name.upper() in PRESET_SCHEMES
+
 
 UNQUANTIZED = dict()
 


### PR DESCRIPTION
Before:
```
{
  "_name_or_path": "/home/george/.cache/huggingface/hub/models--TinyLlama--TinyLlama-1.1B-Chat-v1.0/snapshots/fe8a4ea1ffedaf415f4da2f062534de366a451e6",
  "architectures": [
    "LlamaForCausalLM"
  ],
  "attention_bias": false,
  "attention_dropout": 0.0,
  "bos_token_id": 1,
  "compression_config": {
    "config_groups": {
      "group_0": {
        "input_activations": {
          "actorder": false,
          "block_structure": null,
          "dynamic": false,
          "group_size": null,
          "num_bits": 8,
          "observer": "minmax",
          "observer_kwargs": {},
          "strategy": "tensor",
          "symmetric": true,
          "type": "int"
        },
        "output_activations": null,
        "targets": [
          "Linear"
        ],
        "weights": {
          "actorder": false,
          "block_structure": null,
          "dynamic": false,
          "group_size": null,
          "num_bits": 8,
          "observer": "minmax",
          "observer_kwargs": {},
          "strategy": "tensor",
          "symmetric": true,
          "type": "int"
        }
      }
    },
    "format": "int-quantized",
    "global_compression_ratio": 1.459940558204713,
    "ignore": [],
    "kv_cache_scheme": {
      "actorder": false,
      "block_structure": null,
      "dynamic": false,
      "group_size": null,
      "num_bits": 8,
      "observer": "minmax",
      "observer_kwargs": {},
      "strategy": "tensor",
      "symmetric": true,
      "type": "float"
    },
    "quant_method": "compressed-tensors",
    "quantization_status": "compressed"
  },
  "eos_token_id": 2,
  "hidden_act": "silu",
  "hidden_size": 2048,
  "initializer_range": 0.02,
  "intermediate_size": 5632,
  "max_position_embeddings": 2048,
  "mlp_bias": false,
  "model_type": "llama",
  "num_attention_heads": 32,
  "num_hidden_layers": 22,
  "num_key_value_heads": 4,
  "pretraining_tp": 1,
  "rms_norm_eps": 1e-05,
  "rope_scaling": null,
  "rope_theta": 10000.0,
  "tie_word_embeddings": false,
  "torch_dtype": "bfloat16",
  "transformers_version": "4.44.2",
  "use_cache": true,
  "vocab_size": 32000
}
```

After:
```
{
  "_name_or_path": "/home/george/.cache/huggingface/hub/models--TinyLlama--TinyLlama-1.1B-Chat-v1.0/snapshots/fe8a4ea1ffedaf415f4da2f062534de366a451e6",
  "architectures": [
    "LlamaForCausalLM"
  ],
  "attention_bias": false,
  "attention_dropout": 0.0,
  "bos_token_id": 1,
  "compression_config": {
    "config_groups": {
      "group_0": {
        "input_activations": {
          "strategy": "tensor"
        },
        "targets": [
          "Linear"
        ],
        "weights": {
          "strategy": "tensor"
        }
      }
    },
    "format": "int-quantized",
    "global_compression_ratio": 1.4599405447755927,
    "kv_cache_scheme": {
      "strategy": "tensor",
      "type": "float"
    },
    "quant_method": "compressed-tensors",
    "quantization_status": "compressed"
  },
  "eos_token_id": 2,
  "hidden_act": "silu",
  "hidden_size": 2048,
  "initializer_range": 0.02,
  "intermediate_size": 5632,
  "max_position_embeddings": 2048,
  "mlp_bias": false,
  "model_type": "llama",
  "num_attention_heads": 32,
  "num_hidden_layers": 22,
  "num_key_value_heads": 4,
  "pretraining_tp": 1,
  "rms_norm_eps": 1e-05,
  "rope_scaling": null,
  "rope_theta": 10000.0,
  "tie_word_embeddings": false,
  "torch_dtype": "bfloat16",
  "transformers_version": "4.44.2",
  "use_cache": true,
  "vocab_size": 32000
}
```