### PR TITLE
ignore list

### DIFF
--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -201,6 +201,13 @@ class QuantizationConfig(BaseModel):
         if len(quant_scheme_to_layers) == 0:  # No quantized layers
             return None
 
+        # kv-cache only, no weight/activation quantization
+        if (
+            len(quantization_type_names) == 1
+            and "attention" in list(quantization_type_names)[0].lower()
+        ):
+            quantization_type_names.add("Linear")
+
         # clean up ignore list, we can leave out layers types if none of the
         # instances are quantized
         consolidated_ignore = []


### PR DESCRIPTION
Include "Linear" in the ignore list if only running to get the scales for kv-cache. 
right now quantization_type_names = {"...Attention..."}

before:
 "ignore": [],
    "kv_cache_scheme": {
      "actorder": null,
      "block_structure": null,
      "dynamic": false,
      "group_size": null,
      "num_bits": 8,
      "observer": "minmax",
      "observer_kwargs": {},
      "strategy": "tensor",
      "symmetric": true,
      "type": "float"
    },

after:
 "ignore": [
      "model.layers.0.self_attn.q_proj",
      "model.layers.0.self_attn.k_proj",
      "model.layers.0.self_attn.v_proj",
      "model.layers.0.self_attn.o_proj",
      "model.layers.0.mlp.gate_proj",
      "model.layers.0.mlp.up_proj",
      "model.layers.0.mlp.down_proj",
      "model.layers.1.self_attn.q_proj",
      "model.layers.1.self_attn.k_proj",
      "model.layers.1.self_attn.v_proj",
      "model.layers.1.self_attn.o_proj",
      "model.layers.1.mlp.gate_proj",
      "model.layers.1.mlp.up_proj",
      "model.layers.1.mlp.down_proj",
      "model.layers.2.self_attn.q_proj",
      "model.layers.2.self_attn.k_proj",
      "model.layers.2.self_attn.v_proj",
      "model.layers.2.self_attn.o_proj",
      "model.layers.2.mlp.gate_proj",
      "model.layers.2.mlp.up_proj",
      "model.layers.2.mlp.down_proj",
      "model.layers.3.self_attn.q_proj",
      "model.layers.3.self_attn.k_proj",
      "model.layers.3.self_attn.v_proj",
      "model.layers.3.self_attn.o_proj",
      "model.layers.3.mlp.gate_proj",
      "model.layers.3.mlp.up_proj",
      "model.layers.3.mlp.down_proj",
      "model.layers.4.self_attn.q_proj",
      "model.layers.4.self_attn.k_proj",
      "model.layers.4.self_attn.v_proj",
      "model.layers.4.self_attn.o_proj",
      "model.layers.4.mlp.gate_proj",
      "model.layers.4.mlp.up_proj",
      "model.layers.4.mlp.down_proj",
      "model.layers.5.self_attn.q_proj",
      "model.layers.5.self_attn.k_proj",
      "model.layers.5.self_attn.v_proj",
      "model.layers.5.self_attn.o_proj",
      "model.layers.5.mlp.gate_proj",
      "model.layers.5.mlp.up_proj",
      "model.layers.5.mlp.down_proj",
      "model.layers.6.self_attn.q_proj",
      "model.layers.6.self_attn.k_proj",
      "model.layers.6.self_attn.v_proj",
      "model.layers.6.self_attn.o_proj",
      "model.layers.6.mlp.gate_proj",
      "model.layers.6.mlp.up_proj",
      "model.layers.6.mlp.down_proj",
      "model.layers.7.self_attn.q_proj",
      "model.layers.7.self_attn.k_proj",
      "model.layers.7.self_attn.v_proj",
      "model.layers.7.self_attn.o_proj",
      "model.layers.7.mlp.gate_proj",
      "model.layers.7.mlp.up_proj",
      "model.layers.7.mlp.down_proj",
      "model.layers.8.self_attn.q_proj",
      "model.layers.8.self_attn.k_proj",
      "model.layers.8.self_attn.v_proj",
      "model.layers.8.self_attn.o_proj",
      "model.layers.8.mlp.gate_proj",
      "model.layers.8.mlp.up_proj",
      "model.layers.8.mlp.down_proj",
      "model.layers.9.self_attn.q_proj",
      "model.layers.9.self_attn.k_proj",
      "model.layers.9.self_attn.v_proj",
      "model.layers.9.self_attn.o_proj",
      "model.layers.9.mlp.gate_proj",
      "model.layers.9.mlp.up_proj",
      "model.layers.9.mlp.down_proj",
      "model.layers.10.self_attn.q_proj",
      "model.layers.10.self_attn.k_proj",
      "model.layers.10.self_attn.v_proj",
      "model.layers.10.self_attn.o_proj",
      "model.layers.10.mlp.gate_proj",
      "model.layers.10.mlp.up_proj",
      "model.layers.10.mlp.down_proj",
      "model.layers.11.self_attn.q_proj",
      "model.layers.11.self_attn.k_proj",
      "model.layers.11.self_attn.v_proj",
      "model.layers.11.self_attn.o_proj",
      "model.layers.11.mlp.gate_proj",
      "model.layers.11.mlp.up_proj",
      "model.layers.11.mlp.down_proj",
      "model.layers.12.self_attn.q_proj",
      "model.layers.12.self_attn.k_proj",
      "model.layers.12.self_attn.v_proj",
      "model.layers.12.self_attn.o_proj",
      "model.layers.12.mlp.gate_proj",
      "model.layers.12.mlp.up_proj",
      "model.layers.12.mlp.down_proj",
      "model.layers.13.self_attn.q_proj",
      "model.layers.13.self_attn.k_proj",
      "model.layers.13.self_attn.v_proj",
      "model.layers.13.self_attn.o_proj",
      "model.layers.13.mlp.gate_proj",
      "model.layers.13.mlp.up_proj",
      "model.layers.13.mlp.down_proj",
      "model.layers.14.self_attn.q_proj",
      "model.layers.14.self_attn.k_proj",
      "model.layers.14.self_attn.v_proj",
      "model.layers.14.self_attn.o_proj",
      "model.layers.14.mlp.gate_proj",
      "model.layers.14.mlp.up_proj",
      "model.layers.14.mlp.down_proj",
      "model.layers.15.self_attn.q_proj",
      "model.layers.15.self_attn.k_proj",
      "model.layers.15.self_attn.v_proj",
      "model.layers.15.self_attn.o_proj",
      "model.layers.15.mlp.gate_proj",
      "model.layers.15.mlp.up_proj",
      "model.layers.15.mlp.down_proj",
      "model.layers.16.self_attn.q_proj",
      "model.layers.16.self_attn.k_proj",
      "model.layers.16.self_attn.v_proj",
      "model.layers.16.self_attn.o_proj",
      "model.layers.16.mlp.gate_proj",
      "model.layers.16.mlp.up_proj",
      "model.layers.16.mlp.down_proj",
      "model.layers.17.self_attn.q_proj",
      "model.layers.17.self_attn.k_proj",
      "model.layers.17.self_attn.v_proj",
      "model.layers.17.self_attn.o_proj",
      "model.layers.17.mlp.gate_proj",
      "model.layers.17.mlp.up_proj",
      "model.layers.17.mlp.down_proj",
      "model.layers.18.self_attn.q_proj",
      "model.layers.18.self_attn.k_proj",
      "model.layers.18.self_attn.v_proj",
      "model.layers.18.self_attn.o_proj",
      "model.layers.18.mlp.gate_proj",
      "model.layers.18.mlp.up_proj",
      "model.layers.18.mlp.down_proj",
      "model.layers.19.self_attn.q_proj",
      "model.layers.19.self_attn.k_proj",
      "model.layers.19.self_attn.v_proj",
      "model.layers.19.self_attn.o_proj",
      "model.layers.19.mlp.gate_proj",
      "model.layers.19.mlp.up_proj",
      "model.layers.19.mlp.down_proj",
      "model.layers.20.self_attn.q_proj",
      "model.layers.20.self_attn.k_proj",
      "model.layers.20.self_attn.v_proj",
      "model.layers.20.self_attn.o_proj",
      "model.layers.20.mlp.gate_proj",
      "model.layers.20.mlp.up_proj",
      "model.layers.20.mlp.down_proj",
      "model.layers.21.self_attn.q_proj",
      "model.layers.21.self_attn.k_proj",
      "model.layers.21.self_attn.v_proj",
      "model.layers.21.self_attn.o_proj",
      "model.layers.21.mlp.gate_proj",
      "model.layers.21.mlp.up_proj",
      "model.layers.21.mlp.down_proj",
      "lm_head"
    ],
    "kv_cache_scheme": {
      "actorder": null,
      "block_structure": null,
      "dynamic": false,
      "group_size": null,
      "num_bits": 8,
      "observer": "minmax",
      "observer_kwargs": {},
      "strategy": "tensor",
      "symmetric": true,
      "type": "float"
    },