### PR TITLE
[BugFix] Fix Marlin24 Bug

### DIFF
--- a/src/compressed_tensors/compressors/sparse_quantized_compressors/marlin_24.py
+++ b/src/compressed_tensors/compressors/sparse_quantized_compressors/marlin_24.py
@@ -238,7 +238,7 @@ def pack_scales_24(scales, quantization_args, w_shape):
     _, scale_perm_2_4, scale_perm_single_2_4 = get_permutations_24(num_bits)
 
     if (
-        quantization_args.strategy is QuantizationStrategy.GROUP
+        quantization_args.strategy == QuantizationStrategy.GROUP
         and quantization_args.group_size < size_k
     ):
         scales = scales.reshape((-1, len(scale_perm_2_4)))[:, scale_perm_2_4]


### PR DESCRIPTION
Summary
- Fix the check for permutations which have been incorrectly been running for the channel-wise case
- Idk how this ever worked for group quant

Generations Using Group Quantization in vLLM:
```bash
[' Paris and it is located in the north-west of the country.\nThe population of', ' the leader of the executive branch of the federal government, and thus the head of', ' Liz. I live in a small town in the middle of a prairie.']
```
