### PR TITLE
Allow ModelCompressor.from_pretrained to load from quantization_config, not compression config

### DIFF
--- a/src/compressed_tensors/compressors/base.py
+++ b/src/compressed_tensors/compressors/base.py
@@ -125,8 +125,6 @@ class BaseCompressor(RegistryMixin, ABC):
             return None  # module is not quantized
         quantization_scheme = module.quantization_scheme
         if not hasattr(quantization_scheme, "weights"):
-            # models that ran CompressedLinear.from_linear will
-            # run delattr(module, "weight")
             return None  # weights are not quantized
 
         quantization_args = quantization_scheme.weights

--- a/src/compressed_tensors/compressors/base.py
+++ b/src/compressed_tensors/compressors/base.py
@@ -125,6 +125,8 @@ class BaseCompressor(RegistryMixin, ABC):
             return None  # module is not quantized
         quantization_scheme = module.quantization_scheme
         if not hasattr(quantization_scheme, "weights"):
+            # models that ran CompressedLinear.from_linear will
+            # run delattr(module, "weight")
             return None  # weights are not quantized
 
         quantization_args = quantization_scheme.weights

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -103,7 +103,9 @@ class ModelCompressor:
         :return: compressor for the configs, or None if model is not compressed
         """
         config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **kwargs)
-        compression_config = getattr(config, COMPRESSION_CONFIG_NAME, None)
+        compression_config = getattr(config, COMPRESSION_CONFIG_NAME, None) or getattr(
+            config, QUANTIZATION_CONFIG_NAME, None
+        )
         return cls.from_compression_config(compression_config)
 
     @classmethod

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -38,6 +38,7 @@ from compressed_tensors.quantization import (
     apply_quantization_config,
     load_pretrained_quantization,
 )
+from compressed_tensors.quantization.quant_args import QuantizationArgs
 from compressed_tensors.quantization.utils import (
     is_module_quantized,
     iter_named_leaf_modules,
@@ -267,8 +268,9 @@ class ModelCompressor:
 
         compressed_state_dict = state_dict
 
-        # submodule name to q_args
-        quantized_modules_to_args = map_modules_to_quant_args(model)
+        quantized_modules_to_args: Dict[
+            str, QuantizationArgs
+        ] = map_modules_to_quant_args(model)
 
         if self.quantization_compressor is not None:
             compressed_state_dict = self.quantization_compressor.compress(
@@ -373,7 +375,13 @@ class ModelCompressor:
             update_parameter_data(module, data, param_name)
 
 
-def map_modules_to_quant_args(model: Module) -> Dict:
+def map_modules_to_quant_args(model: Module) -> Dict[str, QuantizationArgs]:
+    """
+    Given a pytorch model, map out the submodule name (usually linear layers)
+     to the QuantizationArgs
+
+    :param model: pytorch model
+    """
     quantized_modules_to_args = {}
     for name, submodule in iter_named_leaf_modules(model):
         if is_module_quantized(submodule):

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -24,7 +24,6 @@ import compressed_tensors
 import torch
 import transformers
 from compressed_tensors.base import (
-    COMPRESSION_CONFIG_NAME,
     COMPRESSION_VERSION_NAME,
     QUANTIZATION_CONFIG_NAME,
     QUANTIZATION_METHOD_NAME,
@@ -103,14 +102,14 @@ class ModelCompressor:
         :return: compressor for the configs, or None if model is not compressed
         """
         config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **kwargs)
