### PR TITLE
Workaround HF Quantizer `apply_quantization_config` misuse

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -107,8 +107,8 @@ def load_pretrained_quantization(model: Module, model_name_or_path: str):
 
 
 def apply_quantization_config(
-    model: Module, config: QuantizationConfig, run_compressed: bool = False
-) -> Dict:
+    model: Module, config: Union[QuantizationConfig, None], run_compressed: bool = False
+) -> OrderedDict:
     """
     Initializes the model for quantization in-place based on the given config
 
@@ -117,6 +117,9 @@ def apply_quantization_config(
     :param run_compressed: Whether the model will be run in compressed mode or
         decompressed fully on load
     """
+    if config is None:
+        return OrderedDict()
+
     # remove reference to the original `config`
     # argument. This function can mutate it, and we'd
     # like to keep the original `config` as it is.

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -117,6 +117,7 @@ def apply_quantization_config(
     :param run_compressed: Whether the model will be run in compressed mode or
         decompressed fully on load
     """
+    # Workaround for when HF Quantizer passes None, see PR #180
     if config is None:
         return OrderedDict()
 


### PR DESCRIPTION
`CompressedTensorsHfQuantizer` attempts to use `apply_quantization_config` to apply the quantization config to the model
```python3
def _process_model_before_weight_loading(self, model, **kwargs):
        from compressed_tensors.quantization import apply_quantization_config

        ct_quantization_config = self.compressor.quantization_config
        apply_quantization_config(model, ct_quantization_config, run_compressed=True)
```

However, `self.compressor.quantization_config` can be `None` in the case that only sparsity is present. This does not align with the function contract of `apply_quantization_config`. In such a case, an error is thrown.
```python3
def apply_quantization_config(
    model: Module, config: QuantizationConfig, run_compressed: bool = False
) -> Dict:
```

This PR adjusts the function to handle `None`s until [this branch](https://github.com/neuralmagic/upstream-transformers/tree/kylesayrs/compressed-tensors-errors)'s changes are landed on transformers