### PR TITLE
[Bugfix] Update expected shape for per token strategy

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -174,7 +174,10 @@ def _initialize_scale_zero_point(
         device = get_execution_device(module)
 
     # infer expected scale/zero point shape
-    expected_shape = 1  # per tensor
+    if quantization_args.strategy == QuantizationStrategy.TOKEN:
+        expected_shape = (1, 1)
+    else:
+        expected_shape = 1
 
     if base_name == "weight" and weight_shape is not None:
         if quantization_args.strategy == QuantizationStrategy.CHANNEL:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,8 +44,6 @@ def mock_per_token_calibration():
         min_val = torch.amin(value, dim=dim, keepdims=True)
         max_val = torch.amax(value, dim=dim, keepdims=True)
         scale, zp = calculate_qparams(min_val, max_val, args)
-        scale = scale.reshape((1, 1))
-        zp = zp.reshape((1, 1))
         update_parameter_data(module, scale, f"{base_name}_scale")
         update_parameter_data(module, zp, f"{base_name}_zero_point")
 
@@ -129,6 +127,7 @@ def mock_per_tensor_calibration():
 
         # per tensor quantization just calls calculate_qparams directly
         min_val, max_val = torch.aminmax(value)
+        breakpoint()
         scale, zp = calculate_qparams(min_val, max_val, args)
         update_parameter_data(module, scale, f"{base_name}_scale")
         update_parameter_data(module, zp, f"{base_name}_zero_point")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,6 @@ def mock_per_tensor_calibration():
 
         # per tensor quantization just calls calculate_qparams directly
         min_val, max_val = torch.aminmax(value)
-        breakpoint()
         scale, zp = calculate_qparams(min_val, max_val, args)
         update_parameter_data(module, scale, f"{base_name}_scale")
         update_parameter_data(module, zp, f"{base_name}_zero_point")

--- a/tests/test_quantization/test_configs/test_strategies.py
+++ b/tests/test_quantization/test_configs/test_strategies.py
@@ -67,8 +67,8 @@ def test_channelwise(
     if input_symmetry is not None:
         mock_per_channel_calibration(model, base_name="input", value=inputs)
 
-    assert list(model.weight_scale.shape) == [model_shape[1], 1]
-    assert list(model.weight_zero_point.shape) == [model_shape[1], 1]
+    assert model.weight_scale.shape == (model_shape[1], 1)
+    assert model.weight_zero_point.shape == (model_shape[1], 1)
 
 
 @torch.no_grad
@@ -97,14 +97,14 @@ def test_group(
             model, base_name="input", value=inputs, group_size=group_size
         )
 
-    assert list(model.weight_scale.shape) == [
+    assert model.weight_scale.shape == (
         model_shape[1],
         int(model_shape[0] / group_size),
-    ]
-    assert list(model.weight_zero_point.shape) == [
+    )
+    assert model.weight_zero_point.shape == (
         model_shape[1],
         int(model_shape[0] / group_size),
-    ]
+    )
 
 
 @torch.no_grad
@@ -131,8 +131,8 @@ def test_token(
     mock_per_channel_calibration(model, base_name="weight", value=model.weight)
     mock_per_token_calibration(model, base_name="input", value=inputs)
 
-    assert list(model.input_scale.shape) == [1, 1]
-    assert list(model.input_zero_point.shape) == [1, 1]
+    assert model.input_scale.shape == (1, 1)
+    assert model.input_zero_point.shape == (1, 1)
 
-    assert list(model.weight_scale.shape) == [256, 1]
-    assert list(model.weight_zero_point.shape) == [256, 1]
+    assert model.weight_scale.shape == (256, 1)
+    assert model.weight_zero_point.shape == (256, 1)

--- a/tests/test_quantization/test_utils/test_helpers.py
+++ b/tests/test_quantization/test_utils/test_helpers.py
@@ -19,10 +19,9 @@ from compressed_tensors.quantization.utils import calculate_qparams
 
 
 @pytest.mark.parametrize(
-    "dim,keepdims,strategy,exp_shape",
+    "keepdims,strategy,exp_shape",
     [
         (
-            tuple(),
             False,
             QuantizationStrategy.TENSOR,
             torch.Size(
@@ -31,10 +30,9 @@ from compressed_tensors.quantization.utils import calculate_qparams
                 ]
             ),
         ),
-        (tuple(), True, QuantizationStrategy.CHANNEL, torch.Size([1, 1])),
-        (tuple(), True, QuantizationStrategy.GROUP, torch.Size([1, 1])),
+        (True, QuantizationStrategy.CHANNEL, torch.Size([1, 1])),
+        (True, QuantizationStrategy.GROUP, torch.Size([1, 1])),
         (
-            tuple(),
             False,
             QuantizationStrategy.BLOCK,
             torch.Size(
@@ -43,13 +41,13 @@ from compressed_tensors.quantization.utils import calculate_qparams
                 ]
             ),
         ),
-        (tuple(), True, QuantizationStrategy.TOKEN, torch.Size([1, 1])),
+        (True, QuantizationStrategy.TOKEN, torch.Size([1, 1])),
     ],
 )
-def test_calculate_qparams(dim, keepdims, strategy, exp_shape):
+def test_calculate_qparams(keepdims, strategy, exp_shape):
     value = torch.randn(14, 5)
-    min_val = torch.amin(value, dim=dim, keepdims=keepdims)
-    max_val = torch.amax(value, dim=dim, keepdims=keepdims)
+    min_val = torch.amin(value, dim=tuple(), keepdims=keepdims)
+    max_val = torch.amax(value, dim=tuple(), keepdims=keepdims)
 
     if strategy == QuantizationStrategy.GROUP:
         args = QuantizationArgs(strategy=strategy, group_size=2)

--- a/tests/test_quantization/test_utils/test_helpers.py
+++ b/tests/test_quantization/test_utils/test_helpers.py
@@ -1,0 +1,38 @@
+import torch
+import pytest
+
+from compressed_tensors.quantization.utils import calculate_qparams
+from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
+
+
+_IN_DIMS = 5
+_OUT_DIMS = 14
+_GROUP_SIZE = 2
+
+@pytest.mark.parametrize(
+    "dim,keepdims,strategy,exp_shape",
+    [
+        (tuple(), False, QuantizationStrategy.TENSOR, torch.Size([1,])),
+        (0, True, QuantizationStrategy.CHANNEL, torch.Size([_OUT_DIMS, 1])),
+        (tuple(), True, QuantizationStrategy.GROUP, torch.Size([_OUT_DIMS // _GROUP_SIZE , 1])),
+        (tuple(), False, QuantizationStrategy.BLOCK, torch.Size([1, ])),
+        (tuple(), True, QuantizationStrategy.TOKEN, torch.Size([1, 1])),
+    ],
+)
+def test_calculate_qparams(dim, keepdims, strategy, exp_shape):
+    value = torch.randn(_OUT_DIMS, _IN_DIMS)
+    min_val = torch.amin(value, dim=dim, keepdims=keepdims)
+    max_val = torch.amax(value, dim=dim, keepdims=keepdims)
+
+    if strategy == QuantizationStrategy.GROUP:
+        args = QuantizationArgs(strategy=strategy, group_size=_GROUP_SIZE)
+        scale, zp = calculate_qparams(min_val, max_val, args)
+        assert scale.shape == exp_shape
+        assert zp.shape == exp_shape
+        
+    else:
+        args = QuantizationArgs(strategy=strategy)
+
+        scale, zp = calculate_qparams(min_val, max_val, args)
+        assert scale.shape == exp_shape
+        assert zp.shape == exp_shape


### PR DESCRIPTION
## Background ##
* While implementing #193, a bug was discovered where the shape of per-token scales is being initialized with the incorrect shape

## Changes ##
* Change shape of initialized quantization parameters in per token case
* Unrelated, compare tuples rather than lists in `tests/test_quantization/test_configs/test_strategies.py`

## Testing ##
* Added new tests in `tests/test_quantization/lifecycle/test_initialize.py`