### PR TITLE
Replace `COMPRESSION_PARAM_NAMES` with Abstract Property

### DIFF
--- a/src/compressed_tensors/compressors/base.py
+++ b/src/compressed_tensors/compressors/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Dict, Generator, List, Optional, Tuple, Union
+from typing import Dict, Generator, Optional, Tuple, Union
 
 import torch
 from compressed_tensors.config import SparsityCompressionConfig
@@ -79,9 +79,9 @@ class BaseCompressor(RegistryMixin, ABC):
 
     @property
     @abstractmethod
-    def compression_param_names(self) -> List[str]:
+    def compression_param_names(self) -> Tuple[str]:
         """
-        Returns a list of compression parameter names introduced by
+        Returns a tuple of compression parameter names introduced by
         the compressor during compression
         """
         raise NotImplementedError()

--- a/src/compressed_tensors/compressors/base.py
+++ b/src/compressed_tensors/compressors/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Dict, Generator, Optional, Tuple, Union
+from typing import Dict, Generator, List, Optional, Tuple, Union
 
 import torch
 from compressed_tensors.config import SparsityCompressionConfig
@@ -74,6 +74,15 @@ class BaseCompressor(RegistryMixin, ABC):
         :param weight_shape: uncompressed weight shape
         :param quantization_args: quantization parameters for the weight
         :return: dictionary mapping compressed parameter names to shape and dtype
+        """
+        raise NotImplementedError()
+
+    @property
+    @abstractmethod
+    def compression_param_names(self) -> List[str]:
+        """
+        Returns a list of compression parameter names introduced by
+        the compressor during compression
         """
         raise NotImplementedError()
 

--- a/src/compressed_tensors/compressors/quantized_compressors/base.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/base.py
@@ -144,7 +144,7 @@ class BaseQuantizationCompressor(BaseCompressor):
 
     def _decompress_from_path(self, path_to_model, names_to_scheme, device):
         weight_mappings = get_nested_weight_mappings(
-            path_to_model, self.COMPRESSION_PARAM_NAMES
+            path_to_model, self.compression_param_names
         )
         for weight_name in weight_mappings.keys():
             weight_data = {}
@@ -161,7 +161,7 @@ class BaseQuantizationCompressor(BaseCompressor):
 
     def _decompress_from_state_dict(self, state_dict, names_to_scheme):
         weight_mappings = get_nested_mappings_from_state_dict(
-            state_dict, self.COMPRESSION_PARAM_NAMES
+            state_dict, self.compression_param_names
         )
         for weight_name in weight_mappings.keys():
             weight_data = {}

--- a/src/compressed_tensors/compressors/quantized_compressors/naive_quantized.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/naive_quantized.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import torch
 from compressed_tensors.compressors.base import BaseCompressor
@@ -47,6 +47,14 @@ class NaiveQuantizationCompressor(BaseQuantizationCompressor):
         "weight_zero_point",
         "weight_g_idx",
     ]
+
+    @property
+    def compression_param_names(self) -> List[str]:
+        """
+        Returns a list of compression parameter names introduced by
+        the compressor during compression
+        """
+        return self.COMPRESSION_PARAM_NAMES
 
     def compression_param_info(
         self,

--- a/src/compressed_tensors/compressors/quantized_compressors/naive_quantized.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/naive_quantized.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import torch
 from compressed_tensors.compressors.base import BaseCompressor
@@ -41,20 +41,18 @@ class NaiveQuantizationCompressor(BaseQuantizationCompressor):
     type to the type specified by the layer's QuantizationArgs.
     """
 
-    COMPRESSION_PARAM_NAMES = [
-        "weight",
-        "weight_scale",
-        "weight_zero_point",
-        "weight_g_idx",
-    ]
-
     @property
-    def compression_param_names(self) -> List[str]:
+    def compression_param_names(self) -> Tuple[str]:
         """
-        Returns a list of compression parameter names introduced by
+        Returns a tuple of compression parameter names introduced by
         the compressor during compression
         """
-        return self.COMPRESSION_PARAM_NAMES
+        return (
+            "weight",
+            "weight_scale",
+            "weight_zero_point",
+            "weight_g_idx",
+        )
 
     def compression_param_info(
         self,

--- a/src/compressed_tensors/compressors/quantized_compressors/pack_quantized.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/pack_quantized.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import math
-from typing import Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -43,6 +43,14 @@ class PackedQuantizationCompressor(BaseQuantizationCompressor):
         "weight_g_idx",
         "weight_shape",
     ]
