### PR TITLE
Revert "Ignore Dense sparsity config (#169)"

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -242,10 +242,6 @@ class ModelCompressor:
         self.sparsity_compressor = None
         self.quantization_compressor = None
 
-        if sparsity_config and sparsity_config.format == CompressionFormat.dense.value:
-            # ignore dense sparsity config
-            self.sparsity_config = None
-
         if sparsity_config is not None:
             self.sparsity_compressor = BaseCompressor.load_from_registry(
                 sparsity_config.format, config=sparsity_config


### PR DESCRIPTION
This reverts commit 6ed94e66a84af5f0ed2238bf61776f8c41653515.


This commit is causing downstream failures such as: 

```
FAILED tests/llmcompressor/transformers/finetune/test_oneshot_and_finetune.py::TestOneshotAndFinetuneGPU_0_nightly::test_oneshot_then_finetune_gpu - TypeError: 'NoneType' object is not subscriptable
```