### PR TITLE
Fix warning for dynamic quantization args

### DIFF
--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -109,10 +109,10 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
     dynamic: bool = False
     actorder: Union[ActivationOrdering, bool, None] = None
     observer: Optional[str] = Field(
-        default="minmax",
+        default=None,
         description=(
-            "The class to use to compute the quantization param - "
-            "scale and zero-point'"
+            "Determines the method of computing quantization parameters (scales and "
+            "zero-points). Defaults to min-max when not using dynamic quantization"
         ),
     )
     observer_kwargs: Dict[str, Any] = Field(


### PR DESCRIPTION
## Purpose ##
* Squelch warning in case where the user instantiates QuantizationArgs with dynamic quantization
```python3
from compressed_tensors.quantization import QuantizationArgs
args = QuantizationArgs(dynamic=True)
```
```
compressed_tensors/quantization/quant_args.py:226: UserWarning: No observer is used for dynamic quantization, setting to None
  warnings.warn(
```

## Changes ##
* Use `None` as observer default. In the model validator, if dynamic, observer is set to `None`. If not dynamic, None gets replaced by `minmax`
* Add help text explaining new default behavior

## Testing ##
* Tests which use dynamic quantization such as `tests/test_quantization/lifecycle/test_dynamic_lifecycle.py::test_apply_tinyllama_dynamic_activations` now no longer raise an error
* See above test script