### PR TITLE
Implement aliasable mixin and alias activation ordering (python3.9 fix)

### DIFF
--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -17,7 +17,7 @@ from enum import Enum
 from typing import Any, Dict, Optional, Union
 
 import torch
-from compressed_tensors.utils import AliasableEnum
+from compressed_tensors.utils import Aliasable
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 
@@ -54,7 +54,7 @@ class QuantizationStrategy(str, Enum):
     TOKEN = "token"
 
 
-class ActivationOrdering(AliasableEnum, str, Enum):
+class ActivationOrdering(Aliasable, str, Enum):
     """
     Enum storing strategies for activation ordering
 

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -71,9 +71,8 @@ class ActivationOrdering(Aliasable, str, Enum):
     DYNAMIC = "dynamic"
     STATIC = "static"
 
-    @property
     @staticmethod
-    def aliases(self) -> Dict[str, str]:
+    def get_aliases() -> Dict[str, str]:
         return {
             "dynamic": "group",
             "static": "weight",

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -17,6 +17,7 @@ from enum import Enum
 from typing import Any, Dict, Optional, Union
 
 import torch
+from compressed_tensors.utils import AliasableEnum
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 
@@ -53,17 +54,30 @@ class QuantizationStrategy(str, Enum):
     TOKEN = "token"
 
 
-class ActivationOrdering(str, Enum):
+class ActivationOrdering(AliasableEnum, str, Enum):
     """
     Enum storing strategies for activation ordering
 
     Group: reorder groups and weight\n
     Weight: only reorder weight, not groups. Slightly lower latency and
     accuracy compared to group actorder\n
+    Dynamic: alias for Group
+    Static: alias for Weight
     """
 
     GROUP = "group"
     WEIGHT = "weight"
+    # aliases
+    DYNAMIC = "dynamic"
+    STATIC = "static"
+
+    @property
+    @staticmethod
+    def aliases(self) -> Dict[str, str]:
+        return {
+            "dynamic": "group",
+            "static": "weight",
+        }
 
 
 class QuantizationArgs(BaseModel, use_enum_values=True):

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -59,10 +59,10 @@ class ActivationOrdering(AliasableEnum, str, Enum):
     Enum storing strategies for activation ordering
 
     Group: reorder groups and weight\n
-    Weight: only reorder weight, not groups. Slightly lower latency and
-    accuracy compared to group actorder\n
-    Dynamic: alias for Group
-    Static: alias for Weight
+    Weight: only reorder weight, not groups. Slightly lower accuracy but also lower
+    latency when compared to group actorder\n
+    Dynamic: alias for Group\n
+    Static: alias for Weight\n
     """
 
     GROUP = "group"

--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -62,6 +62,7 @@ class QuantizationScheme(BaseModel):
 
         return model
 
+
 """
 Pre-Set Quantization Scheme Args
 """

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from abc import abstractmethod
 from typing import Any, Dict, Optional
 
 import torch
@@ -24,7 +25,7 @@ __all__ = [
     "tensor_follows_mask_structure",
     "replace_module",
     "is_compressed_tensors_config",
-    "AliasableEnum",
+    "Aliasable",
 ]
 
 FSDP_WRAPPER_NAME = "_fsdp_wrapped_module"
@@ -122,17 +123,18 @@ def is_compressed_tensors_config(compression_config: Any) -> bool:
         return False
 
 
-class AliasableEnum:
+class Aliasable:
     """
     A mixin for enums to allow aliasing of enum members
 
     Example:
-    >>> class MyClass(AliasableEnum, int, Enum):
+    >>> class MyClass(Aliasable, int, Enum):
     >>>     ...
     """
 
     @property
     @staticmethod
+    @abstractmethod
     def aliases(self) -> Dict[str, str]:
         raise NotImplementedError()
 

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import abstractmethod
 from typing import Any, Dict, Optional
 
 import torch