+
+    @property
+    def compression_param_names(self) -> List[str]:
+        """
+        Returns a list of compression parameter names introduced by
+        the compressor during compression
+        """
+        return self.COMPRESSION_PARAM_NAMES
 
     def compression_param_info(
         self,

--- a/src/compressed_tensors/compressors/quantized_compressors/pack_quantized.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/pack_quantized.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import math
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import numpy as np
 import torch
@@ -36,21 +36,19 @@ class PackedQuantizationCompressor(BaseQuantizationCompressor):
     Compresses a quantized model by packing every eight 4-bit weights into an int32
     """
 
-    COMPRESSION_PARAM_NAMES = [
-        "weight_packed",
-        "weight_scale",
-        "weight_zero_point",
-        "weight_g_idx",
-        "weight_shape",
-    ]
-
     @property
-    def compression_param_names(self) -> List[str]:
+    def compression_param_names(self) -> Tuple[str]:
         """
-        Returns a list of compression parameter names introduced by
+        Returns a tuple of compression parameter names introduced by
         the compressor during compression
         """
-        return self.COMPRESSION_PARAM_NAMES
+        return (
+            "weight_packed",
+            "weight_scale",
+            "weight_zero_point",
+            "weight_g_idx",
+            "weight_shape",
+        )
 
     def compression_param_info(
         self,

--- a/src/compressed_tensors/compressors/sparse_compressors/base.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/base.py
@@ -30,8 +30,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 class BaseSparseCompressor(BaseCompressor):
     """
     Base class representing a sparse compression algorithm. Each child class should
-    implement compression_param_info, compress_weight and decompress_weight; child
-    classes should also define COMPRESSION_PARAM_NAMES.
+    implement compression_param_names, compress_weight and decompress_weight;
 
     Compressors support compressing/decompressing a full module state dict or a single
     quantized PyTorch leaf module.
@@ -113,7 +112,7 @@ class BaseSparseCompressor(BaseCompressor):
         """
         weight_mappings, ignored_params = get_nested_weight_mappings(
             path_to_model_or_tensors,
-            self.COMPRESSION_PARAM_NAMES,
+            self.compression_param_names,
             return_unmatched_params=True,
         )
         for weight_name in weight_mappings.keys():

--- a/src/compressed_tensors/compressors/sparse_compressors/dense.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/dense.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Generator, Tuple
+from typing import Dict, Generator, List, Tuple
 
 from compressed_tensors.compressors.base import BaseCompressor
 from compressed_tensors.config import CompressionFormat
@@ -24,6 +24,14 @@ class DenseCompressor(BaseCompressor):
     """
     Identity compressor for dense models, returns the original state_dict
     """
+
+    @property
+    def compression_param_names(self) -> List[str]:
+        """
+        Returns a list of compression parameter names introduced by
+        the compressor during compression
+        """
+        return []
 
     def compress(self, model_state: Dict[str, Tensor], **kwargs) -> Dict[str, Tensor]:
         return model_state

--- a/src/compressed_tensors/compressors/sparse_compressors/dense.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/dense.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, Generator, List, Tuple
+from typing import Dict, Generator, Tuple
 
 from compressed_tensors.compressors.base import BaseCompressor
 from compressed_tensors.config import CompressionFormat
@@ -26,12 +26,12 @@ class DenseCompressor(BaseCompressor):
     """
 
     @property
-    def compression_param_names(self) -> List[str]:
+    def compression_param_names(self) -> Tuple[str]:
         """
-        Returns a list of compression parameter names introduced by
+        Returns a tuple of compression parameter names introduced by
         the compressor during compression
         """
-        return []
+        return ()
 
     def compress(self, model_state: Dict[str, Tensor], **kwargs) -> Dict[str, Tensor]:
         return model_state

--- a/src/compressed_tensors/compressors/sparse_compressors/sparse_24_bitmask.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/sparse_24_bitmask.py
@@ -46,6 +46,14 @@ class Sparse24BitMaskCompressor(BaseSparseCompressor):
         "bitmask",
     ]
 
