### PR TITLE
Bump version to v0.8.1

### DIFF
--- a/src/compressed_tensors/version.py
+++ b/src/compressed_tensors/version.py
@@ -17,7 +17,7 @@ Functionality for storing and setting the version info for SparseML
 """
 
 
-version_base = "0.8.0"
+version_base = "0.8.1"
 is_release = True  # change to True to set the generated version as a release version
 
 


### PR DESCRIPTION
This PR bumps the compressed-tensors version,

It should NOT land without:
- [ ] #182 
- [ ] #167 
- [x] #213 
- [ ] #210 