### PR TITLE
Fix errors in scripts and notebooks in `examples/` and drop `sparseml` dependence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,4 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-examples/*.safetensors
+examples/**/*.safetensors

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+examples/*.safetensors

--- a/examples/bit_packing/ex_quantize_and_pack.py
+++ b/examples/bit_packing/ex_quantize_and_pack.py
@@ -12,25 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tqdm import tqdm
-from torch.utils.data import RandomSampler
-from compressed_tensors.quantization import (
-    apply_quantization_config,
-    freeze_module_quantization,
-    QuantizationConfig,
-    QuantizationStatus,
-)
-from sparseml.transformers.finetune.data.data_args import DataTrainingArguments
-from sparseml.transformers.finetune.data.base import TextGenerationDataset
-from transformers import AutoModelForCausalLM, AutoTokenizer, DefaultDataCollator
-from torch.utils.data import DataLoader
-from sparseml.pytorch.utils import tensors_to_device
+from pathlib import Path
+
 import torch
 from compressed_tensors.compressors import ModelCompressor
+from compressed_tensors.quantization import (
+    QuantizationConfig,
+    QuantizationStatus,
+    apply_quantization_config,
+)
+from datasets import load_dataset
+from torch.utils.data import DataLoader, RandomSampler
+from tqdm import tqdm
+from transformers import AutoModelForCausalLM, AutoTokenizer, DefaultDataCollator
 
-config_file = "int4_config.json"
+
+config_file = Path(__file__).parent / "int4_config.json"
 model_name = "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T"
-dataset_name = "open_platypus"
+dataset_name = "garage-bAInd/Open-Platypus"
 split = "train"
 num_calibration_samples = 128
 max_seq_length = 512
@@ -38,9 +37,12 @@ pad_to_max_length = False
 output_dir = "./llama1.1b_new_quant_out_test_packing"
 device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
-model = AutoModelForCausalLM.from_pretrained(model_name, device_map=device, torch_dtype="auto")
+model = AutoModelForCausalLM.from_pretrained(
+    model_name, device_map=device, torch_dtype="auto"
+)
 model.eval()  # no grad or updates needed for base model
-config = QuantizationConfig.parse_file(config_file)
+with open(config_file) as f:
+    config = QuantizationConfig.model_validate_json(f)
 
 # set status to calibration
 config.quantization_status = QuantizationStatus.CALIBRATION
@@ -49,36 +51,37 @@ config.quantization_status = QuantizationStatus.CALIBRATION
 apply_quantization_config(model, config)
 
 # create dataset
+dataset = load_dataset(dataset_name, split="train[:128]")
 tokenizer = AutoTokenizer.from_pretrained(model_name)
-data_args = DataTrainingArguments(
-    dataset=dataset_name,
-    max_seq_length=max_seq_length,
-    pad_to_max_length=pad_to_max_length,
-)
-dataset_manager = TextGenerationDataset.load_from_registry(
-    data_args.dataset,
-    data_args=data_args,
-    split=split,
-    tokenizer=tokenizer,
-)
-calib_dataset = dataset_manager.tokenize_and_process(
-    dataset_manager.get_raw_dataset()
-)
+
+
+def tokenize_function(examples):
+    return tokenizer(
+        examples["output"], padding=False, truncation=True, max_length=1024
+    )
+
+
+tokenized_dataset = dataset.map(tokenize_function, batched=True)
+
 data_loader = DataLoader(
-    calib_dataset, batch_size=1, collate_fn=DefaultDataCollator(), sampler=RandomSampler(calib_dataset)
+    tokenized_dataset,
+    batch_size=1,
+    collate_fn=DefaultDataCollator(),
+    sampler=RandomSampler(tokenized_dataset),
 )
 
 # run calibration
 with torch.no_grad():
     for idx, sample in tqdm(enumerate(data_loader), desc="Running calibration"):
-        sample = tensors_to_device(sample, "cuda:0")
+        sample = {k: v.to(model.device) for k, v in sample.items()}
         _ = model(**sample)
 
         if idx >= num_calibration_samples:
             break
 
+# TODO check with team -- move code back from llmcompressor or drop?
 # freeze params after calibration
-model.apply(freeze_module_quantization)
+# model.apply(freeze_module_quantization)
 
 # apply compression
 compressor = ModelCompressor(quantization_config=config)

--- a/examples/bit_packing/ex_quantize_and_pack.py
+++ b/examples/bit_packing/ex_quantize_and_pack.py
@@ -41,8 +41,7 @@ model = AutoModelForCausalLM.from_pretrained(
     model_name, device_map=device, torch_dtype="auto"
 )
 model.eval()  # no grad or updates needed for base model
-with open(config_file) as f:
-    config = QuantizationConfig.model_validate_json(f)
+config = QuantizationConfig.model_validate_json(config_file.read_text())
 
 # set status to calibration
 config.quantization_status = QuantizationStatus.CALIBRATION
@@ -86,5 +85,7 @@ with torch.no_grad():
 # apply compression
 compressor = ModelCompressor(quantization_config=config)
 compressed_state_dict = compressor.compress(model)
+
+# save quantized model
 model.save_pretrained(output_dir, state_dict=compressed_state_dict)
 compressor.update_config(output_dir)

--- a/examples/bit_packing/ex_quantize_and_pack.py
+++ b/examples/bit_packing/ex_quantize_and_pack.py
@@ -77,7 +77,6 @@ data_loader = DataLoader(
     batch_size=1,
 )
 
-# run calibration
 with torch.no_grad():
     for idx, sample in tqdm(enumerate(data_loader), desc="Running calibration"):
         sample = {k: v.to(model.device) for k, v in sample.items()}
@@ -86,10 +85,10 @@ with torch.no_grad():
         if idx >= num_calibration_samples:
             break
 
-# apply compression
+# convert model to QDQ model
 compressor = ModelCompressor(quantization_config=config)
 compressed_state_dict = compressor.compress(model)
 
-# save quantized model
+# save QDQ model
 model.save_pretrained(output_dir, state_dict=compressed_state_dict)
 compressor.update_config(output_dir)

--- a/examples/bit_packing/ex_quantize_and_pack.py
+++ b/examples/bit_packing/ex_quantize_and_pack.py
@@ -50,7 +50,7 @@ config.quantization_status = QuantizationStatus.CALIBRATION
 apply_quantization_config(model, config)
 
 # create dataset
-dataset = load_dataset(dataset_name, split="train[:128]")
+dataset = load_dataset(dataset_name, split=f"train[:{num_calibration_samples}]")
 tokenizer = AutoTokenizer.from_pretrained(model_name)
 
 
@@ -65,8 +65,6 @@ tokenized_dataset = dataset.map(tokenize_function, batched=True)
 data_loader = DataLoader(
     tokenized_dataset,
     batch_size=1,
-    collate_fn=DefaultDataCollator(),
-    sampler=RandomSampler(tokenized_dataset),
 )
 
 # run calibration

--- a/examples/bit_packing/ex_quantize_and_pack.py
+++ b/examples/bit_packing/ex_quantize_and_pack.py
@@ -12,6 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+####
+#
+# The following example shows how to run QDQ inside `compressed-tensors`
+# QDQ (quantize & de-quantize) is a way to evaluate quantized model
+# accuracy but will not lead to a runtime speedup.
+# See `../llama_1.1b/ex_config_quantization.py` to go beyond QDQ
+# and quantize models that will run more performantly.
+#
+####
+
 from pathlib import Path
 
 import torch
@@ -22,9 +32,9 @@ from compressed_tensors.quantization import (
     apply_quantization_config,
 )
 from datasets import load_dataset
-from torch.utils.data import DataLoader, RandomSampler
+from torch.utils.data import DataLoader
 from tqdm import tqdm
-from transformers import AutoModelForCausalLM, AutoTokenizer, DefaultDataCollator
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 
 config_file = Path(__file__).parent / "int4_config.json"
@@ -75,10 +85,6 @@ with torch.no_grad():
 
         if idx >= num_calibration_samples:
             break
-
-# TODO check with team -- move code back from llmcompressor or drop?
-# freeze params after calibration
-# model.apply(freeze_module_quantization)
 
 # apply compression
 compressor = ModelCompressor(quantization_config=config)

--- a/examples/bit_packing/int4_config.json
+++ b/examples/bit_packing/int4_config.json
@@ -12,6 +12,5 @@
             },
             "targets": ["Linear"]
         }
-    },
-	"ignore": ["lm_head"]
+    }
 }

--- a/examples/bitmask_compression.ipynb
+++ b/examples/bitmask_compression.ipynb
@@ -15,7 +15,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting hf-transfer\n",
+      "  Downloading hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.7 kB)\n",
+      "Downloading hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.6 MB)\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.6/3.6 MB\u001b[0m \u001b[31m80.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hInstalling collected packages: hf-transfer\n",
+      "Successfully installed hf-transfer-0.1.9\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pip install hf-transfer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,9 +52,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0ba83d4581e24f358220b00b21a2dec4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "config.json:   0%|          | 0.00/664 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "db48a2de8ea34c0f9e860bcbc7c6c6a9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "pytorch_model.bin:   0%|          | 0.00/438M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "81d6f18b8a054d2984a9e0cc0ac11a7e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "generation_config.json:   0%|          | 0.00/119 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "data": {
       "text/plain": [
@@ -40,12 +105,11 @@
        "    (embed_tokens): Embedding(32000, 768)\n",
        "    (layers): ModuleList(\n",
        "      (0-11): 12 x LlamaDecoderLayer(\n",
-       "        (self_attn): LlamaSdpaAttention(\n",
+       "        (self_attn): LlamaAttention(\n",
        "          (q_proj): Linear(in_features=768, out_features=768, bias=False)\n",
        "          (k_proj): Linear(in_features=768, out_features=768, bias=False)\n",
        "          (v_proj): Linear(in_features=768, out_features=768, bias=False)\n",
        "          (o_proj): Linear(in_features=768, out_features=768, bias=False)\n",
-       "          (rotary_emb): LlamaRotaryEmbedding()\n",
        "        )\n",
        "        (mlp): LlamaMLP(\n",
        "          (gate_proj): Linear(in_features=768, out_features=2048, bias=False)\n",
@@ -53,19 +117,34 @@
        "          (down_proj): Linear(in_features=2048, out_features=768, bias=False)\n",
        "          (act_fn): SiLU()\n",
        "        )\n",
-       "        (input_layernorm): LlamaRMSNorm()\n",
-       "        (post_attention_layernorm): LlamaRMSNorm()\n",
+       "        (input_layernorm): LlamaRMSNorm((768,), eps=1e-05)\n",
+       "        (post_attention_layernorm): LlamaRMSNorm((768,), eps=1e-05)\n",
        "      )\n",
        "    )\n",
-       "    (norm): LlamaRMSNorm()\n",
+       "    (norm): LlamaRMSNorm((768,), eps=1e-05)\n",
+       "    (rotary_emb): LlamaRotaryEmbedding()\n",
        "  )\n",
        "  (lm_head): Linear(in_features=768, out_features=32000, bias=False)\n",
        ")"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "634a76f0b76c4d968e2f77f4523f4be3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model.safetensors:   0%|          | 0.00/438M [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -77,14 +156,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The example layer model.layers.0.self_attn.q_proj.weight has sparsity 0.50%\n"
+      "The example layer model.layers.0.self_attn.q_proj.weight has sparsity 50.00%\n"
      ]
     }
    ],
@@ -93,12 +172,12 @@
     "state_dict = model.state_dict()\n",
     "state_dict.keys()\n",
     "example_layer = \"model.layers.0.self_attn.q_proj.weight\"\n",
-    "print(f\"The example layer {example_layer} has sparsity {torch.sum(state_dict[example_layer] == 0).item() / state_dict[example_layer].numel():.2f}%\")"
+    "print(f\"The example layer {example_layer} has sparsity {100 * state_dict[example_layer].eq(0).sum().item() / state_dict[example_layer].numel():.2f}%\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -110,7 +189,7 @@
     }
    ],
    "source": [
-    "# we can inspect to total sparisity of the state_dict\n",
+    "# we can inspect to total sparsity of the state_dict\n",
     "total_num_parameters = 0\n",
     "total_num_zero_parameters = 0\n",
     "for key in state_dict:\n",
@@ -128,7 +207,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Compressing model: 100%|██████████| 111/111 [00:06<00:00, 17.92it/s]\n"
+      "Compressing model: 100%|██████████| 111/111 [00:00<00:00, 332.63it/s]\n"
      ]
     },
     {
@@ -185,8 +264,8 @@
     "## load the uncompressed safetensors to memory ##\n",
     "state_dict_1 = {}\n",
     "with safe_open('model.safetensors', framework=\"pt\") as f:\n",
-    "   for key in f.keys():\n",
-    "       state_dict_1[key] = f.get_tensor(key)\n",
+    "    for key in f.keys():\n",
+    "        state_dict_1[key] = f.get_tensor(key)\n",
     "\n",
     "## load the compressed-tensors to memory ##\n",
     "config = BitmaskConfig() # we need to specify the method for decompression\n",

--- a/examples/bitmask_compression.ipynb
+++ b/examples/bitmask_compression.ipynb
@@ -15,29 +15,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Collecting hf-transfer\n",
-      "  Downloading hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.7 kB)\n",
-      "Downloading hf_transfer-0.1.9-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.6 MB)\n",
-      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.6/3.6 MB\u001b[0m \u001b[31m80.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25hInstalling collected packages: hf-transfer\n",
-      "Successfully installed hf-transfer-0.1.9\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
-   "source": [
-    "%pip install hf-transfer"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],

--- a/examples/bitmask_compression.ipynb
+++ b/examples/bitmask_compression.ipynb
@@ -34,48 +34,6 @@
    "outputs": [
     {
      "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0ba83d4581e24f358220b00b21a2dec4",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "config.json:   0%|          | 0.00/664 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "db48a2de8ea34c0f9e860bcbc7c6c6a9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "pytorch_model.bin:   0%|          | 0.00/438M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "81d6f18b8a054d2984a9e0cc0ac11a7e",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "generation_config.json:   0%|          | 0.00/119 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
       "text/plain": [
        "LlamaForCausalLM(\n",
        "  (model): LlamaModel(\n",
@@ -108,20 +66,6 @@
      "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "634a76f0b76c4d968e2f77f4523f4be3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "model.safetensors:   0%|          | 0.00/438M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
@@ -133,14 +77,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The example layer model.layers.0.self_attn.q_proj.weight has sparsity 50.00%\n"
+      "The example layer model.layers.0.self_attn.q_proj.weight has sparsity 50%\n"
      ]
     }
    ],
@@ -149,19 +93,19 @@
     "state_dict = model.state_dict()\n",
     "state_dict.keys()\n",
     "example_layer = \"model.layers.0.self_attn.q_proj.weight\"\n",
-    "print(f\"The example layer {example_layer} has sparsity {100 * state_dict[example_layer].eq(0).sum().item() / state_dict[example_layer].numel():.2f}%\")"
+    "print(f\"The example layer {example_layer} has sparsity {100 * state_dict[example_layer].eq(0).sum().item() / state_dict[example_layer].numel():.0f}%\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The model is 31.67% sparse overall\n"
+      "The model is 32% sparse overall\n"
      ]
     }
    ],
@@ -172,19 +116,19 @@
     "for key in state_dict:\n",
     "    total_num_parameters += state_dict[key].numel()\n",
     "    total_num_zero_parameters += state_dict[key].eq(0).sum().item()\n",
-    "print(f\"The model is {total_num_zero_parameters/total_num_parameters*100:.2f}% sparse overall\")"
+    "print(f\"The model is {total_num_zero_parameters/total_num_parameters*100:.0f}% sparse overall\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Compressing model: 100%|██████████| 111/111 [00:00<00:00, 332.63it/s]\n"
+      "Compressing model: 100%|██████████| 111/111 [00:00<00:00, 313.39it/s]\n"
      ]
     },
     {
@@ -224,7 +168,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {

--- a/examples/llama_1.1b/ex_config_quantization.py
+++ b/examples/llama_1.1b/ex_config_quantization.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+
 import torch
 from compressed_tensors.compressors import ModelCompressor
 from compressed_tensors.quantization import (
@@ -23,9 +25,9 @@ from datasets import load_dataset
 from torch.utils.data import DataLoader, RandomSampler
 from tqdm import tqdm
 from transformers import AutoModelForCausalLM, AutoTokenizer, DefaultDataCollator
-from pathlib import Path
 
-config_file = Path(__file__).parent /"example_quant_config.json"
+
+config_file = Path(__file__).parent / "example_quant_config.json"
 model_name = "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T"
 dataset_name = "garage-bAInd/Open-Platypus"
 split = "train"
@@ -76,7 +78,7 @@ with torch.no_grad():
             break
 
 # apply compression
-#TODO this line fails because "fakequant" format is not found in registry
+# TODO this line fails because "fakequant" format is not found in registry
 compressor = ModelCompressor(quantization_config=config)
 compressed_state_dict = compressor.compress(model)
 

--- a/examples/llama_1.1b/ex_config_quantization.py
+++ b/examples/llama_1.1b/ex_config_quantization.py
@@ -95,7 +95,7 @@ def update_scale_zp_hook(
 model.apply(lambda module: module.register_forward_hook(update_scale_zp_hook))
 
 # create dataset
-dataset = load_dataset(dataset_name, split="train[:128]")
+dataset = load_dataset(dataset_name, split=f"train[:num_calibration_samples]")
 tokenizer = AutoTokenizer.from_pretrained(model_name)
 
 

--- a/examples/llama_1.1b/ex_config_quantization.py
+++ b/examples/llama_1.1b/ex_config_quantization.py
@@ -95,7 +95,7 @@ def update_scale_zp_hook(
 model.apply(lambda module: module.register_forward_hook(update_scale_zp_hook))
 
 # create dataset
-dataset = load_dataset(dataset_name, split=f"train[:num_calibration_samples]")
+dataset = load_dataset(dataset_name, split=f"train[:{num_calibration_samples}]")
 tokenizer = AutoTokenizer.from_pretrained(model_name)
 
 

--- a/examples/llama_1.1b/ex_config_quantization.py
+++ b/examples/llama_1.1b/ex_config_quantization.py
@@ -113,7 +113,7 @@ data_loader = DataLoader(
     sampler=RandomSampler(tokenized_dataset),
 )
 
-# run calibration, hook will add scale and zero point where appropriate
+# run calibration, hook will update scales and zero points where applicable
 with torch.no_grad():
     for idx, sample in tqdm(enumerate(data_loader), desc="Running calibration"):
         sample = {k: v.to(model.device) for k, v in sample.items()}

--- a/examples/llama_1.1b/ex_llmcompressor_quantization.py
+++ b/examples/llama_1.1b/ex_llmcompressor_quantization.py
@@ -15,46 +15,27 @@
 ####
 #
 # The following example shows how the example in `ex_config_quantization.py`
-# Can be done with the llm-compressor package in the vllm project
+# can be done within vllm's llm-compressor project
 # Be sure to `pip install llmcompressor` before running
 # See https://github.com/vllm-project/llm-compressor for more information
 #
 ####
 
+from pathlib import Path
+
 import torch
 from llmcompressor.transformers import oneshot
-from llmcompressor.transformers.finetune.data.base import TextGenerationDataset
-from llmcompressor.transformers.finetune.data.data_args import DataTrainingArguments
-from transformers import AutoTokenizer, AutoModelForCausalLM
 
 
-recipe = "example_quant_recipe.yaml"
+recipe = str(Path(__file__).parent / "example_quant_recipe.yaml")
 model_name = "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T"
-dataset_name = "garage-bAInd/Open-Platypus"
+dataset_name = "open_platypus"
 split = "train"
 num_calibration_samples = 512
 max_seq_length = 1024
 pad_to_max_length = False
 output_dir = "./llama1.1b_llmcompressor_quant_out"
-device = "cuda:0" if torch.cuda_is_available() else "cpu"
-
-model = AutoModelForCausalLM.from_pretrained(
-    model_name, device_map=device, torch_dtype="auto"
-)
-
-tokenizer = AutoTokenizer.from_pretrained(model_name)
-data_args = DataTrainingArguments(
-    dataset=dataset_name,
-    max_seq_length=max_seq_length,
-    pad_to_max_length=pad_to_max_length,
-)
-dataset_manager = TextGenerationDataset.load_from_registry(
-    data_args.dataset,
-    data_args=data_args,
-    split=split,
-    tokenizer=tokenizer,
-)
-calib_dataset = dataset_manager.tokenize_and_process(dataset_manager.get_raw_dataset())
+device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
 oneshot(
     model=model_name,

--- a/examples/llama_1.1b/ex_llmcompressor_quantization.py
+++ b/examples/llama_1.1b/ex_llmcompressor_quantization.py
@@ -12,24 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+####
+#
+# The following example shows how the example in `ex_config_quantization.py`
+# Can be done with the llm-compressor package in the vllm project
+# Be sure to `pip install llmcompressor` before running
+# See https://github.com/vllm-project/llm-compressor for more information
+#
+####
+
 import torch
-from sparseml.transformers import SparseAutoModelForCausalLM, oneshot
-from sparseml.transformers.finetune.data.base import TextGenerationDataset
-from sparseml.transformers.finetune.data.data_args import DataTrainingArguments
-from transformers import AutoTokenizer
+from llmcompressor.transformers import oneshot
+from llmcompressor.transformers.finetune.data.base import TextGenerationDataset
+from llmcompressor.transformers.finetune.data.data_args import DataTrainingArguments
+from transformers import AutoTokenizer, AutoModelForCausalLM
 
 
 recipe = "example_quant_recipe.yaml"
 model_name = "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T"
-dataset_name = "open_platypus"
+dataset_name = "garage-bAInd/Open-Platypus"
 split = "train"
 num_calibration_samples = 512
 max_seq_length = 1024
 pad_to_max_length = False
-output_dir = "./llama1.1b_old_quant_out"
+output_dir = "./llama1.1b_llmcompressor_quant_out"
 device = "cuda:0" if torch.cuda_is_available() else "cpu"
 
-model = SparseAutoModelForCausalLM.from_pretrained(
+model = AutoModelForCausalLM.from_pretrained(
     model_name, device_map=device, torch_dtype="auto"
 )
 

--- a/examples/llama_1.1b/ex_sparseml_quantization.py
+++ b/examples/llama_1.1b/ex_sparseml_quantization.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from sparseml.transformers import oneshot, SparseAutoModelForCausalLM
-from sparseml.transformers.finetune.data.data_args import DataTrainingArguments
-from sparseml.transformers.finetune.data.base import TextGenerationDataset
-from transformers import AutoTokenizer
 import torch
+from sparseml.transformers import SparseAutoModelForCausalLM, oneshot
+from sparseml.transformers.finetune.data.base import TextGenerationDataset
+from sparseml.transformers.finetune.data.data_args import DataTrainingArguments
+from transformers import AutoTokenizer
+
 
 recipe = "example_quant_recipe.yaml"
 model_name = "TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T"
@@ -28,7 +29,9 @@ pad_to_max_length = False
 output_dir = "./llama1.1b_old_quant_out"
 device = "cuda:0" if torch.cuda_is_available() else "cpu"
 
-model = SparseAutoModelForCausalLM.from_pretrained(model_name, device_map=device, torch_dtype="auto")
+model = SparseAutoModelForCausalLM.from_pretrained(
+    model_name, device_map=device, torch_dtype="auto"
+)
 
 tokenizer = AutoTokenizer.from_pretrained(model_name)
 data_args = DataTrainingArguments(
@@ -42,17 +45,15 @@ dataset_manager = TextGenerationDataset.load_from_registry(
     split=split,
     tokenizer=tokenizer,
 )
-calib_dataset = dataset_manager.tokenize_and_process(
-    dataset_manager.get_raw_dataset()
-)
+calib_dataset = dataset_manager.tokenize_and_process(dataset_manager.get_raw_dataset())
 
 oneshot(
     model=model_name,
     dataset=dataset_name,
     output_dir=output_dir,
     overwrite_output_dir=True,
-    max_seq_length = max_seq_length,
+    max_seq_length=max_seq_length,
     num_calibration_samples=num_calibration_samples,
     recipe=recipe,
-    pad_to_max_length=pad_to_max_length
+    pad_to_max_length=pad_to_max_length,
 )

--- a/examples/llama_1.1b/example_quant_config.json
+++ b/examples/llama_1.1b/example_quant_config.json
@@ -1,6 +1,6 @@
 {
 	"quant_method": "compressed-tensors",
-	"format": "fakequant",
+	"format": "naive-quantized",
 	"global_compression_ratio": null,
 	"config_groups": {
         "group_1": {
@@ -13,20 +13,10 @@
             "input_activations": {
                 "num_bits": 8,
                 "type": "int",
-                "symmetric": false,
-                "strategy": "tensor"
-            },
-            "targets": ["Linear"]
-        },
-        "group_2": {
-            "weights": {
-                "num_bits": 8,
-                "type": "int",
                 "symmetric": true,
                 "strategy": "tensor"
             },
-            "targets": ["Embedding"]
+            "targets": ["Linear"]
         }
-    },
-	"ignore": ["model.layers.0.mlp.down_proj"]
+    }
 }

--- a/examples/quantize_and_pack_int4.ipynb
+++ b/examples/quantize_and_pack_int4.ipynb
@@ -8,14 +8,14 @@
     "\n",
     "Using compressed-tensors, we can compress a quantized model to store it more efficiently on disk.\n",
     "\n",
-    "In this example, we run post-training quantization (PTQ) to quantize the weights of an example model to 4 bits. We then save a compressed version of the model on disk b packing each group of eight 4-bit weights into a single int32\n",
+    "In this example, we run post-training quantization (PTQ) to quantize the weights of an example model to 4 bits. We then save a compressed version of the model on disk by packing each group of eight 4-bit weights into a single int32\n",
     "\n",
     "By packing groups of eight 4-bit weights into a single int32, we can store a quantized model more efficiently on disk."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,6 @@
     "    QuantizationConfig,\n",
     "    QuantizationStatus,\n",
     "    apply_quantization_config,\n",
-    "    freeze_module_quantization,\n",
     "    compress_quantized_weights\n",
     ")\n",
     "from compressed_tensors.compressors import ModelCompressor\n",
@@ -38,9 +37,87 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c883cdc8ecd04866bd01d61796b81c26",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "config.json:   0%|          | 0.00/560 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "32b18b14b6774ce7b61d2854a1ed5f49",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model.safetensors:   0%|          | 0.00/4.40G [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "370c6d18521a4b65833a411728be1ed7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "generation_config.json:   0%|          | 0.00/129 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "LlamaForCausalLM(\n",
+       "  (model): LlamaModel(\n",
+       "    (embed_tokens): Embedding(32000, 2048)\n",
+       "    (layers): ModuleList(\n",
+       "      (0-21): 22 x LlamaDecoderLayer(\n",
+       "        (self_attn): LlamaAttention(\n",
+       "          (q_proj): Linear(in_features=2048, out_features=2048, bias=False)\n",
+       "          (k_proj): Linear(in_features=2048, out_features=256, bias=False)\n",
+       "          (v_proj): Linear(in_features=2048, out_features=256, bias=False)\n",
+       "          (o_proj): Linear(in_features=2048, out_features=2048, bias=False)\n",
+       "        )\n",
+       "        (mlp): LlamaMLP(\n",
+       "          (gate_proj): Linear(in_features=2048, out_features=5632, bias=False)\n",
+       "          (up_proj): Linear(in_features=2048, out_features=5632, bias=False)\n",
+       "          (down_proj): Linear(in_features=5632, out_features=2048, bias=False)\n",
+       "          (act_fn): SiLU()\n",
+       "        )\n",
+       "        (input_layernorm): LlamaRMSNorm((2048,), eps=1e-05)\n",
+       "        (post_attention_layernorm): LlamaRMSNorm((2048,), eps=1e-05)\n",
+       "      )\n",
+       "    )\n",
+       "    (norm): LlamaRMSNorm((2048,), eps=1e-05)\n",
+       "    (rotary_emb): LlamaRotaryEmbedding()\n",
+       "  )\n",
+       "  (lm_head): Linear(in_features=2048, out_features=32000, bias=False)\n",
+       ")"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# load a dense, unquantized tiny llama model\n",
     "device = \"cuda:0\"\n",
@@ -57,12 +134,12 @@
     "\n",
     "The `format` argument is set to `pack-quantized`, indicating that when the model is saved we should use the `PackedQuantizationCompressor` which will pack every eight 4-bit weights into an `int32`. \n",
     "\n",
-    "This will give us a compression ratio of 4x on each Linear layer compared to the unquantized `float16` representation"
+    "This will give us a compression ratio of 8x on each Linear layer compared to the unquantized `float32` representation"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,7 +183,7 @@
    "source": [
     "# create a dataloader of calibration data\n",
     "\n",
-    "dataset = load_dataset(\"ptb_text_only\")[\"train\"]\n",
+    "dataset = load_dataset(\"ptb_text_only\", trust_remote_code=True)[\"train\"]\n",
     "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
     "\n",
     "def tokenize_function(examples):\n",
@@ -121,9 +198,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Running calibration: 512it [00:33, 15.42it/s]\n"
+     ]
+    }
+   ],
    "source": [
     "# calibrate scale and zero points for quantization using a small amount of train data\n",
     "num_calibration_samples = 512\n",
@@ -137,7 +222,7 @@
     "            break\n",
     "\n",
     "# freeze scale and zero points after calibration\n",
-    "model.apply(freeze_module_quantization)"
+    "# model.apply(freeze_module_quantization)"
    ]
   },
   {
@@ -153,9 +238,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scale: tensor([17296.], device='cuda:4', dtype=torch.float16), Zero Point: tensor([0], device='cuda:4', dtype=torch.int8)\n",
+      "Weight min: -1.587890625 max: 1.0283203125 dtype: torch.float16\n"
+     ]
+    }
+   ],
    "source": [
     "state_dict = model.state_dict()\n",
     "example_layer = \"model.layers.0.self_attn.q_proj.weight\"\n",
@@ -168,9 +262,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scale: tensor([17296.], device='cuda:4', dtype=torch.float16), Zero Point: tensor([0], device='cuda:4', dtype=torch.int8)\n",
+      "Weight min: 0 max: 0 dtype: torch.int8\n"
+     ]
+    }
+   ],
    "source": [
     "# convert quantized weights to integers\n",
     "model.apply(compress_quantized_weights)\n",
@@ -195,9 +298,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Compression format: pack-quantized\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Quantized Compression: 100%|██████████| 509/509 [00:03<00:00, 153.70it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Size of the model's weights on disk using safetensors: 712.23 MB\n"
+     ]
+    }
+   ],
    "source": [
     "# apply compression and save the model to disk\n",
     "\n",


### PR DESCRIPTION
After running some of the examples and discussing with Kyle, proposing some alterations to the examples provided in `compresed_tensors`. I updated the examples so that one is QDQ, one is compression using only compressed-tensors, and the last shows llm-compressor. A comment has been added at the top of each file to explain.

This refactor resolves the question around whether `freeze_module_quantization` should be moved. It's no longer needed

Other maintenance to do after merging this into Kyle's PR
- Add CI/CD to test example/notebook files as PR checks