+    @property
+    def compression_param_names(self) -> List[str]:
+        """
+        Returns a list of compression parameter names introduced by
+        the compressor during compression
+        """
+        return self.COMPRESSION_PARAM_NAMES
+
     def compress_weight(self, name, value):
         bitmask_tensor = Sparse24BitMaskTensor.from_dense(
             value, self.config.sparsity_structure

--- a/src/compressed_tensors/compressors/sparse_compressors/sparse_24_bitmask.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/sparse_24_bitmask.py
@@ -40,19 +40,17 @@ class Sparse24BitMaskCompressor(BaseSparseCompressor):
     values tensor, with their locations stored in a 2d bitmask
     """
 
-    COMPRESSION_PARAM_NAMES = [
-        "shape",
-        "compressed",
-        "bitmask",
-    ]
-
     @property
-    def compression_param_names(self) -> List[str]:
+    def compression_param_names(self) -> Tuple[str]:
         """
-        Returns a list of compression parameter names introduced by
+        Returns a tuple of compression parameter names introduced by
         the compressor during compression
         """
-        return self.COMPRESSION_PARAM_NAMES
+        return (
+            "shape",
+            "compressed",
+            "bitmask",
+        )
 
     def compress_weight(self, name, value):
         bitmask_tensor = Sparse24BitMaskTensor.from_dense(

--- a/src/compressed_tensors/compressors/sparse_compressors/sparse_bitmask.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/sparse_bitmask.py
@@ -40,6 +40,14 @@ class BitmaskCompressor(BaseSparseCompressor):
 
     COMPRESSION_PARAM_NAMES = ["shape", "compressed", "bitmask", "row_offsets"]
 
+    @property
+    def compression_param_names(self) -> List[str]:
+        """
+        Returns a list of compression parameter names introduced by
+        the compressor during compression
+        """
+        return self.COMPRESSION_PARAM_NAMES
+
     def compress_weight(self, name, value):
         bitmask_tensor = BitmaskTensor.from_dense(value)
         bitmask_dict = bitmask_tensor.dict(name_prefix=name, device="cpu")

--- a/src/compressed_tensors/compressors/sparse_compressors/sparse_bitmask.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/sparse_bitmask.py
@@ -38,15 +38,13 @@ class BitmaskCompressor(BaseSparseCompressor):
     values tensor, with their locations stored in a 2d bitmask
     """
 
-    COMPRESSION_PARAM_NAMES = ["shape", "compressed", "bitmask", "row_offsets"]
-
     @property
-    def compression_param_names(self) -> List[str]:
+    def compression_param_names(self) -> Tuple[str]:
         """
-        Returns a list of compression parameter names introduced by
+        Returns a tuple of compression parameter names introduced by
         the compressor during compression
         """
-        return self.COMPRESSION_PARAM_NAMES
+        return ("shape", "compressed", "bitmask", "row_offsets")
 
     def compress_weight(self, name, value):
         bitmask_tensor = BitmaskTensor.from_dense(value)

--- a/src/compressed_tensors/compressors/sparse_quantized_compressors/marlin_24.py
+++ b/src/compressed_tensors/compressors/sparse_quantized_compressors/marlin_24.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Dict, Generator, Tuple
+from typing import Dict, Generator, List, Tuple
 
 import numpy as np
 import torch
@@ -104,6 +104,14 @@ class Marlin24Compressor(BaseCompressor):
             )
 
         return True
