### PR TITLE
Add: missing and unexpected keys in ModelCompressor

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -308,10 +308,14 @@ class ModelCompressor:
         :param model: The PyTorch model to check for unexpected keys.
         :return: A list of extra keys introduced by the compression process.
         """
+
         unexpected_keys = set()
 
         # Identify unexpected keys from sparsity compression
-        if self.sparsity_compressor:
+        if (
+            self.sparsity_compressor
+            and self.sparsity_config.format != CompressionFormat.dense.value
+        ):
             sparse_targets: Set[str] = expand_target_names(
                 model=model,
                 targets=self.sparsity_config.targets,

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -260,8 +260,13 @@ class ModelCompressor:
 
     def get_missing_module_keys(self, model: Module) -> List[str]:
         """
-        Identifies the expected missing keys in the compressed state_dict
-        based on the model structure and applied compression techniques.
+        Identifies the expected missing weight keys in the compressed state_dict.
+
+        When a model undergoes sparsity or quantization compression, certain
+        weight tensors may be absent from the checkpoint by virtue of compression.
+        This function determines which weight keys are missing based on the
+        applied compression techniques.
+
 
         :param model: The PyTorch model to check for missing keys.
         :return: A list of missing keys expected in the compressed state_dict.
@@ -302,11 +307,21 @@ class ModelCompressor:
 
     def get_unexpected_file_keys(self, model: Module) -> List[str]:
         """
-        Identifies extra keys introduced by the compressor(s) in the
+        Identifies extra keys introduced by the compression process in the
         compressed state_dict that are not expected by the model graph.
 
+        During sparsity or quantization compression, additional metadata or
+        auxiliary parameters may be stored in the checkpoint, which do not
+        correspond to any parameter in the original model. These keys are
+        typically introduced to support the reconstruction of compressed weights.
+
+        For example, Sparse24Bitmask compression may introduce keys such as
+        'compressed', 'bitmask', and 'shape' in the checkpoint, which are
+        not part of the original model parameters.
+
         :param model: The PyTorch model to check for unexpected keys.
-        :return: A list of extra keys introduced by the compression process.
+        :return: A list of extra keys introduced by the compression process
+                that are not expected by the model.
         """
 
         unexpected_keys = set()

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -52,8 +52,8 @@ __all__ = [
     "apply_quantization_config",
     "apply_quantization_status",
     "find_name_or_class_matches",
-    "expand_sparse_target_names",
-    "is_sparse_target",
+    "expand_target_names",
+    "is_target",
 ]
 
 from compressed_tensors.quantization.utils.helpers import is_module_quantized
@@ -247,7 +247,7 @@ def apply_quantization_status(model: Module, status: QuantizationStatus):
         model.apply(compress_quantized_weights)
 
 
