### PR TITLE
Support for `targets` and `ignore` in `Sparsity Compressors`

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -18,7 +18,7 @@ import operator
 import os
 import re
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Dict, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Set, TypeVar, Union
 
 import compressed_tensors
 import torch
@@ -38,6 +38,7 @@ from compressed_tensors.quantization import (
     apply_quantization_config,
     load_pretrained_quantization,
 )
+from compressed_tensors.quantization.lifecycle import expand_targets
 from compressed_tensors.quantization.quant_args import QuantizationArgs
 from compressed_tensors.quantization.utils import (
     is_module_quantized,
@@ -282,8 +283,14 @@ class ModelCompressor:
                 )
 
         if self.sparsity_compressor is not None:
+            sparse_compression_targets: Set[str] = expand_targets(
+                model=model,
+                targets=self.sparsity_config.targets,
+                ignore=self.sparsity_config.ignore,
+            )
             compressed_state_dict = self.sparsity_compressor.compress(
-                compressed_state_dict
+                compressed_state_dict,
+                compression_targets=sparse_compression_targets,
             )
 
         # HACK: Override the dtype_byte_size function in transformers to

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -38,7 +38,7 @@ from compressed_tensors.quantization import (
     apply_quantization_config,
     load_pretrained_quantization,
 )
-from compressed_tensors.quantization.lifecycle import expand_targets
+from compressed_tensors.quantization.lifecycle import expand_sparse_target_names
 from compressed_tensors.quantization.quant_args import QuantizationArgs
 from compressed_tensors.quantization.utils import (
     is_module_quantized,
@@ -269,9 +269,9 @@ class ModelCompressor:
 
         compressed_state_dict = state_dict
 
-        quantized_modules_to_args: Dict[
-            str, QuantizationArgs
-        ] = map_modules_to_quant_args(model)
+        quantized_modules_to_args: Dict[str, QuantizationArgs] = (
+            map_modules_to_quant_args(model)
+        )
 
         if self.quantization_compressor is not None:
             compressed_state_dict = self.quantization_compressor.compress(
@@ -283,7 +283,7 @@ class ModelCompressor:
                 )
 
         if self.sparsity_compressor is not None:
-            sparse_compression_targets: Set[str] = expand_targets(
+            sparse_compression_targets: Set[str] = expand_sparse_target_names(
                 model=model,
                 targets=self.sparsity_config.targets,
                 ignore=self.sparsity_config.ignore,

--- a/src/compressed_tensors/compressors/sparse_compressors/base.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Dict, Generator, Tuple
+from typing import Dict, Generator, Optional, Set, Tuple
 
 from compressed_tensors.compressors.base import BaseCompressor
 from compressed_tensors.utils import get_nested_weight_mappings, merge_names
@@ -30,7 +30,8 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 class BaseSparseCompressor(BaseCompressor):
     """
     Base class representing a sparse compression algorithm. Each child class should
-    implement compression_param_info, compress_weight and decompress_weight.
+    implement compression_param_info, compress_weight and decompress_weight; child
+    classes should also define COMPRESSION_PARAM_NAMES.
 
     Compressors support compressing/decompressing a full module state dict or a single
     quantized PyTorch leaf module.
@@ -59,11 +60,17 @@ class BaseSparseCompressor(BaseCompressor):
     :param config: config specifying compression parameters
     """
 
-    def compress(self, model_state: Dict[str, Tensor]) -> Dict[str, Tensor]:
+    def compress(
+        self,
+        model_state: Dict[str, Tensor],
+        compression_targets: Optional[Set[str]] = None,
+    ) -> Dict[str, Tensor]:
         """
         Compresses a dense state dict using bitmask compression
 
         :param model_state: state dict of uncompressed model
+        :param compression_targets: optional set of layer prefixes to compress, if None
+            compress all layers (for backwards compatibility)
         :return: compressed state dict
         """
         compressed_dict = {}
@@ -71,6 +78,9 @@ class BaseSparseCompressor(BaseCompressor):
             f"Compressing model with {len(model_state)} parameterized layers..."
         )
         for name, value in tqdm(model_state.items(), desc="Compressing model"):
+            if not self.should_compress(name, compression_targets):
+                compressed_dict[name] = value
+                continue
             compression_data = self.compress_weight(name, value)
             for key in compression_data.keys():
                 if key in compressed_dict:
@@ -97,8 +107,10 @@ class BaseSparseCompressor(BaseCompressor):
         :param device: device to load decompressed weights onto
         :return: iterator for generating decompressed weights
         """
-        weight_mappings = get_nested_weight_mappings(
-            path_to_model_or_tensors, self.COMPRESSION_PARAM_NAMES
+        weight_mappings, other_params = get_nested_weight_mappings(
+            path_to_model_or_tensors,
+            self.COMPRESSION_PARAM_NAMES,
+            return_other_params=True,
         )
         for weight_name in weight_mappings.keys():
             weight_data = {}
@@ -107,4 +119,24 @@ class BaseSparseCompressor(BaseCompressor):
                 with safe_open(safe_path, framework="pt", device=device) as f:
                     weight_data[param_name] = f.get_tensor(full_name)
             decompressed = self.decompress_weight(weight_data)
-            yield weight_name, decompressed
+            full_name = merge_names(weight_name, "weight")
+            yield full_name, decompressed
+
+        for other_name, safe_path in other_params.items():
+            with safe_open(safe_path, framework="pt", device=device) as f:
+                value = f.get_tensor(other_name)
+            yield other_name, value
+
+    @staticmethod
+    def should_compress(name: str, targets: Optional[Set[str]] = None) -> bool:
+        """
+        Check if a parameter should be compressed
+
+        :param name: name of the parameter
+        :param targets: set of layer prefixes to compress
+        :return: whether or not the parameter should be compressed
+        """
+        if targets is None:
+            return name.endswith(".weight")
+
+        return name.endswith(".weight") and name[: -(len(".weight"))] in targets

--- a/src/compressed_tensors/compressors/sparse_compressors/base.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/base.py
@@ -129,7 +129,8 @@ class BaseSparseCompressor(BaseCompressor):
     @staticmethod
     def should_compress(name: str, expanded_targets: Optional[Set[str]] = None) -> bool:
         """
-        Check if a parameter should be compressed
+        Check if a parameter should be compressed.
+        Currently, this only returns True for weight parameters.
 
         :param name: name of the parameter
         :param expanded_targets: set of layer prefixes to compress

--- a/src/compressed_tensors/compressors/sparse_compressors/base.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/base.py
@@ -119,8 +119,7 @@ class BaseSparseCompressor(BaseCompressor):
                 with safe_open(safe_path, framework="pt", device=device) as f:
                     weight_data[param_name] = f.get_tensor(full_name)
             decompressed = self.decompress_weight(weight_data)
-            full_name = merge_names(weight_name, "weight")
-            yield full_name, decompressed
+            yield weight_name, decompressed
 
         for other_name, safe_path in other_params.items():
             with safe_open(safe_path, framework="pt", device=device) as f:

--- a/src/compressed_tensors/compressors/sparse_compressors/base.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/base.py
@@ -127,15 +127,17 @@ class BaseSparseCompressor(BaseCompressor):
             yield other_name, value
 
     @staticmethod
-    def should_compress(name: str, targets: Optional[Set[str]] = None) -> bool:
+    def should_compress(name: str, expanded_targets: Optional[Set[str]] = None) -> bool:
         """
         Check if a parameter should be compressed
 
         :param name: name of the parameter
-        :param targets: set of layer prefixes to compress
+        :param expanded_targets: set of layer prefixes to compress
         :return: whether or not the parameter should be compressed
         """
-        if targets is None:
+        if expanded_targets is None:
             return name.endswith(".weight")
 
-        return name.endswith(".weight") and name[: -(len(".weight"))] in targets
+        return (
+            name.endswith(".weight") and name[: -(len(".weight"))] in expanded_targets
+        )

--- a/src/compressed_tensors/compressors/sparse_compressors/base.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/base.py
@@ -107,10 +107,10 @@ class BaseSparseCompressor(BaseCompressor):
         :param device: device to load decompressed weights onto
         :return: iterator for generating decompressed weights
         """
-        weight_mappings, other_params = get_nested_weight_mappings(
+        weight_mappings, uncompressed_params = get_nested_weight_mappings(
             path_to_model_or_tensors,
             self.COMPRESSION_PARAM_NAMES,
-            return_other_params=True,
+            return_unmatched_params=True,
         )
         for weight_name in weight_mappings.keys():
             weight_data = {}
@@ -121,10 +121,10 @@ class BaseSparseCompressor(BaseCompressor):
             decompressed = self.decompress_weight(weight_data)
             yield weight_name, decompressed
 
-        for other_name, safe_path in other_params.items():
+        for uncompressed_param_name, safe_path in uncompressed_params.items():
             with safe_open(safe_path, framework="pt", device=device) as f:
-                value = f.get_tensor(other_name)
-            yield other_name, value
+                value = f.get_tensor(uncompressed_param_name)
+            yield uncompressed_param_name, value
 
     @staticmethod
     def should_compress(name: str, expanded_targets: Optional[Set[str]] = None) -> bool:

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -18,7 +18,7 @@ from collections import OrderedDict, defaultdict
 from copy import deepcopy
 from typing import Dict, Iterable, List, Optional
 from typing import OrderedDict as OrderedDictType
-from typing import Union
+from typing import Set, Union
 
 import torch
 from compressed_tensors.config import CompressionFormat
@@ -52,6 +52,8 @@ __all__ = [
     "apply_quantization_config",
     "apply_quantization_status",
     "find_name_or_class_matches",
+    "expand_targets",
+    "is_target",
 ]
 
 from compressed_tensors.quantization.utils.helpers import is_module_quantized
@@ -243,6 +245,49 @@ def apply_quantization_status(model: Module, status: QuantizationStatus):
 
     if current_status < status >= QuantizationStatus.COMPRESSED > current_status:
         model.apply(compress_quantized_weights)
+
+
+def expand_targets(
+    model: Module, targets: Iterable[str], ignore: Iterable[str]
+) -> Set[str]:
+    """
+    Finds all the targets in the model that match the given
+    targets and ignore lists.
+
+    Note: Targets must be regexes, layer types, or full layer names.
+
+    :param model: model to search for targets in
+    :param targets: list of targets to search for
+    :param ignore: list of targets to ignore
+    :return: set of all targets that match the given targets and should
+        not be ignored
+    """
+    return {
+        name
+        for name, module in iter_named_leaf_modules(model)
+        if is_target(name, module, targets, ignore)
+    }
+
+
+def is_target(
+    name: str, module: Module, targets: Iterable[str], ignore: Iterable[str]
+) -> bool:
+    """
+    Determines if a module should be included in the targets based on the
+    targets and ignore lists.
+
+    Note: Targets must be regexes, layer types, or full layer names.
+
+    :param name: name of the module
+    :param module: the module itself
+    :param targets: list of targets to search for
+    :param ignore: list of targets to ignore
+    :return: True if the module is a target and not ignored, False otherwise
+    """
+    return bool(
+        find_name_or_class_matches(name, module, targets)
+        and not find_name_or_class_matches(name, module, ignore)
+    )
 
 
 def find_name_or_class_matches(

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -52,7 +52,7 @@ __all__ = [
     "apply_quantization_config",
     "apply_quantization_status",
     "find_name_or_class_matches",
-    "expand_targets",
+    "expand_sparse_target_names",
     "is_target",
 ]
 
@@ -247,11 +247,11 @@ def apply_quantization_status(model: Module, status: QuantizationStatus):
         model.apply(compress_quantized_weights)
 
 
-def expand_targets(
+def expand_sparse_target_names(
     model: Module, targets: Iterable[str], ignore: Iterable[str]
 ) -> Set[str]:
     """
-    Finds all the targets in the model that match the given
+    Finds all unique module names in the model that match the given
     targets and ignore lists.
 
     Note: Targets must be regexes, layer types, or full layer names.

--- a/src/compressed_tensors/utils/safetensors_load.py
+++ b/src/compressed_tensors/utils/safetensors_load.py
@@ -32,11 +32,10 @@ __all__ = [
     "get_nested_weight_mappings",
     "get_quantization_state_dict",
     "is_quantization_param",
-    "get_nested_mappings_from_state_dict",
 ]
 
-WEIGHT_MAPPING_TYPE = Dict[str, str]
-NESTED_WEIGHT_MAPPING_TYPE = Dict[str, WEIGHT_MAPPING_TYPE]
+WeightMappingType = Dict[str, str]
+NestedWeightMappingType = Dict[str, WeightMappingType]
 
 
 def get_safetensors_folder(
@@ -181,9 +180,7 @@ def get_weight_mappings(path_to_model_or_tensors: str) -> Dict[str, str]:
 
 def get_nested_weight_mappings(
     model_path: str, params_to_nest: List[str], return_other_params: bool = False
-) -> Union[
-    NESTED_WEIGHT_MAPPING_TYPE, Tuple[NESTED_WEIGHT_MAPPING_TYPE, WEIGHT_MAPPING_TYPE]
-]:
+) -> Union[NestedWeightMappingType, Tuple[NestedWeightMappingType, WeightMappingType]]:
     """
     Takes a path to a state dict saved in safetensors format and returns a nested
     mapping from uncompressed parameterized layer names to the file locations of each
@@ -256,17 +253,3 @@ def is_quantization_param(name: str) -> bool:
         return True
 
     return False
-
-
-def get_nested_mappings_from_state_dict(state_dict, params_to_nest):
-    nested_weight_mappings = {}
-    for key in state_dict.keys():
-        for param_name in params_to_nest:
-            maybe_match = match_param_name(key, param_name)
-            if maybe_match is not None:
-                dense_param = maybe_match
-                if dense_param not in nested_weight_mappings:
-                    nested_weight_mappings[dense_param] = {}
-                nested_weight_mappings[dense_param][param_name] = state_dict[key]
-
-    return nested_weight_mappings

--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -296,7 +296,7 @@ def test_apply_quantization_status(caplog, ignore, should_raise_warning):
 
 
 @pytest.mark.parametrize(
-    "targets, ignore, expected",
+    "targets, ignore, expected_targets",
     [
         ([], [], set()),
         (["layer1", "layer2"], [], {"layer1", "layer2"}),
@@ -305,13 +305,13 @@ def test_apply_quantization_status(caplog, ignore, should_raise_warning):
         (["re:layer.*"], ["layer3"], {"layer1", "layer2"}),
     ],
 )
-def test_expand_targets_with_mock(mock_model, targets, ignore, expected):
-    result = expand_targets(mock_model, targets, ignore)
-    assert result == expected
+def test_expand_targets_with_mock(mock_model, targets, ignore, expected_targets):
+    expanded_targets = expand_targets(mock_model, targets, ignore)
+    assert expanded_targets == expected_targets
 
 
 @pytest.mark.parametrize(
-    "targets, ignore, expected",
+    "targets, ignore, expected_targets",
     [
         (
             ["re:model.layers.[01].self_attn.q_proj"],
@@ -344,10 +344,10 @@ def test_expand_targets_with_mock(mock_model, targets, ignore, expected):
     ],
 )
 def test_expand_targets_with_llama_stories(
-    llama_stories_model, targets, ignore, expected
+    llama_stories_model, targets, ignore, expected_targets
 ):
-    actual_targets = expand_targets(llama_stories_model, targets, ignore)
-    assert actual_targets == expected
+    expanded_targets = expand_targets(llama_stories_model, targets, ignore)
+    assert expanded_targets == expected_targets
 
 
 @pytest.mark.parametrize(

--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -27,7 +27,7 @@ from compressed_tensors.quantization import (
 from compressed_tensors.quantization.lifecycle import (
     apply_quantization_config,
     apply_quantization_status,
-    expand_targets,
+    expand_sparse_target_names,
     is_target,
 )
 from compressed_tensors.quantization.utils import iter_named_leaf_modules
@@ -306,7 +306,7 @@ def test_apply_quantization_status(caplog, ignore, should_raise_warning):
     ],
 )
 def test_expand_targets_with_mock(mock_model, targets, ignore, expected_targets):
-    expanded_targets = expand_targets(mock_model, targets, ignore)
+    expanded_targets = expand_sparse_target_names(mock_model, targets, ignore)
     assert expanded_targets == expected_targets
 
 
@@ -346,7 +346,7 @@ def test_expand_targets_with_mock(mock_model, targets, ignore, expected_targets)
 def test_expand_targets_with_llama_stories(
     llama_stories_model, targets, ignore, expected_targets
 ):
-    expanded_targets = expand_targets(llama_stories_model, targets, ignore)
+    expanded_targets = expand_sparse_target_names(llama_stories_model, targets, ignore)
     assert expanded_targets == expected_targets
 
 

--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -14,6 +14,7 @@
 
 import re
 from typing import Optional
+from unittest.mock import MagicMock
 
 import pytest
 import torch
@@ -26,10 +27,36 @@ from compressed_tensors.quantization import (
 from compressed_tensors.quantization.lifecycle import (
     apply_quantization_config,
     apply_quantization_status,
+    expand_targets,
+    is_target,
 )
 from compressed_tensors.quantization.utils import iter_named_leaf_modules
 from tests.testing_utils import requires_accelerate
 from transformers import AutoModelForCausalLM
+
+
+@pytest.fixture
+def mock_model():
+    model = MagicMock()
+    model.named_modules.return_value = [
+        ("layer1", MagicMock()),
+        ("layer2", MagicMock()),
+        ("layer3", MagicMock()),
+    ]
+    return model
+
+
+@pytest.fixture
+def mock_module():
+    return MagicMock()
+
+
+@pytest.fixture
+def llama_stories_model():
+    return AutoModelForCausalLM.from_pretrained(
+        "Xenova/llama2.c-stories15M",
+        torch_dtype="auto",
+    )
 
 
 def test_target_prioritization(mock_frozen):
@@ -266,3 +293,73 @@ def test_apply_quantization_status(caplog, ignore, should_raise_warning):
             assert len(caplog.text) > 0
         else:
             assert len(caplog.text) == 0
+
+
+@pytest.mark.parametrize(
+    "targets, ignore, expected",
+    [
+        ([], [], set()),
+        (["layer1", "layer2"], [], {"layer1", "layer2"}),
+        ([], ["layer1"], set()),
+        (["layer1", "layer2"], ["layer2"], {"layer1"}),
+        (["re:layer.*"], ["layer3"], {"layer1", "layer2"}),
+    ],
+)
+def test_expand_targets_with_mock(mock_model, targets, ignore, expected):
+    result = expand_targets(mock_model, targets, ignore)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "targets, ignore, expected",
+    [
+        (
+            ["re:model.layers.[01].self_attn.q_proj"],
+            ["re:model.layers.1.self_attn.q_proj"],
+            set(["model.layers.0.self_attn.q_proj"]),
+        ),
+        (
+            ["re:model.layers.[01].self_attn.q_proj"],
+            [],
+            set(["model.layers.0.self_attn.q_proj", "model.layers.1.self_attn.q_proj"]),
+        ),
+        (
+            ["re:model.layers.[0-2].self_attn.q_proj"],
+            ["re:model.layers.1.self_attn.q_proj"],
+            set(["model.layers.0.self_attn.q_proj", "model.layers.2.self_attn.q_proj"]),
+        ),
+        (
+            ["model.layers.0.self_attn.q_proj"],
+            ["model.layers.0.self_attn.q_proj"],
+            set(),
+        ),
+        (
+            ["re:model.layers.*.self_attn.q_proj"],
+            ["re:model.layers.[01].self_attn.q_proj"],
+            set(
+                f"model.layers.{layer_idx}.self_attn.q_proj"
+                for layer_idx in range(2, 6)
+            ),
+        ),
+    ],
+)
+def test_expand_targets_with_llama_stories(
+    llama_stories_model, targets, ignore, expected
+):
+    actual_targets = expand_targets(llama_stories_model, targets, ignore)
+    assert actual_targets == expected
+
+
+@pytest.mark.parametrize(
+    "name, targets, ignore, expected",
+    [
+        ("layer1", ["layer1"], [], True),
+        ("layer1", ["layer1"], ["layer1"], False),
+        ("layer1", ["layer2"], [], False),
+        ("layer1", ["re:layer.*"], [], True),
+        ("layer1", ["re:layer.*"], ["re:layer1"], False),
+    ],
+)
+def test_is_target_with_mock(mock_module, name, targets, ignore, expected):
+    result = is_target(name, mock_module, targets, ignore)
+    assert result == expected

--- a/tests/test_utils/test_safetensors_load.py
+++ b/tests/test_utils/test_safetensors_load.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+from compressed_tensors.utils.safetensors_load import get_nested_weight_mappings
+
+
+mock_weight_mappings = {
+    "layer1.weight": "file1",
+    "layer1.bias": "file2",
+    "layer2.weight": "file3",
+    "layer2.bias": "file4",
+    "layer3.weight": "file5",
+}
+
+
+@pytest.fixture
+def mock_get_weight_mappings():
+    with patch(
+        "compressed_tensors.utils.safetensors_load.get_weight_mappings",
+        return_value=mock_weight_mappings,
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("mock_get_weight_mappings")
+class TestGetNestedWeightMappings:
+    def test_single_param(self):
+        params_to_nest = ["weight"]
+        result = get_nested_weight_mappings("dummy_path", params_to_nest)
+        expected = {
+            "layer1": {"weight": "file1"},
+            "layer2": {"weight": "file3"},
+            "layer3": {"weight": "file5"},
+        }
+        assert result == expected
+
+    def test_multiple_params(self):
+        params_to_nest = ["weight", "bias"]
+        result = get_nested_weight_mappings("dummy_path", params_to_nest)
+        expected = {
+            "layer1": {"weight": "file1", "bias": "file2"},
+            "layer2": {"weight": "file3", "bias": "file4"},
+            "layer3": {"weight": "file5"},
+        }
+        assert result == expected
+
+    def test_return_other_params(self):
+        params_to_nest = ["weight"]
+        result, other_params = get_nested_weight_mappings(
+            "dummy_path", params_to_nest, return_other_params=True
+        )
+        expected_nested = {
+            "layer1": {"weight": "file1"},
+            "layer2": {"weight": "file3"},
+            "layer3": {"weight": "file5"},
+        }
+        expected_other = {
+            "layer1.bias": "file2",
+            "layer2.bias": "file4",
+        }
+        assert result == expected_nested
+        assert other_params == expected_other

--- a/tests/test_utils/test_safetensors_load.py
+++ b/tests/test_utils/test_safetensors_load.py
@@ -61,7 +61,7 @@ class TestGetNestedWeightMappings:
     def test_return_other_params(self):
         params_to_nest = ["weight"]
         result, other_params = get_nested_weight_mappings(
-            "dummy_path", params_to_nest, return_other_params=True
+            "dummy_path", params_to_nest, return_unmatched_params=True
         )
         expected_nested = {
             "layer1": {"weight": "file1"},


### PR DESCRIPTION
This PR introduces support for using `targets` and `ignore` in sparsity compressors. It has been tested against the `llm-compressor` repository at commit `a47137d8` (on `main`).

### Changes Made
- Cleaned up several utilities and added corresponding tests.
- Updated the `BaseSparsity.compress(...)` methods to accept a new `compression_targets` argument.
- Enhanced the `ModelCompressor` to directly populate the `compression_targets` argument.

### Verification
The functionality was verified using the following script:

<details>
<summary>Verification Script</summary>

```python
"""
Usage: python verification.py
Tested against llm-compressor commit a47137d8
"""


from transformers import AutoTokenizer, AutoModelForCausalLM
from llmcompressor.transformers.compression.sparsity_config import SparsityConfigMetadata
from llmcompressor.transformers import oneshot
from safetensors import safe_open

MODEL_ID = "nm-testing/llama2.c-stories42M-pruned2.4"

def check_first_layer(save_dir, check_compressed=True):
    with safe_open(f"{save_dir}/model.safetensors", framework="pt", device=0) as f:
        layer_0_keys = [key for key in f.keys() if "model.layers.0" in key]
        if check_compressed:
            assert any("compressed" in key for key in layer_0_keys), "First layer is not compressed as expected."
        else:
            assert not any("compressed" in key for key in layer_0_keys), "First layer is compressed unexpectedly."

def main():
    model = AutoModelForCausalLM.from_pretrained(MODEL_ID, device_map="auto", torch_dtype="auto")
    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)

    # Apply oneshot to wrap save_pretrained 
    oneshot(model=model)

    # Compress and save the model
    sparsity_config = SparsityConfigMetadata.from_pretrained(model, compress=True)
    save_dir_compressed = f"{MODEL_ID.split('/')[1]}-2of4-compressed"
    model.save_pretrained(save_dir_compressed, sparsity_config=sparsity_config)
    tokenizer.save_pretrained(save_dir_compressed)

    # Verify the first layer is compressed
    check_first_layer(save_dir_compressed, check_compressed=True)

    # Ignore the first layer and save the model again
    sparsity_config.ignore.append("re:model.layers.0.*")
    save_dir_ignored = f"{MODEL_ID.split('/')[1]}-2of4-ignored-first-layer"
    model.save_pretrained(save_dir_ignored, sparsity_config=sparsity_config)
    tokenizer.save_pretrained(save_dir_ignored)

    # Verify the first layer is not compressed
    check_first_layer(save_dir_ignored, check_compressed=False)

if __name__ == "__main__":
    main()
```

The script passes successfully without any assertions.


</details>

<details>
<summary>Script Output</summary>

```bash

2024-11-27T10:18:45.295223+0000 | one_shot | INFO - *** One Shot ***
2024-11-27T10:18:45.295382+0000 | initialize | INFO - Compression lifecycle initialized for 0 modifiers
2024-11-27T10:18:45.295428+0000 | finalize | INFO - Compression lifecycle finalized for 0 modifiers
Calculating model sparsity: 100%|███████████████████████████████████████████████████████████████████████████████████████████| 75/75 [00:00<00:00, 1068.21it/s]
Checking whether model follows 2:4 sparsity structure: 100%|████████████████████████████████████████████████████████████████| 57/57 [00:00<00:00, 1572.75it/s]
Calculating model sparsity: 100%|███████████████████████████████████████████████████████████████████████████████████████████| 75/75 [00:00<00:00, 1562.54it/s]
Compressing model: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 75/75 [00:00<00:00, 1205.22it/s]
2024-11-27T10:18:46.694477+0000 | get_serialized_recipe | WARNING - Recipe not found in session - it may have been reset
Calculating model sparsity: 100%|███████████████████████████████████████████████████████████████████████████████████████████| 75/75 [00:00<00:00, 1892.06it/s]
Compressing model: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 75/75 [00:00<00:00, 1701.64it/s]
2024-11-27T10:18:47.582677+0000 | get_serialized_recipe | WARNING - Recipe not found in session - it may have been reset
```
</details>