-        compression_config = getattr(config, COMPRESSION_CONFIG_NAME, None) or getattr(
-            config, QUANTIZATION_CONFIG_NAME, None
-        )
+        compression_config = getattr(config, QUANTIZATION_CONFIG_NAME, None)
+
         return cls.from_compression_config(compression_config)
 
     @classmethod
     def from_compression_config(
-        cls, compression_config: Union[Dict[str, Any], "CompressedTensorsConfig"]
+        cls,
+        compression_config: Union[Dict[str, Any], "CompressedTensorsConfig"],
     ):
         """
         :param compression_config:
@@ -267,7 +266,10 @@ class ModelCompressor:
             state_dict = model.state_dict()
 
         compressed_state_dict = state_dict
+
+        # submodule name to q_args
         quantized_modules_to_args = map_modules_to_quant_args(model)
+
         if self.quantization_compressor is not None:
             compressed_state_dict = self.quantization_compressor.compress(
                 state_dict, names_to_scheme=quantized_modules_to_args

--- a/src/compressed_tensors/linear/compressed_linear.py
+++ b/src/compressed_tensors/linear/compressed_linear.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Dict, Tuple
+
 import torch
 from compressed_tensors.compressors.base import BaseCompressor
 from compressed_tensors.quantization import (
@@ -53,7 +55,7 @@ class CompressedLinear(Linear):
         )
 
         # get the shape and dtype of compressed parameters
-        compression_params = module.compressor.compression_param_info(
+        compression_params: Dict[str, Tuple] = module.compressor.compression_param_info(
             module.weight.shape, quantization_scheme.weights
         )
 

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -106,7 +106,8 @@ def apply_quantization_config(
     model: Module, config: Union[QuantizationConfig, None], run_compressed: bool = False
 ) -> OrderedDict:
     """
-    Initializes the model for quantization in-place based on the given config
+    Initializes the model for quantization in-place based on the given config.
+    Optionally coverts quantizable modules to compressed_linear modules
 
     :param model: model to apply quantization config to
     :param config: quantization config

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -35,7 +35,6 @@ from torch.nn import Module
 __all__ = [
     "QuantizationStatus",
     "QuantizationConfig",
-    "QuantizationConfigHFQuantizer",
     "LIFECYCLE_ORDER",
     "DEFAULT_QUANTIZATION_METHOD",
     "DEFAULT_QUANTIZATION_FORMAT",
@@ -263,14 +262,3 @@ class QuantizationConfig(BaseModel):
                     return True
 
         return False
-
-
-# For HFQuantizer, be able to adjust run_compressed on model load
-class QuantizationConfigHFQuantizer(QuantizationConfig):
-    """
-    :param run_compressed: param used set run_compressed.
-     Used for `apply_quantization_config` in CompressedTensorsHfQuantizer
-     in transformers
-    """
-
-    run_compressed: bool = True

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -35,6 +35,7 @@ from torch.nn import Module
 __all__ = [
     "QuantizationStatus",
     "QuantizationConfig",
+    "QuantizationConfigHFQuantizer",
     "LIFECYCLE_ORDER",
     "DEFAULT_QUANTIZATION_METHOD",
     "DEFAULT_QUANTIZATION_FORMAT",
@@ -132,9 +133,9 @@ class QuantizationConfig(BaseModel):
         `k_proj` and `v_proj` in their names. If this is not the case
         and kv_cache_scheme != None, the quantization of kv cache will fail
     :global_compression_ratio: optional informational config to report the model
-    compression ratio acheived by the quantization config
+        compression ratio acheived by the quantization config
     :ignore: optional list of layers to ignore from config_groups. Layers in this list
-    are not quantized even if they match up with a target in config_groups
+        are not quantized even if they match up with a target in config_groups
     """
 
     config_groups: Dict[str, Union[QuantizationScheme, List[str]]]
@@ -262,3 +263,14 @@ class QuantizationConfig(BaseModel):
                     return True
 
         return False
+
+
+# For HFQuantizer, be able to adjust run_compressed on model load
+class QuantizationConfigHFQuantizer(QuantizationConfig):
+    """
+    :param run_compressed: param used set run_compressed.
+     Used for `apply_quantization_config` in CompressedTensorsHfQuantizer
+     in transformers
+    """
+
+    run_compressed: bool = True


### PR DESCRIPTION
Fix bugs on loading the compression_config to quantization_config. Loading from the former is now removed
Added minor doc string and type checks for confusing output from functions