### PR TITLE
Rectify Asym Compression/Decompression Pathways

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -534,7 +534,15 @@ def map_modules_to_quant_args(model: Module) -> Dict[str, QuantizationArgs]:
         if is_module_quantized(submodule):
             if submodule.quantization_scheme.weights is not None:
                 name = fix_fsdp_module_name(name)
-                quantized_modules_to_args[name] = submodule.quantization_scheme.weights
+                quantized_modules_to_args[name] = (
+                    submodule.quantization_scheme.weights,
+                )
+                if submodule.quantization_scheme.input_activations is not None:
+                    weight_args = quantized_modules_to_args.get(name)[0]
+                    quantized_modules_to_args[name] = (
+                        weight_args,
+                        submodule.quantization_scheme.input_activations,
+                    )
 
     return quantized_modules_to_args
 

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -534,11 +534,9 @@ def map_modules_to_quant_args(model: Module) -> Dict[str, QuantizationArgs]:
         if is_module_quantized(submodule):
             if submodule.quantization_scheme.weights is not None:
                 name = fix_fsdp_module_name(name)
-                quantized_modules_to_args[name] = (
-                    submodule.quantization_scheme.weights,
-                )
+                quantized_modules_to_args[name] = submodule.quantization_scheme.weights
                 if submodule.quantization_scheme.input_activations is not None:
-                    weight_args = quantized_modules_to_args.get(name)[0]
+                    weight_args = quantized_modules_to_args.get(name)
                     quantized_modules_to_args[name] = (
                         weight_args,
                         submodule.quantization_scheme.input_activations,

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -19,7 +19,7 @@ import os
 import re
 from contextlib import contextmanager
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, TypeVar, Union
 
 import compressed_tensors
 import torch
@@ -522,10 +522,13 @@ class ModelCompressor:
                 update_parameter_data(module, data, param_name)
 
 
-def map_modules_to_quant_args(model: Module) -> Dict[str, QuantizationArgs]:
+def map_modules_to_quant_args(
+    model: Module,
+) -> Dict[str, Union[QuantizationArgs, Tuple[QuantizationArgs, QuantizationArgs]]]:
     """
     Given a pytorch model, map out the submodule name (usually linear layers)
-     to the QuantizationArgs
+    to the weight QuantizationArgs. If running input activation quantization, will also
+    map to the input QuantizationArgs in a tuple.
 
     :param model: pytorch model
     """

--- a/src/compressed_tensors/compressors/quantized_compressors/base.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/base.py
@@ -116,13 +116,11 @@ class BaseQuantizationCompressor(BaseCompressor):
                 weight_zp
                 and names_to_scheme.get(name[: -(len(weight_zp_suffix))])[0].symmetric
             ):
-                print("skipping zp")
                 continue
             elif (
                 input_zp
                 and names_to_scheme.get(name[: -(len(input_zp_suffix))])[1].symmetric
             ):
-                print("skipping input zp")
                 continue
             elif name.endswith("g_idx") and torch.any(value <= -1):
                 continue

--- a/src/compressed_tensors/compressors/quantized_compressors/base.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/base.py
@@ -91,19 +91,21 @@ class BaseQuantizationCompressor(BaseCompressor):
         for name, value in tqdm(model_state.items(), desc="Quantized Compression"):
             # check if the parameter we're compressing is the weight zp
             # or the input zp
-            weight_zp = name.endswith(weight_zp_suffix)
-            input_zp = name.endswith(input_zp_suffix)
+            is_weight_zp = name.endswith(weight_zp_suffix)
+            is_input_zp = name.endswith(input_zp_suffix)
 
-            # if we're compressing the weight zp, fetch weight quant args
-            if weight_zp:
+            # if we're saving the weight zp, fetch weight quant args
+            if is_weight_zp:
                 quant_args_zp = names_to_scheme.get(name[: -(len(weight_zp_suffix))])
                 if isinstance(quant_args_zp, tuple):
+                    # If tuple, first value is weight args, second is input args
                     quant_args_zp = quant_args_zp[0]
 
-            # if we're compressing the input zp, fetch input quant args
-            if input_zp:
+            # if we're saving the input zp, fetch input quant args
+            if is_input_zp:
                 input_args_zp = names_to_scheme.get(name[: -(len(input_zp_suffix))])
                 if isinstance(input_args_zp, tuple):
+                    # If tuple, first value is weight args, second is input args
                     input_args_zp = input_args_zp[-1]
 
             if name.endswith(weight_suffix):
@@ -131,10 +133,10 @@ class BaseQuantizationCompressor(BaseCompressor):
                 else:
                     compressed_dict[name] = value.to("cpu")
             # only save if asym