-def expand_sparse_target_names(
+def expand_target_names(
     model: Module, targets: Iterable[str], ignore: Iterable[str]
 ) -> Set[str]:
     """
@@ -265,11 +265,11 @@ def expand_sparse_target_names(
     return {
         name
         for name, module in iter_named_leaf_modules(model)
-        if is_sparse_target(name, module, targets, ignore)
+        if is_target(name, module, targets, ignore)
     }
 
 
-def is_sparse_target(
+def is_target(
     name: str, module: Module, targets: Iterable[str], ignore: Iterable[str]
 ) -> bool:
     """

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -248,7 +248,9 @@ def apply_quantization_status(model: Module, status: QuantizationStatus):
 
 
 def expand_target_names(
-    model: Module, targets: Iterable[str], ignore: Iterable[str]
+    model: Module,
+    targets: Optional[Iterable[str]] = None,
+    ignore: Optional[Iterable[str]] = None,
 ) -> Set[str]:
     """
     Finds all unique module names in the model that match the given
@@ -257,8 +259,8 @@ def expand_target_names(
     Note: Targets must be regexes, layer types, or full layer names.
 
     :param model: model to search for targets in
-    :param targets: list of targets to search for
-    :param ignore: list of targets to ignore
+    :param targets: Iterable of targets to search for
+    :param ignore: Iterable of targets to ignore
     :return: set of all targets that match the given targets and should
         not be ignored
     """
@@ -270,7 +272,10 @@ def expand_target_names(
 
 
 def is_target(
-    name: str, module: Module, targets: Iterable[str], ignore: Iterable[str]
+    name: str,
+    module: Module,
+    targets: Optional[Iterable[str]] = None,
+    ignore: Optional[Iterable[str]] = None,
 ) -> bool:
     """
     Determines if a module should be included in the targets based on the
@@ -280,12 +285,12 @@ def is_target(
 
     :param name: name of the module
     :param module: the module itself
-    :param targets: list of targets to search for
-    :param ignore: list of targets to ignore
+    :param targets: Iterable of targets to search for
+    :param ignore: Iterable of targets to ignore
     :return: True if the module is a target and not ignored, False otherwise
     """
     return bool(
-        find_name_or_class_matches(name, module, targets)
+        find_name_or_class_matches(name, module, targets or [])
         and not find_name_or_class_matches(name, module, ignore or [])
     )
 

--- a/tests/test_compressors/model_compressors/test_model_compressor.py
+++ b/tests/test_compressors/model_compressors/test_model_compressor.py
@@ -18,9 +18,10 @@ from pathlib import Path
 
 import pytest
 import torch
+import torch.nn as nn
 from compressed_tensors.compressors import ModelCompressor
-from compressed_tensors.config.base import SparsityCompressionConfig
-from compressed_tensors.quantization.quant_config import QuantizationConfig
+from compressed_tensors.config import SparsityCompressionConfig
+from compressed_tensors.quantization import QuantizationConfig
 from safetensors.torch import save_file
 from tests.testing_utils import induce_sparsity, requires_hf_quantizer
 
@@ -115,44 +116,38 @@ def test_hf_compressor_tensors_config(s_config, q_config, tmp_path):
     )
 
 
-@pytest.fixture
-def fake_model_class():
-    import torch.nn as nn
+class DummyLinearModel(nn.Module):
+    def __init__(self, weights, weight_scale=None, weight_zero_point=None):
+        super(DummyLinearModel, self).__init__()
+        out_features, in_features = weights.shape
 
-    class CustomLinearModel(nn.Module):
-        def __init__(self, weights, weight_scale=None, weight_zero_point=None):
-            super(CustomLinearModel, self).__init__()
-            out_features, in_features = weights.shape
+        # Define a linear layer without bias
+        self.linear = nn.Linear(in_features, out_features, bias=False)
 
-            # Define a linear layer without bias
-            self.linear = nn.Linear(in_features, out_features, bias=False)
+        # Set the weights of the linear layer
+        self.linear.weight = nn.Parameter(weights, requires_grad=False)
 
-            # Set the weights of the linear layer
-            self.linear.weight = nn.Parameter(weights, requires_grad=False)
+        # Attach weight_scale and weight_zero_point as parameters
+        if weight_scale is not None:
+            self.linear.weight_scale = nn.Parameter(
+                torch.tensor(weight_scale), requires_grad=False
+            )
+        if weight_zero_point is not None:
+            self.linear.weight_zero_point = nn.Parameter(
+                torch.tensor(weight_zero_point), requires_grad=False
+            )
 
-            # Attach weight_scale and weight_zero_point as parameters
-            if weight_scale is not None:
-                self.linear.weight_scale = nn.Parameter(
-                    torch.tensor(weight_scale), requires_grad=False
-                )
-            if weight_zero_point is not None:
-                self.linear.weight_zero_point = nn.Parameter(
-                    torch.tensor(weight_zero_point), requires_grad=False
-                )
-
-        def forward(self, x):
-            return self.linear(x)
-
-    return CustomLinearModel
+    def forward(self, x):
+        return self.linear(x)
 
 
-def get_bitmask_sparsity_config():
+def get_bitmask_sparsity_config(targets=["Linear"]):
     from compressed_tensors import BitmaskConfig
 
     return BitmaskConfig(
         format="sparse-bitmask",
         global_sparsity=0.7,
-        targets=["Linear"],
+        targets=targets,
         sparsity_structure="unstructured",
     )
 
@@ -187,35 +182,12 @@ def create_quantization_config(bits=8, type="int", strategy="tensor"):
         create_quantization_config(bits=8, type="float", strategy="channel"),
     ],
 )
-def test_composability(
-    tmp_path, fake_model_class, sparsity_config, quantization_config
-):
-    from compressed_tensors.quantization.lifecycle.forward import quantize
+def test_composability(tmp_path, sparsity_config, quantization_config):
 
-    weights = torch.rand(10, 5)
-    sparse_weights = induce_sparsity(weights, sparsity_config.global_sparsity)
-
-    quantization_args = quantization_config.config_groups["group_0"].weights
-
-    if quantization_args.strategy == "channel":
-        scale = torch.ones((weights.shape[0], 1))
-    elif quantization_args.strategy == "tensor":
-        scale = torch.tensor([1.0])
-
-    zero_point = torch.zeros_like(scale)
-
-    quantized_weights = quantize(
-        sparse_weights,
-        scale=scale,
-        zero_point=zero_point,
-        args=quantization_args,
-    )
-
-    fake_oneshot_model = fake_model_class(quantized_weights, scale, zero_point)
-    fake_oneshot_model.linear.quantization_scheme = quantization_config.config_groups[
-        "group_0"
-    ]
     model_compressor = ModelCompressor(
+        sparsity_config=sparsity_config, quantization_config=quantization_config
+    )
+    fake_oneshot_model: DummyLinearModel = _get_fake_oneshot_sparse_quantized_model(
         sparsity_config=sparsity_config, quantization_config=quantization_config
     )
     # does both sparse and quantization compression
