### PR TITLE
[Bugfix] Support offloaded parameters when initializing KV cache parameters

### DIFF
--- a/src/compressed_tensors/linear/compressed_linear.py
+++ b/src/compressed_tensors/linear/compressed_linear.py
@@ -21,6 +21,7 @@ from compressed_tensors.quantization import (
     QuantizationStatus,
     initialize_module_for_quantization,
 )
+from compressed_tensors.utils import register_offload_parameter
 from torch import Tensor
 from torch.nn import Parameter
 from torch.nn.functional import linear
@@ -68,7 +69,7 @@ class CompressedLinear(Linear):
             param = Parameter(
                 torch.empty(shape, device=device, dtype=dtype), requires_grad=False
             )
-            module.register_parameter(name, param)
+            register_offload_parameter(name, param)
 
         # mark module as compressed
         module.quantization_status = QuantizationStatus.COMPRESSED

--- a/src/compressed_tensors/linear/compressed_linear.py
+++ b/src/compressed_tensors/linear/compressed_linear.py
@@ -69,7 +69,7 @@ class CompressedLinear(Linear):
             param = Parameter(
                 torch.empty(shape, device=device, dtype=dtype), requires_grad=False
             )
-            register_offload_parameter(name, param)
+            register_offload_parameter(module, name, param)
 
         # mark module as compressed
         module.quantization_status = QuantizationStatus.COMPRESSED

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -203,11 +203,10 @@ def _initialize_attn_scales(module: Module) -> None:
         torch.empty(expected_shape, dtype=scale_dtype, device=device),
         requires_grad=False,
     )
-
-    module.register_parameter(KVCacheScaleType.KEY.value, init_scale)
+    register_offload_parameter(module, KVCacheScaleType.KEY.value, init_scale)
 
     init_scale = Parameter(
         torch.empty(expected_shape, dtype=scale_dtype, device=device),
         requires_grad=False,
     )
-    module.register_parameter(KVCacheScaleType.VALUE.value, init_scale)
+    register_offload_parameter(module, KVCacheScaleType.VALUE.value, init_scale)


### PR DESCRIPTION
## Purpose ##
* Support offloaded parameters when initializing KV cache parameters

## Related Issues ##
* Fixes https://github.com/vllm-project/llm-compressor/issues/1192

## Changes ##
* Replace uses of `module.register_parameter` with offloading-friendly `register_offload_parameter`