### PR TITLE
Fix: Disable Sparse Decompression for Dense Compressors

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -269,9 +269,9 @@ class ModelCompressor:
 
         compressed_state_dict = state_dict
 
-        quantized_modules_to_args: Dict[
-            str, QuantizationArgs
-        ] = map_modules_to_quant_args(model)
+        quantized_modules_to_args: Dict[str, QuantizationArgs] = (
+            map_modules_to_quant_args(model)
+        )
 
         if self.quantization_compressor is not None:
             compressed_state_dict = self.quantization_compressor.compress(
@@ -310,7 +310,10 @@ class ModelCompressor:
         model_path = get_safetensors_folder(model_path)
         sparse_decompressed = False
 
-        if self.sparsity_compressor is not None:
+        if (
+            self.sparsity_compressor is not None
+            and self.sparsity_config.format != "dense"
+        ):
             # Sparse decompression is applied on the model_path
             dense_gen = self.sparsity_compressor.decompress(model_path)
             self._replace_weights(dense_gen, model)

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -312,7 +312,7 @@ class ModelCompressor:
 
         if (
             self.sparsity_compressor is not None
-            and self.sparsity_config.format != "dense"
+            and self.sparsity_config.format != CompressionFormat.dense.value
         ):
             # Sparse decompression is applied on the model_path
             dense_gen = self.sparsity_compressor.decompress(model_path)

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -269,9 +269,9 @@ class ModelCompressor:
 
         compressed_state_dict = state_dict
 
-        quantized_modules_to_args: Dict[str, QuantizationArgs] = (
-            map_modules_to_quant_args(model)
-        )
+        quantized_modules_to_args: Dict[
+            str, QuantizationArgs
+        ] = map_modules_to_quant_args(model)
 
         if self.quantization_compressor is not None:
             compressed_state_dict = self.quantization_compressor.compress(


### PR DESCRIPTION
### **Problem**
When the sparse compressor is set to `"dense"`, sparse decompression is incorrectly triggered, causing uninitialized weights and downstream errors.  
Example CI failure: [[GitHub Actions Log](https://github.com/vllm-project/llm-compressor/actions/runs/12659596814/job/35326229412)](https://github.com/vllm-project/llm-compressor/actions/runs/12659596814/job/35326229412).

### **Solution**
Added a condition to skip sparse decompression when the sparsity configuration format is `"dense"`.

### **Testing**
- Verified against `llm-compressor` main commit: `03e21770`.
- Confirmed weights load correctly for dense compressors.
- All CI workflows pass without regressions.