-            elif weight_zp and quant_args_zp.symmetric:
+            elif is_weight_zp and quant_args_zp.symmetric:
                 continue
             # only save if asym
-            elif input_zp and input_args_zp.symmetric:
+            elif is_input_zp and input_args_zp.symmetric:
                 continue
             elif name.endswith("g_idx") and torch.any(value <= -1):
                 continue

--- a/src/compressed_tensors/compressors/sparse_quantized_compressors/marlin_24.py
+++ b/src/compressed_tensors/compressors/sparse_quantized_compressors/marlin_24.py
@@ -57,9 +57,9 @@ class Marlin24Compressor(BaseCompressor):
             a ValueError otherwise
         """
         for name, quant_args in model_quant_args.items():
-            strategy = quant_args.strategy
-            group_size = quant_args.group_size
-            symmetric = quant_args.symmetric
+            strategy = quant_args[0].strategy
+            group_size = quant_args[0].group_size
+            symmetric = quant_args[0].symmetric
             if (
                 strategy is not QuantizationStrategy.GROUP.value
                 and strategy is not QuantizationStrategy.CHANNEL.value
@@ -146,7 +146,7 @@ class Marlin24Compressor(BaseCompressor):
                     value = value.to(torch.float16)
 
                     # quantize weight, keeping it as a float16 for now
-                    quant_args = names_to_scheme[prefix]
+                    quant_args = names_to_scheme[prefix][0]
                     value = quantize(
                         x=value, scale=scale, zero_point=zp, args=quant_args
                     )

--- a/src/compressed_tensors/compressors/sparse_quantized_compressors/marlin_24.py
+++ b/src/compressed_tensors/compressors/sparse_quantized_compressors/marlin_24.py
@@ -57,9 +57,9 @@ class Marlin24Compressor(BaseCompressor):
             a ValueError otherwise
         """
         for name, quant_args in model_quant_args.items():
-            strategy = quant_args[0].strategy
-            group_size = quant_args[0].group_size
-            symmetric = quant_args[0].symmetric
+            strategy = quant_args.strategy
+            group_size = quant_args.group_size
+            symmetric = quant_args.symmetric
             if (
                 strategy is not QuantizationStrategy.GROUP.value
                 and strategy is not QuantizationStrategy.CHANNEL.value
@@ -146,7 +146,7 @@ class Marlin24Compressor(BaseCompressor):
                     value = value.to(torch.float16)
 
                     # quantize weight, keeping it as a float16 for now
-                    quant_args = names_to_scheme[prefix][0]
+                    quant_args = names_to_scheme[prefix]
                     value = quantize(
                         x=value, scale=scale, zero_point=zp, args=quant_args
                     )

--- a/tests/test_compressors/quantized_compressors/test_int_quant.py
+++ b/tests/test_compressors/quantized_compressors/test_int_quant.py
@@ -27,11 +27,13 @@ from compressed_tensors.quantization.lifecycle.forward import fake_quantize
 from safetensors.torch import save_file
 
 
-def get_dummy_quant_config(strategy, group_size=None):
+def get_dummy_quant_config(strategy, group_size=None, symmetric=True):
     config_groups = {
         "group_1": QuantizationScheme(
             targets=["Linear"],
-            weights=QuantizationArgs(strategy=strategy, group_size=group_size),
+            weights=QuantizationArgs(
+                strategy=strategy, group_size=group_size, symmetric=symmetric
+            ),
         ),
     }
     ignore = ["lm_head"]
@@ -69,7 +71,9 @@ def test_quant_format(strategy, symmetric, group_size, sc, zp):
         "dummy.weight_scale": torch.tensor(sc, dtype=torch.float32),
         "dummy.weight_zero_point": torch.tensor(zp, dtype=torch.int32),
     }
-    quant_config = get_dummy_quant_config(strategy=strategy, group_size=group_size)
+    quant_config = get_dummy_quant_config(
+        strategy=strategy, group_size=group_size, symmetric=symmetric
+    )
 
     compressor = IntQuantizationCompressor(config=quant_config)
     quantized_modules_to_args = {"dummy": quant_config.config_groups["group_1"].weights}


### PR DESCRIPTION
# Summary
- Previously, we were not saving the zp if the values stored in the parameter were 0s (assumes symmetric quantization with this condition when it is certainly possible that we may have 0s as the zp for the asym case)
- However, this fails loading in the event that we're running asymmetric quantization (missing parameters)
- Update the condition for compression to directly check if we're running asym or sym quantization

Fixes: https://github.com/vllm-project/llm-compressor/issues/1190 and our general decompression issues with asym models 

# Testing
- Validated models with existing integration in vLLM for W8A8 int8
- Validated asym models compressed can be loaded and run as expected