### PR TITLE
BugFix: Shape should be a flat list

### DIFF
--- a/src/compressed_tensors/compressors/sparse_compressors/sparse_24_bitmask.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/sparse_24_bitmask.py
@@ -103,8 +103,10 @@ class Sparse24BitMaskTensor:
         :param bitmask: 2d bitmask of non-zero values
         :return: instantiated Sparse24BitMaskTensor
         """
-        if isinstance(shape, Tensor):
-            shape = shape.tolist()
+        if isinstance(shape, list):
+            shape = torch.tensor(shape)
+        if isinstance(shape, torch.Tensor):
+            shape = shape.flatten().tolist()
         return Sparse24BitMaskTensor(
             shape=shape, compressed=compressed, bitmask=bitmask
         )

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -301,7 +301,7 @@ def pack_bitmasks(bytemasks: torch.Tensor) -> torch.Tensor:
 
 
 def unpack_bitmasks(
-    packed_bitmasks: torch.Tensor, original_shape: torch.Size
+    packed_bitmasks: torch.Tensor, original_shape: List[int]
 ) -> torch.Tensor:
     """
     Converts a bitmask tensor back to a bytemask tensor for use during decompression


### PR DESCRIPTION
This PR fixes a missed case where shape can be a 2-D list for `Sparse24Compressor`

Tested locally with https://github.com/vllm-project/llm-compressor/pull/948