@@ -226,7 +198,9 @@ def test_composability(
         compressed_state_dict, save_dir, model_compressor
     )
 
-    decompressed_model = fake_model_class(torch.zeros_like(weights))
+    decompressed_model = DummyLinearModel(
+        torch.zeros_like(fake_oneshot_model.linear.weight)
+    )
     model_compressor.decompress(model=decompressed_model, model_path=save_dir)
 
     # check that the decompressed model is the same as the original model
@@ -254,3 +228,138 @@ def _check_state_dicts(state_dict1, state_dict2):
             decompressed_tensor = state_dict2[key].to(original_tensor.dtype)
             diff = torch.abs(original_tensor - decompressed_tensor)
             assert not torch.any(diff > 0.01), f"Max diff: {torch.max(diff)}"
+
+
+def _get_fake_oneshot_sparse_quantized_model(quantization_config, sparsity_config):
+    from compressed_tensors.quantization.lifecycle.forward import quantize
+
+    weights = torch.rand(10, 5)
+    sparse_weights = induce_sparsity(weights, sparsity_config.global_sparsity)
+
+    quantization_args = quantization_config.config_groups["group_0"].weights
+
+    if quantization_args.strategy == "channel":
+        scale = torch.ones((weights.shape[0], 1))
+    elif quantization_args.strategy == "tensor":
+        scale = torch.tensor([1.0])
+
+    zero_point = torch.zeros_like(scale)
+
+    quantized_weights = quantize(
+        sparse_weights,
+        scale=scale,
+        zero_point=zero_point,
+        args=quantization_args,
+    )
+
+    fake_oneshot_model = DummyLinearModel(quantized_weights, scale, zero_point)
+    fake_oneshot_model.linear.quantization_scheme = quantization_config.config_groups[
+        "group_0"
+    ]
+    return fake_oneshot_model
+
+
+class TwoLayerModel(nn.Module):
+    def __init__(self):
+        super(TwoLayerModel, self).__init__()
+        self.layer1 = nn.Linear(10, 10, bias=False)
+        self.layer2 = nn.Linear(10, 10, bias=False)
+
+    def forward(self, x):
+        x = self.layer1(x)
+        x = self.layer2(x)
+        return x
+
+
+@pytest.mark.parametrize(
+    "model, sparsity_config, quantization_config, expected",
+    [
+        (
+            TwoLayerModel(),
+            get_bitmask_sparsity_config(),
+            create_quantization_config(bits=8, type="int", strategy="channel"),
+            {"layer1.weight"},
+        )
+    ],
+)
+def test_get_missing_keys(model, sparsity_config, quantization_config, expected):
+    model_compressor = ModelCompressor(
+        sparsity_config=sparsity_config, quantization_config=quantization_config
+    )
+
+    actual = model_compressor.get_missing_module_keys(model)
+    assert len(actual) == len(expected) and all(key in actual for key in expected)
+
+
+@pytest.mark.parametrize(
+    "model, sparsity_config, quantization_config, expected",
+    [
+        (
+            TwoLayerModel(),
+            get_bitmask_sparsity_config(targets=["re:.*layer1$"]),
+            create_quantization_config(bits=8, type="int", strategy="channel"),
+            {
+                f"{layer}.{suffix}"
+                for layer, suffixes in {
+                    "layer1": [
+                        "shape",
+                        "row_offsets",
+                        "weight_zero_point",
+                        "weight_g_idx",
+                        "bitmask",
+                        "weight_scale",
+                        "compressed",
+                    ],
+                    "layer2": ["weight_scale", "weight_zero_point", "weight_g_idx"],
+                }.items()
+                for suffix in suffixes
+            },
+        )
+    ],
+)
+def test_get_unexpected_keys(model, sparsity_config, quantization_config, expected):
+    model_compressor = ModelCompressor(
+        sparsity_config=sparsity_config, quantization_config=quantization_config
+    )
+
+    actual = model_compressor.get_unexpected_file_keys(model)
+    assert len(actual) == len(expected) and all(key in actual for key in expected)
+
+
+@pytest.mark.parametrize(
+    "sparsity_config, quantization_config, missing, unexpected",
+    [
+        (
+            get_bitmask_sparsity_config(),
+            create_quantization_config(bits=8, type="int", strategy="channel"),
+            {"linear.weight"},
+            {
+                "linear.bitmask",
+                "linear.compressed",
+                "linear.row_offsets",
+                "linear.shape",
+                "linear.weight_scale",
+            },
+        )
+    ],
+)
+def test_missing_and_unexpected_keys_on_compression(
+    tmp_path, sparsity_config, quantization_config, missing, unexpected
+):
+
+    model_compressor = ModelCompressor(
+        sparsity_config=sparsity_config, quantization_config=quantization_config
+    )
+    fake_oneshot_model: DummyLinearModel = _get_fake_oneshot_sparse_quantized_model(
+        sparsity_config=sparsity_config, quantization_config=quantization_config
+    )
+
+    og_state_dict_keys = set(
+        DummyLinearModel(weights=torch.randn(10, 5)).state_dict().keys()
+    )
+    compressed_state_dict_keys = set(
+        model_compressor.compress(fake_oneshot_model).keys()
+    )
+
+    assert og_state_dict_keys - compressed_state_dict_keys == missing
+    assert compressed_state_dict_keys - og_state_dict_keys == unexpected

