### PR TITLE
Update & fix Testmo actions/logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,12 +76,9 @@ jobs:
               with:
                   ref: ${{ inputs.gitref }}
 
-            - name: install testmo
-              uses: neuralmagic/nm-actions/actions/install-testmo@v1.0.0
-
             - name: create testmo run
               id: create_testmo_run
-              uses: neuralmagic/nm-actions/actions/testmo-run-create@v1.2.0
+              uses: neuralmagic/nm-actions/actions/testmo-run-create@v1.11.0
               if: success()
               with:
                 testmo_url: https://neuralmagic.testmo.net
@@ -142,8 +139,8 @@ jobs:
 
             - name: report build status to testmo
               id: report_build
-              uses: neuralmagic/nm-actions/actions/testmo-run-submit-thread@v1.2.0
-              if: (success() || failure()) && ${{ inputs.testmo_run_id != '' }}
+              uses: neuralmagic/nm-actions/actions/testmo-run-submit-thread@v1.11.0
+              if: success() || failure()
               with:
                   testmo_url: https://neuralmagic.testmo.net
                   testmo_token: ${{ secrets.TESTMO_TEST_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,6 @@ jobs:
             - name: create testmo run
               id: create_testmo_run
               uses: neuralmagic/nm-actions/actions/testmo-run-create@v1.11.0
-              if: success()
               with:
                 testmo_url: https://neuralmagic.testmo.net
                 testmo_token: ${{ secrets.TESTMO_TEST_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,9 +90,6 @@ jobs:
               with:
                   venv: TEST
 
-            - name: install testmo
-              uses: neuralmagic/nm-actions/actions/install-testmo@v1.0.0
-
             - name: download whl
               id: download
               uses: actions/download-artifact@v4
@@ -108,8 +105,8 @@ jobs:
 
             - name: report test results
               id: report_test
-              uses: neuralmagic/nm-actions/actions/testmo-run-submit-thread@v1.2.0
-              if: (success() || failure()) && ${{ inputs.testmo_run_id != '' }}
+              uses: neuralmagic/nm-actions/actions/testmo-run-submit-thread@v1.11.0
+              if: (success() || failure()) && inputs.testmo_run_id != ''
               with:
                   testmo_url: https://neuralmagic.testmo.net
                   testmo_token: ${{ secrets.TESTMO_TEST_TOKEN }}

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -69,12 +69,9 @@ jobs:
               with:
                 python-version: 3.10.12
 
-            - name: install testmo
-              uses: neuralmagic/nm-actions/actions/install-testmo@v1.0.0
-
             - name: complete testmo run
-              uses: neuralmagic/nm-actions/actions/testmo-run-complete@v1.2.0
-              if: (success() || failure()) && ${{ inputs.testmo_run_id != '' }}
+              uses: neuralmagic/nm-actions/actions/testmo-run-complete@v1.11.0
+              if: (success() || failure()) && inputs.testmo_run_id != ''
               with:
                   testmo_url: https://neuralmagic.testmo.net
                   testmo_token: ${{ secrets.TESTMO_TEST_TOKEN }}


### PR DESCRIPTION
This PR updates and fixes Testmo actions/usage logic:
* All Testmo actions are updated to the latest version (which, among other things, eliminates the need to install the CLI tool separately)
* Fixes a "bug" in the conditional logic so that it is properly evaluated (it seems that GitHub doesn’t like mixing functions / expressions in and out of the double-curly braces in these places)

Here is a re-run of the upload workflow that failed on `main` (due to a Testmo step not being correctly skipped and thus failing): https://github.com/neuralmagic/compressed-tensors/actions/runs/12468376137/job/34799436033