@@ -132,24 +131,22 @@ class Aliasable:
     >>>     ...
     """
 
-    @property
     @staticmethod
-    @abstractmethod
-    def aliases(self) -> Dict[str, str]:
+    def get_aliases() -> Dict[str, str]:
         raise NotImplementedError()
 
     def __eq__(self, other):
         if isinstance(other, self.__class__):
+            aliases = self.get_aliases()
             return self.value == other.value or (
-                self.aliases.get(self.value, self.value)
-                == self.aliases.get(other.value, other.value)
+                aliases.get(self.value, self.value)
+                == aliases.get(other.value, other.value)
             )
         else:
-            self_value = self.aliases.get(self.value, self.value)
-            other_value = self.aliases.get(other, other)
+            aliases = self.get_aliases()
+            self_value = aliases.get(self.value, self.value)
+            other_value = aliases.get(other, other)
             return self_value == other_value
-
-        return False
 
     def __hash__(self):
         canonical_value = self.aliases.get(self.value, self.value)

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import torch
 from transformers import AutoConfig
@@ -24,6 +24,7 @@ __all__ = [
     "tensor_follows_mask_structure",
     "replace_module",
     "is_compressed_tensors_config",
+    "AliasableEnum",
 ]
 
 FSDP_WRAPPER_NAME = "_fsdp_wrapped_module"
@@ -119,3 +120,35 @@ def is_compressed_tensors_config(compression_config: Any) -> bool:
         return isinstance(compression_config, CompressedTensorsConfig)
     except ImportError:
         return False
+
+
+class AliasableEnum:
+    """
+    A mixin for enums to allow aliasing of enum members
+
+    Example:
+    >>> class MyClass(int, AliasableEnum, Enum):
+    >>>     ...
+    """
+
+    @property
+    @staticmethod
+    def aliases(self) -> Dict[str, str]:
+        raise NotImplementedError()
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.value == other.value or (
+                self.aliases.get(self.value, self.value)
+                == self.aliases.get(other.value, other.value)
+            )
+        else:
+            self_value = self.aliases.get(self.value, self.value)
+            other_value = self.aliases.get(other, other)
+            return self_value == other_value
+
+        return False
+
+    def __hash__(self):
+        canonical_value = self.aliases.get(self.value, self.value)
+        return hash(canonical_value)

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -127,7 +127,7 @@ class AliasableEnum:
     A mixin for enums to allow aliasing of enum members
 
     Example:
-    >>> class MyClass(int, AliasableEnum, Enum):
+    >>> class MyClass(AliasableEnum, int, Enum):
     >>>     ...
     """
 

--- a/tests/test_quantization/test_quant_args.py
+++ b/tests/test_quantization/test_quant_args.py
@@ -83,14 +83,28 @@ def test_actorder():
     # test group inference with actorder
     args = QuantizationArgs(group_size=128, actorder=ActivationOrdering.GROUP)
     assert args.strategy == QuantizationStrategy.GROUP
+    args = QuantizationArgs(group_size=128, actorder=ActivationOrdering.DYNAMIC)
+    assert args.strategy == QuantizationStrategy.GROUP
 
     # test invalid pairings
     with pytest.raises(ValueError):
+        QuantizationArgs(group_size=None, actorder="group")
+    with pytest.raises(ValueError):
         QuantizationArgs(group_size=None, actorder="weight")
+    with pytest.raises(ValueError):
+        QuantizationArgs(group_size=None, actorder="static")
+    with pytest.raises(ValueError):
+        QuantizationArgs(group_size=-1, actorder="group")
     with pytest.raises(ValueError):
         QuantizationArgs(group_size=-1, actorder="weight")
     with pytest.raises(ValueError):
+        QuantizationArgs(group_size=-1, actorder="static")
+    with pytest.raises(ValueError):
+        QuantizationArgs(strategy="tensor", actorder="group")
+    with pytest.raises(ValueError):
         QuantizationArgs(strategy="tensor", actorder="weight")
+    with pytest.raises(ValueError):
+        QuantizationArgs(strategy="tensor", actorder="static")
 
     # test boolean and none defaulting
     assert (
@@ -99,6 +113,38 @@ def test_actorder():
     )
     assert QuantizationArgs(group_size=1, actorder=False).actorder is None
     assert QuantizationArgs(group_size=1, actorder=None).actorder is None
+
+
+def test_actorder_aliases():
+    assert (
+        ActivationOrdering.GROUP
+        == ActivationOrdering.DYNAMIC
+        # == ActivationOrdering.GROUP
+    )
+    assert (
+        ActivationOrdering.WEIGHT
+        == ActivationOrdering.STATIC
+        == ActivationOrdering.WEIGHT
+    )
+
+    assert ActivationOrdering.GROUP == "dynamic" == ActivationOrdering.GROUP
+    assert ActivationOrdering.DYNAMIC == "dynamic" == ActivationOrdering.DYNAMIC
+    assert ActivationOrdering.GROUP == "group" == ActivationOrdering.GROUP
+    assert ActivationOrdering.DYNAMIC == "group" == ActivationOrdering.DYNAMIC
+
+    assert ActivationOrdering.WEIGHT == "static" == ActivationOrdering.WEIGHT
+    assert ActivationOrdering.STATIC == "static" == ActivationOrdering.STATIC
+    assert ActivationOrdering.WEIGHT == "weight" == ActivationOrdering.WEIGHT
+    assert ActivationOrdering.STATIC == "weight" == ActivationOrdering.STATIC
+
+    assert ActivationOrdering.WEIGHT != "dynamic" != ActivationOrdering.WEIGHT
+    assert ActivationOrdering.STATIC != "dynamic" != ActivationOrdering.STATIC
+    assert ActivationOrdering.WEIGHT != "group" != ActivationOrdering.WEIGHT
+    assert ActivationOrdering.STATIC != "group" != ActivationOrdering.STATIC
+    assert ActivationOrdering.GROUP != "static" != ActivationOrdering.GROUP
+    assert ActivationOrdering.DYNAMIC != "static" != ActivationOrdering.DYNAMIC
+    assert ActivationOrdering.GROUP != "weight" != ActivationOrdering.GROUP
+    assert ActivationOrdering.DYNAMIC != "weight" != ActivationOrdering.DYNAMIC
 
 
 def test_invalid():

