### PR TITLE
Update: Test for Compatibility with Transformers 4.48

### DIFF
--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -31,8 +31,9 @@ from compressed_tensors.quantization.lifecycle import (
     is_sparse_target,
 )
 from compressed_tensors.quantization.utils import iter_named_leaf_modules
+from packaging import version
 from tests.testing_utils import requires_accelerate
-from transformers import AutoModelForCausalLM
+from transformers import AutoModelForCausalLM, __version__
 
 
 @pytest.fixture
@@ -138,7 +139,12 @@ def test_apply_quantization_config_tinyllama():
     # sanity check correct number of layers targeted
     assert num_linears == 154  # 155 Linear layers - 1 that gets ignored
     assert num_embeddings == 1
-    assert num_rotary_embeddings == 23  # model updated, now has model.rotary_embedding
+
+    # Handle num_rotary_embeddings based on transformers version
+    if version.parse(__version__) < version.parse("4.48"):
+        assert num_rotary_embeddings == 23
+    else:
+        assert num_rotary_embeddings == 1
 
     # test quantization compression
     # sample forward pass to fill scales, zps


### PR DESCRIPTION
We recently encountered a failure due to the release of Transformers 4.48. Details of the failure can be found here: [GitHub Actions Failure](https://github.com/neuralmagic/compressed-tensors/actions/runs/12711091190/job/35434507893#step:6:164).

## Cause
The failure occurred because the Llama model definition in Transformers was updated to use a single rotary embedding for the model, replacing the previous implementation where there was one rotary embedding per attention block. This change was introduced in the following commit: [Transformers Commit (line 261)](https://github.com/huggingface/transformers/commit/d363e71d0e32f44d7a5b3571d4921371907bd0ee#diff-06392bad3b9e97be9ade6[…]d507c2ba1384ab872711c51L286).

## Fix and Validation
Instead of relying o hardcoded values, we count the modules in question now, and check if after quantization config application the number stays the same. Credits to @horheynm for the better fix #238. The test now successfully passes with all versions of Transformers, as demonstrated below:

### Transformers 4.47.1
```bash
(.venv) ➜ compressed-tensors git:(update-test) ✗ pytest "./tests/test_quantization/lifecycle/test_apply.py::test_apply_quantization_config_tinyllama"
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.10.12, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/rahul/compressed-tensors
configfile: pyproject.toml
collected 1 item                                                                                                                                                                                          

tests/test_quantization/lifecycle/test_apply.py .                                                                                                                                                   [100%]

============================================================================================ 1 passed in 3.68s ============================================================================================
```

### Transformers 4.48.0
```bash
(.venv) ➜ compressed-tensors git:(update-test) ✗ pytest "./tests/test_quantization/lifecycle/test_apply.py::test_apply_quantization_config_tinyllama"
=========================================================================================== test session starts ===========================================================================================
platform linux -- Python 3.10.12, pytest-8.3.4, pluggy-1.5.0
rootdir: /home/rahul/compressed-tensors
configfile: pyproject.toml
collected 1 item                                                                                                                                                                                          

tests/test_quantization/lifecycle/test_apply.py .                                                                                                                                                   [100%]

============================================================================================ 1 passed in 4.08s ============================================================================================
```

## Summary
This update ensures compatibility with the latest Transformers release (4.48) while maintaining support for previous versions. All relevant tests now pass, confirming the fix.