### PR TITLE
Fix uninitialized variable in quantized compressors

### DIFF
--- a/src/compressed_tensors/compressors/quantized_compressors/naive_quantized.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/naive_quantized.py
@@ -93,9 +93,11 @@ class NaiveQuantizationCompressor(BaseQuantizationCompressor):
                 args=quantization_args,
                 dtype=quantization_args.pytorch_dtype(),
             )
+        else:
+            quantized_weight = weight
 
-            if device is not None:
-                quantized_weight = quantized_weight.to(device)
+        if device is not None:
+            quantized_weight = quantized_weight.to(device)
 
         return {"weight": quantized_weight}
 

--- a/src/compressed_tensors/compressors/quantized_compressors/pack_quantized.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/pack_quantized.py
@@ -94,6 +94,8 @@ class PackedQuantizationCompressor(BaseQuantizationCompressor):
                 args=quantization_args,
                 dtype=torch.int8,
             )
+        else:
+            quantized_weight = weight
 
         packed_weight = pack_to_int32(quantized_weight, quantization_args.num_bits)
         weight_shape = torch.tensor(weight.shape)


### PR DESCRIPTION
Both compressors have a `can_quantize()` check, which if ever doesn't succeed would trigger:

> UnboundLocalError: cannot access local variable 'quantized_weight' where it is not associated with a value

Add the obvious fix for this and highly artificial test cases that would trigger it.

Looks like this error was introduced by #109

Definitely begs the question whether this code path has any real world use!