### PR TITLE
Clean up observer defaulting logic, better error message

### DIFF
--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -114,12 +114,6 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
         """
         :return: torch quantization FakeQuantize built based on these QuantizationArgs
         """
-
-        # No observer required for the dynamic case
-        if self.dynamic:
-            self.observer = None
-            return self.observer
-
         return self.observer
 
     @field_validator("type", mode="before")
@@ -217,15 +211,15 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
                 warnings.warn(
                     "No observer is used for dynamic quantization, setting to None"
                 )
-                model.observer = None
+                observer = None
 
-        # if we have not set an observer and we
-        # are running static quantization, use minmax
-        if not observer and not dynamic:
-            model.observer = "minmax"
+        elif observer is None:
+            # default to minmax for non-dynamic cases
+            observer = "minmax"
 
         # write back modified values
         model.strategy = strategy
+        model.observer = observer
         return model
 
     def pytorch_dtype(self) -> torch.dtype:

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -197,6 +197,7 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
                 "activation ordering"
             )
 
+        # infer observer w.r.t. dynamic
         if dynamic:
             if strategy not in (
                 QuantizationStrategy.TOKEN,
@@ -208,9 +209,10 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
                     "quantization",
                 )
             if observer is not None:
-                warnings.warn(
-                    "No observer is used for dynamic quantization, setting to None"
-                )
+                if observer != "memoryless":  # avoid annoying users with old configs
+                    warnings.warn(
+                        "No observer is used for dynamic quantization, setting to None"
+                    )
                 observer = None
 
         elif observer is None:

--- a/src/compressed_tensors/registry/registry.py
+++ b/src/compressed_tensors/registry/registry.py
@@ -258,7 +258,7 @@ def get_from_registry(
         retrieved_value = _import_and_get_value_from_module(module_path, value_name)
     else:
         # look up name in alias registry
-        name = _ALIAS_REGISTRY[parent_class].get(name)
+        name = _ALIAS_REGISTRY[parent_class].get(name, name)
         # look up name in registry
         retrieved_value = _REGISTRY[parent_class].get(name)
         if retrieved_value is None:


### PR DESCRIPTION
## Purpose ##
* Better error message when attempting to load an unregistered class instance
* Avoid annoying users with configs which have observer=memoryless for dynamic quantization

## Changes ##
* Clean up observer defaulting logic
* Return the type name in the case that it is not found in the list of aliases
* Condition warning on if observer != memoryless

## Testing ##
### Registry Error ###
```python3
from llmcompressor.observers import Observer
Observer.load_from_registry("asdf", quantization_args=None)
```
```
- KeyError: "Unable to find None registered under type <class 'llmcompressor.observers.base.Observer'>.\nRegistered values for <class 'llmcompressor.observers.base.Observer'>: ['minmax', 'mse']\nRegistered aliases for <class 'llmcompressor.observers.base.Observer'>: []"
+ KeyError: "Unable to find asdf registered under type <class 'llmcompressor.observers.base.Observer'>.\nRegistered values for <class 'llmcompressor.observers.base.Observer'>: ['minmax', 'mse']\nRegistered aliases for <class 'llmcompressor.observers.base.Observer'>: []" 
```

### Observer Warning ###
```python3
from compressed_tensors.quantization import QuantizationArgs
args = QuantizationArgs(dynamic=True, observer="minmax-whatever")
>>> /home/ksayers/compressed-tensors/src/compressed_tensors/quantization/quant_args.py:213: UserWarning: No observer is used for dynamic quantization, setting to None
  warnings.warn(
```
```python3
from compressed_tensors.quantization import QuantizationArgs
args = QuantizationArgs(dynamic=True, observer="memoryless")
>>> 
```