### PR TITLE
Fix device allocation for MSE observer

### DIFF
--- a/src/compressed_tensors/quantization/observers/mse.py
+++ b/src/compressed_tensors/quantization/observers/mse.py
@@ -70,9 +70,9 @@ class MovingAverageMSEObserver(Observer):
             absolute_min_val = torch.amin(observed, dim=reduce_dims, keepdims=True)
             absolute_max_val = torch.amax(observed, dim=reduce_dims, keepdims=True)
 
-        best = torch.full(absolute_min_val.shape, float("inf"))
-        min_val = torch.ones(absolute_min_val.shape)
-        max_val = torch.zeros(absolute_max_val.shape)
+        best = torch.full_like(absolute_min_val.shape, torch.iinfo(absolute_min_val.dtype).max)
+        min_val = torch.ones_like(absolute_min_val)
+        max_val = torch.zeros_like(absolute_max_val)
         for i in range(int(self.maxshrink * self.grid)):
             p = 1 - i / self.grid
             shrinked_min_val = p * absolute_min_val

--- a/src/compressed_tensors/quantization/observers/mse.py
+++ b/src/compressed_tensors/quantization/observers/mse.py
@@ -70,7 +70,7 @@ class MovingAverageMSEObserver(Observer):
             absolute_min_val = torch.amin(observed, dim=reduce_dims, keepdims=True)
             absolute_max_val = torch.amax(observed, dim=reduce_dims, keepdims=True)
 
-        best = torch.full_like(absolute_min_val.shape, torch.iinfo(absolute_min_val.dtype).max)
+        best = torch.full_like(absolute_min_val, torch.finfo(absolute_min_val.dtype).max)
         min_val = torch.ones_like(absolute_min_val)
         max_val = torch.zeros_like(absolute_max_val)
         for i in range(int(self.maxshrink * self.grid)):

--- a/tests/test_quantization/test_observers/test_mse.py
+++ b/tests/test_quantization/test_observers/test_mse.py
@@ -27,7 +27,7 @@ from compressed_tensors.quantization.quant_args import QuantizationArgs
     ],
 )
 def test_mse_observer(symmetric, expected_scale, expected_zero_point):
-    tensor = torch.tensor([1, 1, 1, 1, 1])
+    tensor = torch.tensor([1., 1., 1., 1., 1.])
     num_bits = 8
     weights = QuantizationArgs(num_bits=num_bits, symmetric=symmetric, observer="mse")
 


### PR DESCRIPTION
This PR fixes the pre-allocation of a few tensors used in the MSE observer. The original allocation did not specify the device, which ended up leading to failures due to computation with tensors in different devices.