### PR TITLE
Update build workflow to Python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
 
             - name: build
               id: build
-              uses: neuralmagic/nm-actions/actions/build-ml-whl@v1.12.0
+              uses: neuralmagic/nm-actions/actions/build-ml-whl@support-py312-build
               with:
                   dev: false
                   release: ${{ inputs.wf_category == 'RELEASE' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
 
             - name: build
               id: build
-              uses: neuralmagic/nm-actions/actions/build-ml-whl@support-py312-build
+              uses: neuralmagic/nm-actions/actions/build-ml-whl@v1.12.0
               with:
                   dev: false
                   release: ${{ inputs.wf_category == 'RELEASE' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
             - name: set python
               uses: actions/setup-python@v4
               with:
-                  python-version: '3.10'
+                  python-version: '3.12'
 
             - name: checkout code
               id: checkout
@@ -88,7 +88,7 @@ jobs:
 
             - name: build
               id: build
-              uses: neuralmagic/nm-actions/actions/build-ml-whl@v1.6.0
+              uses: neuralmagic/nm-actions/actions/build-ml-whl@v1.12.0
               with:
                   dev: false
                   release: ${{ inputs.wf_category == 'RELEASE' }}


### PR DESCRIPTION
This PR updates the build workflow to use Python 3.12 (and a matching updated `nm-action`) so that the tarball that gets produced will have a filename compliant with [PEP-625](https://peps.python.org/pep-0625/).

**TODO**
- [x] Switch nm-action ref to tagged version once neuralmagic/nm-actions#43 lands and is tagged