--- a/tests/test_quantization/test_quant_args.py
+++ b/tests/test_quantization/test_quant_args.py
@@ -119,7 +119,7 @@ def test_actorder_aliases():
     assert (
         ActivationOrdering.GROUP
         == ActivationOrdering.DYNAMIC
-        # == ActivationOrdering.GROUP
+        == ActivationOrdering.GROUP
     )
     assert (
         ActivationOrdering.WEIGHT


### PR DESCRIPTION
## Purpose ##
* Add aliases for activation ordering options to improve usability for researchers familiar with autogptq
* Update previous #213 to support python<=3.9

## Changes ##
* Implement `AliasableEnum` mixin which allows enums to be aliased
* Add `AliasableEnum` to `ActivationOrdering` with the following map:
```python3
{
    "dynamic": "group",
    "static": "weight",
}
```
* Remove the `@property` decorator from aliases to avoid interactions in python<=3.9 https://bugs.python.org/issue43682

## Testing ##
* Added passing tests in `tests/test_quantization/test_quant_args.py`
* Successfully quantized a model using `dynamic` actorder and tested e2e with vllm
* Tested the above using python3.9

<details><summary>llama3.py</summary>

```python3
from accelerate import cpu_offload
from datasets import load_dataset
from transformers import AutoModelForCausalLM, AutoTokenizer

from llmcompressor.modifiers.quantization import GPTQModifier
from llmcompressor.transformers import oneshot

# Select model and load it.
# MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"
MODEL_ID = "meta-llama/Llama-3.2-1B-Instruct"

model = AutoModelForCausalLM.from_pretrained(
    MODEL_ID,
    device_map="cuda:0",
    torch_dtype="auto",
)
# cpu_offload(model)
tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)

# Select calibration dataset.
DATASET_ID = "HuggingFaceH4/ultrachat_200k"
DATASET_SPLIT = "train_sft"

# Select number of samples. 512 samples is a good place to start.
# Increasing the number of samples can improve accuracy.
NUM_CALIBRATION_SAMPLES = 285  # 2048
MAX_SEQUENCE_LENGTH = 2048

# Load dataset and preprocess.
ds = load_dataset(DATASET_ID, split=DATASET_SPLIT)
ds = ds.shuffle(seed=42).select(range(NUM_CALIBRATION_SAMPLES))


def preprocess(example):
    return {
        "text": tokenizer.apply_chat_template(
            example["messages"],
            tokenize=False,
        )
    }


ds = ds.map(preprocess)


# Tokenize inputs.
def tokenize(sample):
    return tokenizer(
        sample["text"],
        padding=False,
        max_length=MAX_SEQUENCE_LENGTH,
        truncation=True,
        add_special_tokens=False,
    )


ds = ds.map(tokenize, remove_columns=ds.column_names)

# Configure the quantization algorithm to run.
from compressed_tensors.quantization import QuantizationArgs, QuantizationType, QuantizationStrategy, ActivationOrdering, QuantizationScheme
recipe = GPTQModifier(
    targets="Linear",
    config_groups={
        "config_group": QuantizationScheme(
            targets=["Linear"],
            weights=QuantizationArgs(
                num_bits=4,
                type=QuantizationType.INT,
                strategy=QuantizationStrategy.GROUP,
                group_size=128,
                symmetric=True,
                dynamic=False,
                actorder="dynamic",
            ),
        ),
    },
    ignore=["lm_head"],
    dampening_frac=0.5
)

# Apply algorithms.
oneshot(
    model=model,
    dataset=ds,
    recipe=recipe,
    max_seq_length=MAX_SEQUENCE_LENGTH,
    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
)

# Confirm generations of the quantized model look sane.
print("\n\n")
print("========== SAMPLE GENERATION ==============")
input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to("cuda")
output = model.generate(input_ids, max_new_tokens=100)
print(tokenizer.decode(output[0]))
print("==========================================\n\n")

# Save to disk compressed.
SAVE_DIR = MODEL_ID.split("/")[1] + "-W4A16-G128"
model.save_pretrained(SAVE_DIR, save_compressed=True)
tokenizer.save_pretrained(SAVE_DIR)
```
</details>