### PR TITLE
Allow ModelCompressor to load quantization configs

### DIFF
--- a/src/compressed_tensors/compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressor.py
@@ -20,9 +20,9 @@ import re
 from copy import deepcopy
 from typing import Any, Dict, Optional, Union
 
+import compressed_tensors
 import torch
 import transformers
-import compressed_tensors
 from compressed_tensors.base import (
     COMPRESSION_CONFIG_NAME,
     COMPRESSION_VERSION_NAME,
@@ -90,10 +90,12 @@ class ModelCompressor:
         configs and load a ModelCompressor
 
         :param pretrained_model_name_or_path: path to model config on disk or HF hub
-        :return: compressor for the extracted configs
+        :return: compressor for the configs, or None if model is not compressed
         """
         config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **kwargs)
-        compression_config = getattr(config, COMPRESSION_CONFIG_NAME, None)
+        compression_config = getattr(config, QUANTIZATION_CONFIG_NAME, None) or getattr(
+            config, COMPRESSION_CONFIG_NAME, None
+        )
         return cls.from_compression_config(compression_config)
 
     @classmethod
@@ -215,7 +217,6 @@ class ModelCompressor:
         self.quantization_config = quantization_config
         self.sparsity_compressor = None
         self.quantization_compressor = None
-
 
         if sparsity_config and sparsity_config.format == CompressionFormat.dense.value:
             # ignore dense sparsity config

--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -211,7 +211,7 @@ PRESET_SCHEMES = {
     "W4A16": W4A16,
     # Integer weight and activation schemes
     "W8A8": INT8_W8A8,
-    "INT8": INT8_W8A8, # alias for W8A8
+    "INT8": INT8_W8A8,  # alias for W8A8
     "W4A8": INT8_W4A8,
     # Float weight and activation schemes
     "FP8": FP8,

--- a/tests/test_compressors/test_model_compressor.py
+++ b/tests/test_compressors/test_model_compressor.py
@@ -16,11 +16,14 @@ from copy import deepcopy
 
 import pytest
 from compressed_tensors.compressors.model_compressor import ModelCompressor
+from compressed_tensors.config.base import SparsityCompressionConfig
+from compressed_tensors.quantization.quant_config import QuantizationConfig
+from transformers import AutoConfig
 
 
 def sparsity_config():
     return {
-        "format": "dense",
+        "format": "sparse-bitmask",  # dense format is ignored by ModelCompressor
         "global_sparsity": 19.098103233975568,
         "registry_requires_subclass": False,
         "sparsity_structure": "unstructured",
@@ -60,9 +63,94 @@ def _get_combined_config(s_config, q_config):
     return combined
 
 
-@pytest.mark.parametrize("s_config", [sparsity_config(), None])
-@pytest.mark.parametrize("q_config", [quantization_config(), None])
+@pytest.mark.parametrize(
+    "s_config,q_config",
+    [
+        (sparsity_config(), quantization_config()),
+        (sparsity_config(), None),
+        (None, quantization_config()),
+        (None, None),
+    ],
+)
 def test_config_format(s_config, q_config):
     combined_config = _get_combined_config(s_config, q_config)
     assert ModelCompressor.parse_sparsity_config(combined_config) == s_config
     assert ModelCompressor.parse_quantization_config(combined_config) == q_config
+
+
+@pytest.mark.parametrize(
+    "s_config,q_config",
+    [
+        (sparsity_config(), quantization_config()),
+        (sparsity_config(), None),
+        (None, quantization_config()),
+        (None, None),
+    ],
+)
+def test_from_compression_config_dict(s_config, q_config, tmp_path):
+    combined_config = _get_combined_config(s_config, q_config)
+
+    compressor = ModelCompressor.from_compression_config(combined_config)
+
+    s_config = (
+        SparsityCompressionConfig.load_from_registry(s_config.get("format"), **s_config)
+        if s_config is not None
+        else None
+    )
+    q_config = QuantizationConfig(**q_config) if q_config is not None else None
+
+    if s_config is q_config is None:
+        assert compressor is None
+    else:
+        assert compressor.sparsity_config == s_config
+        assert compressor.quantization_config == q_config
+
+
+@pytest.mark.parametrize(
+    "s_config,q_config",
+    [
+        (sparsity_config(), quantization_config()),
+        (sparsity_config(), None),
+        (None, quantization_config()),
+    ],
+)
+def test_from_pretrained_reload(s_config, q_config, tmp_path):
+    combined_config = _get_combined_config(s_config, q_config)
+    model_config = AutoConfig.from_pretrained("Xenova/llama2.c-stories15M")
+    compressor = ModelCompressor.from_compression_config(combined_config)
+    assert compressor is not None
+
+    model_config.save_pretrained(tmp_path)
+    compressor.update_config(tmp_path)
+
+    reloaded = ModelCompressor.from_pretrained(tmp_path)
+    assert reloaded is not None
+    assert compressor.sparsity_config == reloaded.sparsity_config
+    assert compressor.quantization_config == reloaded.quantization_config
+
+
+@pytest.mark.parametrize(
+    "model_path",
+    [
+        "nm-testing/tinyllama-oneshot-w4a16-group128-v3",
+        "nm-testing/tinyllama-w4a16-compressed-hf-quantizer",
+        "nm-testing/TinyLlama-1.1B-Chat-v1.0-actorder-group-e2e",
+    ],
+)
+def test_from_compressed_model_reload(model_path, tmp_path):
+    model_config = AutoConfig.from_pretrained(model_path)
+    compressor = ModelCompressor.from_pretrained(model_path)
+    assert compressor is not None
+
+    model_config.save_pretrained(tmp_path)
+    compressor.update_config(tmp_path)
+
+    reloaded = ModelCompressor.from_pretrained(tmp_path)
+    assert compressor.sparsity_config == reloaded.sparsity_config
+    assert compressor.quantization_config == reloaded.quantization_config
+
+
+def test_from_uncompressed_model_load(tmp_path):
+    model_path = "Xenova/llama2.c-stories15M"
+    compressor = ModelCompressor.from_pretrained(model_path)
+    assert compressor is None


### PR DESCRIPTION
## Purpose ##
* Bring back `ModelCompressor` reloading, support for which was removed by  https://github.com/neuralmagic/compressed-tensors/pull/164 in which the config is saved under quantization_config but loaded under compression_config

## Changes ##
* `ModelCompressor.from_pretrained` now checks for q_config before checking for comp_config
* Add model reloading tests
* Apply style

## Testing ##
* Added tests fail on main but pass on this branch