+
+    @property
+    def compression_param_names(self) -> List[str]:
+        """
+        Returns a list of compression parameter names introduced by
+        the compressor during compression
+        """
+        return self.COMPRESSION_PARAM_NAMES
 
     def compress(
         self,

--- a/src/compressed_tensors/compressors/sparse_quantized_compressors/marlin_24.py
+++ b/src/compressed_tensors/compressors/sparse_quantized_compressors/marlin_24.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import logging
-from typing import Dict, Generator, List, Tuple
+from typing import Dict, Generator, Tuple
 
 import numpy as np
 import torch
@@ -41,8 +41,6 @@ class Marlin24Compressor(BaseCompressor):
     Compresses a quantized model with 2:4 sparsity structure for inference with the
     Marlin24 kernel. Decompression is not implemented for this compressor.
     """
-
-    COMPRESSION_PARAM_NAMES = ["weight_packed", "scale_packed", "meta"]
 
     @staticmethod
     def validate_quant_compatability(
@@ -106,12 +104,12 @@ class Marlin24Compressor(BaseCompressor):
         return True
 
     @property
-    def compression_param_names(self) -> List[str]:
+    def compression_param_names(self) -> Tuple[str]:
         """
-        Returns a list of compression parameter names introduced by
+        Returns a tuple of compression parameter names introduced by
         the compressor during compression
         """
-        return self.COMPRESSION_PARAM_NAMES
+        return ("weight_packed", "scale_packed", "meta")
 
     def compress(
         self,

--- a/src/compressed_tensors/utils/safetensors_load.py
+++ b/src/compressed_tensors/utils/safetensors_load.py
@@ -16,7 +16,7 @@ import json
 import os
 import re
 import struct
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, Iterable, Optional, Tuple, Union
 
 from safetensors import safe_open
 from torch import Tensor
@@ -180,7 +180,9 @@ def get_weight_mappings(path_to_model_or_tensors: str) -> Dict[str, str]:
 
 
 def get_nested_weight_mappings(
-    model_path: str, params_to_nest: List[str], return_unmatched_params: bool = False
+    model_path: str,
+    params_to_nest: Iterable[str],
+    return_unmatched_params: bool = False,
 ) -> Union[NestedWeightMappingType, Tuple[NestedWeightMappingType, WeightMappingType]]:
     """
     Takes a path to a state dict saved in safetensors format and returns a nested
@@ -211,7 +213,7 @@ def get_nested_weight_mappings(
 
     :param model_path: Path to the safetensors state dict, must contain either a
         single safetensors file or multiple files with an index.
-    :param params_to_nest: List of parameter names to nest.
+    :param params_to_nest: Iterable of parameter names to nest.
     :param return_unmatched_params: If True, return a second dictionary containing
         the remaining parameters that were not matched to the params_to_nest.
     :return:
@@ -247,7 +249,7 @@ def get_nested_weight_mappings(
 
 
 def get_nested_mappings_from_state_dict(
-    state_dict, params_to_nest
+    state_dict, params_to_nest: Iterable[str]
 ) -> NestedWeightMappingType:
     """
     Takes a state dict and returns a nested mapping from uncompressed
@@ -262,7 +264,7 @@ def get_nested_mappings_from_state_dict(
     }
 
     :param state_dict: state dict of the model
-    :param params_to_nest: List of parameter names to nest.
+    :param params_to_nest: Iterable of parameter names to nest.
     :return: Nested mapping of parameterized layer names to the value of
         each layer's compression parameters.
     """

--- a/tests/test_compressors/sparse_quantized_compressors/test_marlin_24.py
+++ b/tests/test_compressors/sparse_quantized_compressors/test_marlin_24.py
@@ -111,6 +111,6 @@ def test_marlin24_format(
         state_dict[f"{NOT_QUANT_NAME}.weight"],
         compressed_state_dict[f"{NOT_QUANT_NAME}.weight"],
     )
-    for param_name in compressor.COMPRESSION_PARAM_NAMES:
+    for param_name in compressor.compression_param_names:
         full_param_name = merge_names(QUANT_NAME, param_name)
         assert full_param_name in compressed_state_dict


### PR DESCRIPTION
This PR **removes the class variable** `COMPRESSION_PARAM_NAMES` and replaces it with an **abstract property** `compression_param_names`, ensuring all compressors explicitly define it.  

#### Why This Change?
- **Prevents Mutation** – Previously, `COMPRESSION_PARAM_NAMES` could be modified at runtime. Now, `compression_param_names` is a property, enforcing immutability.  
- **Ensures Implementation** – All subclasses **must** define `compression_param_names`, avoiding missing implementations.  
- **Improves Interoperability** – External frameworks like `huggingface/transformers` can reliably check expected parameters, especially when handling **stacked compressors**.  These framework(s) can now access a property
enforced via a contract rather than rely on a class variable which may or may not have been implemented.

#### Key Changes 
✅ Removed `COMPRESSION_PARAM_NAMES` from all compressors.  
✅ Added `compression_param_names` as an **abstract property** in `BaseCompressor`.  
✅ Implemented `compression_param_names` for all existing compressors.  
✅ Updated `get_nested_weight_mappings` and related utils typing to accept `Iterable[str]` over `List[str`.  
✅ Updated tests to check for `compression_param_names`.

#### **Usage Examples**  

**Accessing Compression Parameter Names + Error on Assignment**  
```python
>>> from compressed_tensors.compressors import BaseCompressor
>>> compressor = BaseCompressor.load_from_registry("naive_quantized")
>>> compressor.compression_param_names
('weight', 'weight_scale', 'weight_zero_point', 'weight_g_idx')

>>> compressor.compression_param_names = ("something_else")
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[4], line 1
----> 1 compressor.compression_param_names = ("something_else")

AttributeError: can't set attribute 'compression_param_names'
```
