### PR TITLE
Replace `compression_config` to be `quantization_config` for `HFQuantizer` support

### DIFF
--- a/src/compressed_tensors/compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressor.py
@@ -306,16 +306,16 @@ class ModelCompressor:
         with open(config_file_path, "r") as config_file:
             config_data = json.load(config_file)
 
-        config_data[COMPRESSION_CONFIG_NAME] = {}
+        config_data[QUANTIZATION_CONFIG_NAME] = {}
         if self.quantization_config is not None:
             quant_config_data = self.quantization_config.model_dump()
-            config_data[COMPRESSION_CONFIG_NAME] = quant_config_data
+            config_data[QUANTIZATION_CONFIG_NAME] = quant_config_data
         if self.sparsity_config is not None:
             sparsity_config_data = self.sparsity_config.model_dump()
-            config_data[COMPRESSION_CONFIG_NAME][
+            config_data[QUANTIZATION_CONFIG_NAME][
                 SPARSITY_CONFIG_NAME
             ] = sparsity_config_data
-        config_data[COMPRESSION_CONFIG_NAME][
+        config_data[QUANTIZATION_CONFIG_NAME][
             COMPRESSION_VERSION_NAME
         ] = compressed_tensors.__version__
 


### PR DESCRIPTION
# Summary
- Updates to swap out the `compression_config` key for `quantization_config`
- This will allow us to leverage `HFQuantizer` support and the `AutoModelForCausalLM` pathway
- Models can still be loaded through the `SparseAutoModelForCausalLM` pathway as well
- Old models (with the `compression_config` key) will still work through the `SparseAutoModelForCausalLM` pathway

# Example Config:

```yaml
{
  "_name_or_path": "/home/dsikka/.cache/huggingface/hub/models--TinyLlama--TinyLlama-1.1B-Chat-v1.0/snapshots/fe8a4ea1ffedaf415f4da2f062534de366a451e6",
  "architectures": [
    "LlamaForCausalLM"
  ],
  "attention_bias": false,
  "attention_dropout": 0.0,
  "bos_token_id": 1,
  "eos_token_id": 2,
  "head_dim": 64,
  "hidden_act": "silu",
  "hidden_size": 2048,
  "initializer_range": 0.02,
  "intermediate_size": 5632,
  "max_position_embeddings": 2048,
  "mlp_bias": false,
  "model_type": "llama",
  "num_attention_heads": 32,
  "num_hidden_layers": 22,
  "num_key_value_heads": 4,
  "pretraining_tp": 1,
  "quantization_config": {
    "config_groups": {
      "group_0": {
        "input_activations": {
          "actorder": null,
          "block_structure": null,
          "dynamic": true,
          "group_size": null,
          "num_bits": 8,
          "observer": "memoryless",
          "observer_kwargs": {},
          "strategy": "token",
          "symmetric": true,
          "type": "int"
        },
        "output_activations": null,
        "targets": [
          "Linear"
        ],
        "weights": {
          "actorder": null,
          "block_structure": null,
          "dynamic": false,
          "group_size": null,
          "num_bits": 8,
          "observer": "minmax",
          "observer_kwargs": {},
          "strategy": "channel",
          "symmetric": true,
          "type": "int"
        }
      }
    },
    "format": "int-quantized",
    "global_compression_ratio": 1.2383372224751887,
    "ignore": [
      "lm_head"
    ],
    "kv_cache_scheme": null,
    "quant_method": "compressed-tensors",
    "quantization_status": "compressed",
    "version": "0.6.0.20240927"
  },
  "rms_norm_eps": 1e-05,
  "rope_scaling": null,
  "rope_theta": 10000.0,
  "tie_word_embeddings": false,
  "torch_dtype": "bfloat16",
  "transformers_version": "4.45.1",
  "use_cache": true,
  "vocab_size": 32000
```
# Running the model 

```python
from transformers import AutoTokenizer, AutoModelForCausalLM

MODEL_ID = "/home/dsikka/llm-compressor/examples/quantization_w8a8_int8/TinyLlama-1.1B-Chat-v1.0-W8A8-Dynamic-Per-Token"

model = AutoModelForCausalLM.from_pretrained(MODEL_ID, device_map="cuda")
tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to("cuda")
output = model.generate(input_ids.to("cuda"), max_new_tokens=100)
print(tokenizer.decode(output[0]))
```

# SparseAutoModelForCausalLM

```python
from transformers import AutoTokenizer
from llmcompressor.transformers import SparseAutoModelForCausalLM

MODEL_ID = "/home/dsikka/llm-compressor/examples/quantization_w8a8_int8/TinyLlama-1.1B-Chat-v1.0-W8A8-Dynamic-Per-Token"

model = SparseAutoModelForCausalLM.from_pretrained(
    MODEL_ID,
    device_map="cuda",
)


tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to("cuda")
output = model.generate(input_ids.to("cuda"), max_new_tokens=100)
print(tokenizer.decode(output[0]))
```