--- a/tests/test_compressors/model_compressors/test_model_compressor.py
+++ b/tests/test_compressors/model_compressors/test_model_compressor.py
@@ -251,7 +251,7 @@ class TwoLayerModel(nn.Module):
     [
         (
             TwoLayerModel(),
-            get_bitmask_sparsity_config(),
+            get_bitmask_sparsity_config(targets=["re:.*layer1$"]),
             create_quantization_config(bits=8, type="int", strategy="channel"),
             {"layer1.weight"},
         )

--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -28,8 +28,8 @@ from compressed_tensors.quantization import (
 from compressed_tensors.quantization.lifecycle import (
     apply_quantization_config,
     apply_quantization_status,
-    expand_sparse_target_names,
-    is_sparse_target,
+    expand_target_names,
+    is_target,
 )
 from compressed_tensors.quantization.utils import iter_named_leaf_modules
 from tests.testing_utils import requires_accelerate
@@ -312,7 +312,7 @@ def test_apply_quantization_status(caplog, ignore, should_raise_warning):
     ],
 )
 def test_expand_targets_with_mock(mock_model, targets, ignore, expected_targets):
-    expanded_targets = expand_sparse_target_names(mock_model, targets, ignore)
+    expanded_targets = expand_target_names(mock_model, targets, ignore)
     assert expanded_targets == expected_targets
 
 
@@ -352,7 +352,7 @@ def test_expand_targets_with_mock(mock_model, targets, ignore, expected_targets)
 def test_expand_targets_with_llama_stories(
     llama_stories_model, targets, ignore, expected_targets
 ):
-    expanded_targets = expand_sparse_target_names(llama_stories_model, targets, ignore)
+    expanded_targets = expand_target_names(llama_stories_model, targets, ignore)
     assert expanded_targets == expected_targets
 
 
@@ -367,5 +367,5 @@ def test_expand_targets_with_llama_stories(
     ],
 )
 def test_is_target_with_mock(mock_module, name, targets, ignore, expected):
-    result = is_sparse_target(name, mock_module, targets, ignore)
+    result = is_target(name, mock_module, targets, ignore)
     assert result == expected


### PR DESCRIPTION
This PR introduces utility functions in `ModelCompressor` to support loading **stack-compressed models** (models with both sparsity and quantization) via Hugging Face’s `AutoModelForCausalLM`. These changes are necessary for [huggingface/transformers PR 36152](https://github.com/huggingface/transformers/pull/36152), which enables loading of stack-compressed models in the Transformers library w/o raising warnings around unexpected/missing keys.

## **Background & Motivation**  
When using `HFQuantizer`, the model graph is instantiated, and safetensor keys are validated against expected keys. Any **extra or missing keys** trigger warnings. However, due to our compression method, certain extra and missing keys are **expected**:

- **Extra keys**: Represent compression metadata stored on disk but not explicitly expected by the model graph.  
- **Missing keys**: Expected in the model graph but omitted from storage since they can be reconstructed from compression metadata.  

To handle these cases, this PR extends `ModelCompressor` to:  
✔ Identify extra keys introduced by compression.  
✔ Infer expected missing keys by virtue of compression 

## **Changes Introduced**  
- Adds utility functions to `ModelCompressor` for handling expected extra/missing keys.  
- Renames `expand_sparse_targets` → `expand_targets` for broader applicability.  

## **Impact**  
These changes ensure that utilities needed to load stack-compressed models in `AutoModelForCausalLM` are exposed via a clean API (wink wink)

```python
from compressed_tensors.compressors import ModelCompressor

model = ... # instantiated model graph
compressor = ModelCompressor(sparsity_config=..., quantization_config=...)
extra_keys = compressor.get_unexpected_file_keys(model)
missing_keys = compressor.get_missing_module_keys(model)
```

## **Testing**  
✅ Added automated tests to validate the behavior of the new utility functions.  
✅ Verified functionality against [huggingface/transformers PR #2](https://github.com/neuralmagic/upstream-transformers/pull/2).  
