### PR TITLE
Remove QuantizationScheme.default_scheme

### DIFF
--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -36,7 +36,7 @@ class QuantizationScheme(BaseModel):
     of modules should be quantized
 
     :param targets: list of modules to apply the QuantizationArgs to, can be layer
-    names, layer types or a regular expression
+    names, layer types or a regular expression, typically ["Linear"]
     :param weights: quantization config for layer weights
     :param input_activations: quantization config for layer inputs
     :param output_activations: quantization config for layer outputs
@@ -46,28 +46,6 @@ class QuantizationScheme(BaseModel):
     weights: Optional[QuantizationArgs] = None
     input_activations: Optional[QuantizationArgs] = None
     output_activations: Optional[QuantizationArgs] = None
-
-    @classmethod
-    def default_scheme(
-        cls,
-        targets: Optional[List[str]] = None,
-    ):
-
-        if targets is None:
-            # default to quantizing all Linear layers
-            targets = ["Linear"]
-
-        # by default, activations and weights are left unquantized
-        weights = None
-        input_activations = None
-        output_activations = None
-
-        return cls(
-            targets=targets,
-            weights=weights,
-            input_activations=input_activations,
-            output_activations=output_activations,
-        )
 
 
 """

--- a/tests/test_quantization/test_quant_scheme.py
+++ b/tests/test_quantization/test_quant_scheme.py
@@ -53,7 +53,7 @@ def test_needs_targets():
 
 def test_defaults():
     targets = ["Linear"]
-    output = QuantizationScheme.default_scheme(targets=targets)
+    output = QuantizationScheme(targets=targets)
     assert output.weights is None
     assert output.input_activations is None
     assert output.output_activations is None


### PR DESCRIPTION
## Purpose ##
* Remove unused function. I believe that this function was initially intended to provide defaults to QuantizationModifier while not overwriting existing configs, but since all these values are all written to configs and the  QuantizationModifier is now also the default for configs which do not specify values, this function is no longer necessary.

## Prerequisites ##
* https://github.com/vllm-project/llm-compressor/pull/889

## Changes ##
* Remove QuantizationScheme.default_scheme

## Testing ##
* Grepped codebases for uses