### PR TITLE
[Transforms] Transform Data and Integration testing

### DIFF
--- a/src/compressed_tensors/transforms/matrix_multiply.py
+++ b/src/compressed_tensors/transforms/matrix_multiply.py
@@ -16,7 +16,7 @@ import torch
 from compressed_tensors.transforms import Transforms
 
 
-@Transforms.register("matrix_mul")
+@Transforms.register("matrix-mul")
 class MatrixMultiply(Transforms):
     @staticmethod
     def apply(

--- a/src/compressed_tensors/transforms/random_hadamard.py
+++ b/src/compressed_tensors/transforms/random_hadamard.py
@@ -19,7 +19,7 @@ from compressed_tensors.transforms import Transforms
 from compressed_tensors.transforms.hadamard_utils import random_hadamard_matrix
 
 
-@Transforms.register("random_hadamard")
+@Transforms.register("random-hadamard")
 class RandomHadamard(Transforms):
     def __new__(
         cls,

--- a/src/compressed_tensors/transforms/scalar_multiply.py
+++ b/src/compressed_tensors/transforms/scalar_multiply.py
@@ -16,7 +16,7 @@ import torch
 from compressed_tensors.transforms import Transforms
 
 
-@Transforms.register("scalar_mul")
+@Transforms.register("scalar-mul")
 class ScalarMultiply(Transforms):
     @staticmethod
     def apply(transform: torch.Tensor, input_tensor: torch.Tensor) -> torch.Tensor:

--- a/src/compressed_tensors/transforms/transform_args.py
+++ b/src/compressed_tensors/transforms/transform_args.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, Field, model_validator
+
+
+__all__ = ["TransformationArgs"]
+
+
+class ModuleTarget(str, Enum):
+    """
+    Enum storing parameter or activation types being targeted by transforms
+    in a particuilar module.
+    """
+
+    WEIGHTS = "weights"
+    INPUT_ACTIVATIONS = "input_activations"
+    OUTPUT_ACTIVATIONS = "output_activations"
+
+
+class TransformationArgs(BaseModel):
+    targets: List[str]
+    module_targets: List[Union[ModuleTarget, str]]
+    args: Optional[Dict[str, Any]] = None
+    ignore: Optional[List[str]] = Field(default_factory=list)

--- a/src/compressed_tensors/transforms/transform_args.py
+++ b/src/compressed_tensors/transforms/transform_args.py
@@ -34,6 +34,20 @@ class ModuleTarget(str, Enum):
 
 
 class TransformationArgs(BaseModel):
+    """
+    User-facing arguments used to define which modules and their specific
+    parameters and/or activations should be targeted by a particular transform.
+
+    :param targets: list of layers to target
+    :param module_targets: list of layer parameters and/or activations onto which the
+        transform should be applied. The same transform will be applied for all
+        module targets in the list.
+    :param call_args: dictionary of args needed for the transform during runtime,
+        beyond the input_tensor or transform
+    :param ignore: any submodule which should be ignored from the targets list
+
+    """
+
     targets: List[str]
     module_targets: List[Union[ModuleTarget, str]]
     call_args: Optional[Dict[str, Any]] = None

--- a/src/compressed_tensors/transforms/transform_config.py
+++ b/src/compressed_tensors/transforms/transform_config.py
@@ -14,7 +14,7 @@
 
 from typing import Dict
 
-from compressed_tensors.transforms.transfrom_scheme import TransformationScheme
+from compressed_tensors.transforms.transform_scheme import TransformationScheme
 from pydantic import BaseModel
 
 
@@ -25,5 +25,4 @@ class TransformationConfig(BaseModel):
     transform_groups: Dict[str, TransformationScheme]
 
     def to_dict(self):
-        # for compatibility with HFQuantizer
         return self.model_dump()

--- a/src/compressed_tensors/transforms/transform_config.py
+++ b/src/compressed_tensors/transforms/transform_config.py
@@ -22,6 +22,15 @@ __all__ = ["TransformationConfig"]
 
 
 class TransformationConfig(BaseModel):
+    """
+    Configuration of transforms to be added within a model's config.json.
+
+    :param transform_groups: A dictionary of the different TransformationSchemes
+        that should be applied to a particular model. The keys can be any
+        arbitrary string and a TransformationScheme should be provided
+        for each new transform type.
+    """
+
     transform_groups: Dict[str, TransformationScheme]
 
     def to_dict(self):

--- a/src/compressed_tensors/transforms/transform_config.py
+++ b/src/compressed_tensors/transforms/transform_config.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict
+
+from compressed_tensors.transforms.transfrom_scheme import TransformationScheme
+from pydantic import BaseModel
+
+
+__all__ = ["TransformationConfig"]
+
+
+class TransformationConfig(BaseModel):
+    transform_groups: Dict[str, TransformationScheme]
+
+    def to_dict(self):
+        # for compatibility with HFQuantizer
+        return self.model_dump()

--- a/src/compressed_tensors/transforms/transform_data.py
+++ b/src/compressed_tensors/transforms/transform_data.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Dict
+from typing import Any, Callable, Dict
 
 
 __all__ = ["TransformData"]
@@ -21,4 +21,5 @@ __all__ = ["TransformData"]
 
 @dataclass
 class TransformData:
+    # TransformData(data={transform_name: {"apply": Callable, "call_args": Dict}})
     data: Dict

--- a/src/compressed_tensors/transforms/transform_data.py
+++ b/src/compressed_tensors/transforms/transform_data.py
@@ -19,7 +19,16 @@ from typing import Any, Callable, Dict
 __all__ = ["TransformData"]
 
 
+# TODO: adding for now but we may not need it during runtime depending on the
+# integration.
 @dataclass
 class TransformData:
-    # TransformData(data={transform_name: {"apply": Callable, "call_args": Dict}})
+    """
+    Data that is required during runtime in order to apply the transform.
+
+    Example:
+        data={transform_name: {"apply": Callable, "call_args": Dict}})
+        transform_data = TransformData(data=data)
+    """
+
     data: Dict

--- a/src/compressed_tensors/transforms/transform_data.py
+++ b/src/compressed_tensors/transforms/transform_data.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+__all__ = ["TransformData"]
+
+
+@dataclass
+class TransformData:
+    data: Dict

--- a/src/compressed_tensors/transforms/transform_scheme.py
+++ b/src/compressed_tensors/transforms/transform_scheme.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import Any, Dict, List, Optional
 
 from compressed_tensors.transforms.transform_args import TransformationArgs
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 __all__ = ["TransformationScheme"]
@@ -24,7 +24,10 @@ __all__ = ["TransformationScheme"]
 class TransformationScheme(BaseModel):
     transform_type: str
     groups: List[TransformationArgs]
-    # Use the same transformation for each value returned by the target list
-    # If false, use a new transformation for each value in the target list, unless in the same transformer block?
     global_transform: bool = False
-    transform_creation_args: Optional[dict] = None
+    transform_creation_args: Optional[Dict[str, Any]] = None
+
+    @field_validator("transform_type", mode="before")
+    def validate_transform_type(cls, value) -> str:
+        assert value in ["hadamard"]
+        return value

--- a/src/compressed_tensors/transforms/transform_scheme.py
+++ b/src/compressed_tensors/transforms/transform_scheme.py
@@ -14,6 +14,7 @@
 
 from typing import Any, Dict, List, Optional
 
+from compressed_tensors.transforms import Transforms
 from compressed_tensors.transforms.transform_args import TransformationArgs
 from pydantic import BaseModel, field_validator
 
@@ -29,5 +30,5 @@ class TransformationScheme(BaseModel):
 
     @field_validator("transform_type", mode="before")
     def validate_transform_type(cls, value) -> str:
-        assert value in ["hadamard"]
+        assert value in Transforms.registered_names()
         return value

--- a/src/compressed_tensors/transforms/transform_scheme.py
+++ b/src/compressed_tensors/transforms/transform_scheme.py
@@ -23,6 +23,20 @@ __all__ = ["TransformationScheme"]
 
 
 class TransformationScheme(BaseModel):
+    """
+    :param transform_type: string indicating the particular transform that
+        should be created and applied. This should be one of the registered transforms
+        i.e be in Transforms.registered_names()
+    :param groups: includes TransformationArgs containing the information about the
+        layers that should be targeted by the specified transform. By providing a list,
+        users have the ability to apply the same transform type (with the same set
+        of arguments) to different layers.
+    :param transform_creation_args: arguments needed to initialize the transform, if
+        any
+    :param global_transform: whether an identical transform is applied to all the
+        TransformationArgs in the groups list
+    """
+
     transform_type: str
     groups: List[TransformationArgs]
     global_transform: bool = False

--- a/src/compressed_tensors/transforms/transform_scheme.py
+++ b/src/compressed_tensors/transforms/transform_scheme.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+from compressed_tensors.transforms.transform_args import TransformationArgs
+from pydantic import BaseModel
+
+
+__all__ = ["TransformationScheme"]
+
+
+class TransformationScheme(BaseModel):
+    transform_type: str
+    groups: List[TransformationArgs]
+    # Use the same transformation for each value returned by the target list
+    # If false, use a new transformation for each value in the target list, unless in the same transformer block?
+    global_transform: bool = False
+    transform_creation_args: Optional[dict] = None

--- a/tests/test_transforms/test_integration.py
+++ b/tests/test_transforms/test_integration.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+import torch.nn as nn
+from compressed_tensors.transforms import Hadamard, Transforms
+from compressed_tensors.transforms.transform_args import (
+    ModuleTarget,
+    TransformationArgs,
+)
+from compressed_tensors.transforms.transform_config import TransformationConfig
+from compressed_tensors.transforms.transform_data import TransformData
+from compressed_tensors.transforms.transform_scheme import TransformationScheme
+
+
+@pytest.fixture
+def transform_recipe_basic():
+    targets = ["Embedding"]
+    module_targets = [ModuleTarget.OUTPUT_ACTIVATIONS]
+    embedding_args = TransformationArgs(targets=targets, module_targets=module_targets)
+
+    targets = ["Linear"]
+    module_targets = [ModuleTarget.WEIGHTS]
+    linear_layer_args = TransformationArgs(
+        targets=targets, module_targets=module_targets
+    )
+
+    scheme = TransformationScheme(
+        transform_type="hadamard",
+        groups=[embedding_args, linear_layer_args],
+        transform_creation_args={"size": 64},
+    )
+
+    config = TransformationConfig(
+        transform_groups={
+            "transform_0": scheme,
+        }
+    )
+    return config
+
+
+@pytest.fixture
+def transform_recipe_complex():
+    # Multiple transform for a given module 
+    # Weight Activations and Weight Activations for a given module
+    pass
+
+
+@pytest.fixture
+def basic_model():
+    class BasicModel(nn.Module):
+        def __init__(self, vocab_size, embed_size, hidden_size, num_classes):
+            super(BasicModel, self).__init__()
+
+            self.embedding = nn.Embedding(vocab_size, embed_size)
+            self.block1 = nn.Sequential(
+                nn.Linear(embed_size, hidden_size), nn.ReLU(), nn.Dropout(0.2)
+            )
+            self.block2 = nn.Sequential(
+                nn.Linear(hidden_size, hidden_size), nn.ReLU(), nn.Dropout(0.2)
+            )
+            self.fc = nn.Linear(hidden_size, num_classes)
+
+        def forward(self, x):
+            x = self.embedding(x)
+            x = x.mean(dim=1)
+            x = self.block1(x)
+            x = self.block2(x)
+            x = self.fc(x)
+
+            return x
+
+    vocab_size = 1000
+    embed_size = 128
+    hidden_size = 64
+    num_classes = 10
+    return BasicModel(vocab_size, embed_size, hidden_size, num_classes)
+
+
+def test_basic_model(basic_model, transform_recipe_basic):
+    transform_groups = transform_recipe_basic.transform_groups
+    for _, group in transform_groups.items():
+        # Each group/scheme targets one type of transform
+        transform_type = group.transform_type
+        transform_creation_args = group.transform_creation_args
+
+        global_transform = None
+        if group.global_transform:
+            # create transform
+            global_transform = Transforms.load_from_registry(
+                transform_type, **transform_creation_args
+            )
+
+        # Need a better name - too many groups
+        for transform_arg in group.groups:
+            target = transform_arg.targets
+            module_targets = transform_arg.module_targets
+            call_args = transform_arg.call_args
+
+            if global_transform is None:
+                transform = Transforms.load_from_registry(
+                    transform_type, **transform_creation_args
+                )
+                transform
+
+            for _, submodule in basic_model.named_modules():
+                name = submodule.__class__.__name__
+                if name in target:
+                    transform_data = TransformData(
+                        data={
+                            module_targets[0]: {
+                                "transform": transform,
+                                "call_args": call_args,
+                            }
+                        }
+                    )
+                    submodule.transform_data = transform_data
+
+    # Should have the following structure:
+    """
+    >> basic_model.embedding.transform_data
+    TransformData(
+        data={
+            <ModuleTarget.OUTPUT_ACTIVATIONS: 'output_activations'>: 
+                {'transform': <compressed_tensors.transforms.hadamard.Hadamard object at 0x7ac77ef3fa00>, 
+                'call_args': None
+            }
+        }
+    )
+
+    >> basic_model.block1[0].transform_data
+    TransformData(
+        data={
+            <ModuleTarget.WEIGHTS: 'weights'>: 
+                {'transform': <compressed_tensors.transforms.hadamard.Hadamard object at 0x7ac77ef3f940>, 
+                'call_args': None
+            }
+        }
+    )
+    """
+
+    # Verify Embedding layers and Linear Layers have the correct data attached to them
+    assert hasattr(basic_model.embedding, "transform_data")
+    assert isinstance(basic_model.embedding.transform_data, TransformData)
+    activation_transform = basic_model.embedding.transform_data.data.get(
+        "output_activations"
+    )
+    assert isinstance(activation_transform.get("transform"), Hadamard)
+
+    blocks = [basic_model.block1, basic_model.block2]
+    for block in blocks:
+        for layer in block:
+            if isinstance(layer, torch.nn.Linear):
+                assert hasattr(layer, "transform_data")
+                assert isinstance(layer.transform_data, TransformData)
+                weight_transform = layer.transform_data.data.get("weights")
+                assert isinstance(weight_transform.get("transform"), Hadamard)

--- a/tests/test_transforms/test_integration.py
+++ b/tests/test_transforms/test_integration.py
@@ -121,14 +121,17 @@ def _apply_transfoms_to_model(model, transform_groups):
             module_targets = transform_arg.module_targets
             call_args = transform_arg.call_args
 
-            transform = Transforms.load_from_registry(
-                transform_type, **transform_creation_args
-            )
-            apply = Transforms.fetch_apply(transform_type)
-
             for _, submodule in model.named_modules():
                 name = submodule.__class__.__name__
                 if name in target:
+
+                    # Every layer which matches gets its own transform
+                    # Same transform type and args are used however
+                    transform = Transforms.load_from_registry(
+                        transform_type, **transform_creation_args
+                    )
+                    apply = Transforms.fetch_apply(transform_type)
+
                     # attach the transform to the submodule
                     transform_name = f"{module_targets[0]}_transform"
                     setattr(submodule, transform_name, transform)

--- a/tests/test_transforms/test_integration.py
+++ b/tests/test_transforms/test_integration.py
@@ -132,7 +132,6 @@ def _test_model(model, transform_groups):
                 transform = Transforms.load_from_registry(
                     transform_type, **transform_creation_args
                 )
-                transform
 
             for _, submodule in model.named_modules():
                 name = submodule.__class__.__name__
@@ -162,24 +161,9 @@ def test_recipe_complex(basic_model, transform_recipe_complex):
                 assert hasattr(layer, "transform_data")
                 assert isinstance(layer.transform_data, TransformData)
                 weight_transform = layer.transform_data.data.get("weights")
-                assert isinstance(weight_transform.get("transform"), Hadamard)
+                assert isinstance(weight_transform.get("transform"), torch.nn.Parameter)
                 output_transform = layer.transform_data.data.get("output_activations")
-                assert isinstance(output_transform.get("transform"), RandomHadamard)
-
-    """
-    >> basic_model.block1[0].transform_data
-
-    TransformData(
-        data={
-            <ModuleTarget.WEIGHTS: 'weights'>: 
-                {'transform': <compressed_tensors.transforms.hadamard.Hadamard object at 0x705403b3baf0>, 
-                'call_args': None},    
-            <ModuleTarget.OUTPUT_ACTIVATIONS: 'output_activations'>: 
-                {'transform': <compressed_tensors.transforms.random_hadamard.RandomHadamard object at 0x74535bd6e230>, 
-                'call_args': None}
-            }
-        )
-    """
+                assert isinstance(output_transform.get("transform"), torch.nn.Parameter)
 
 
 def test_recipe_basic(basic_model, transform_recipe_basic):
@@ -193,7 +177,7 @@ def test_recipe_basic(basic_model, transform_recipe_basic):
                 assert hasattr(layer, "transform_data")
                 assert isinstance(layer.transform_data, TransformData)
                 weight_transform = layer.transform_data.data.get("weights")
-                assert isinstance(weight_transform.get("transform"), Hadamard)
+                assert isinstance(weight_transform.get("transform"), torch.nn.Parameter)
 
 
 def test_recipe_complex_multiple(basic_model, transform_recipe_complex_multiple):
@@ -206,28 +190,37 @@ def test_recipe_complex_multiple(basic_model, transform_recipe_complex_multiple)
     TransformData(
         data={
             <ModuleTarget.OUTPUT_ACTIVATIONS: 'output_activations'>: 
-                {'transform': <compressed_tensors.transforms.hadamard.Hadamard object at 0x7ac77ef3fa00>, 
-                'call_args': None
-            }
-        }
-    )
+            {'transform': 
+            Parameter containing:
+             tensor([[ 1.,  1.,  1.,  ...,  1.,  1.,  1.],
+                     [ 1., -1.,  1.,  ..., -1.,  1., -1.],
+                     [ 1.,  1., -1.,  ...,  1., -1., -1.],
+                     ...,
+                     [ 1., -1.,  1.,  ..., -1.,  1., -1.],
+                     [ 1.,  1., -1.,  ...,  1., -1., -1.],
+                     [ 1., -1., -1.,  ..., -1., -1.,  1.]], dtype=torch.bfloat16), 
+            'call_args': None}})
 
     >> basic_model.block1[0].transform_data
     TransformData(
-        data={
-            <ModuleTarget.WEIGHTS: 'weights'>: 
-                {'transform': <compressed_tensors.transforms.hadamard.Hadamard object at 0x7ac77ef3f940>, 
-                'call_args': None
-            }
-        }
-    )
+        data={<ModuleTarget.WEIGHTS: 'weights'>: 
+            {'transform': 
+            Parameter containing:
+             tensor([[ 1.,  1.,  1.,  ...,  1.,  1.,  1.],
+                     [ 1., -1.,  1.,  ..., -1.,  1., -1.],
+                     [ 1.,  1., -1.,  ...,  1., -1., -1.],
+                     ...,
+                     [ 1., -1.,  1.,  ..., -1.,  1., -1.],
+                     [ 1.,  1., -1.,  ...,  1., -1., -1.],
+                     [ 1., -1., -1.,  ..., -1., -1.,  1.]], dtype=torch.bfloat16), 
+            'call_args': None}})
     """
 
     # Verify Embedding layers and Linear Layers have the correct data attached to them
     assert hasattr(model.embedding, "transform_data")
     assert isinstance(model.embedding.transform_data, TransformData)
     activation_transform = model.embedding.transform_data.data.get("output_activations")
-    assert isinstance(activation_transform.get("transform"), Hadamard)
+    assert isinstance(activation_transform.get("transform"), torch.nn.Parameter)
 
     blocks = [model.block1, model.block2]
     for block in blocks:
@@ -236,4 +229,4 @@ def test_recipe_complex_multiple(basic_model, transform_recipe_complex_multiple)
                 assert hasattr(layer, "transform_data")
                 assert isinstance(layer.transform_data, TransformData)
                 weight_transform = layer.transform_data.data.get("weights")
-                assert isinstance(weight_transform.get("transform"), Hadamard)
+                assert isinstance(weight_transform.get("transform"), torch.nn.Parameter)

--- a/tests/test_transforms/test_integration.py
+++ b/tests/test_transforms/test_integration.py
@@ -109,18 +109,11 @@ def basic_model():
     return BasicModel(vocab_size, embed_size, hidden_size, num_classes)
 
 
-def _test_model(model, transform_groups):
+def _apply_transfoms_to_model(model, transform_groups):
     for _, group in transform_groups.items():
         # Each group/scheme targets one type of transform
         transform_type = group.transform_type
         transform_creation_args = group.transform_creation_args
-
-        global_transform = None
-        if group.global_transform:
-            # create transform
-            global_transform = Transforms.load_from_registry(
-                transform_type, **transform_creation_args
-            )
 
         # Need a better name - too many groups
         for transform_arg in group.groups:
@@ -128,20 +121,21 @@ def _test_model(model, transform_groups):
             module_targets = transform_arg.module_targets
             call_args = transform_arg.call_args
 
-            if global_transform is None:
-                transform = Transforms.load_from_registry(
-                    transform_type, **transform_creation_args
-                )
+            transform = Transforms.load_from_registry(
+                transform_type, **transform_creation_args
+            )
+            apply = Transforms.fetch_apply(transform_type)
 
             for _, submodule in model.named_modules():
                 name = submodule.__class__.__name__
                 if name in target:
-                    data = {
-                        module_targets[0]: {
-                            "transform": transform,
-                            "call_args": call_args,
-                        }
-                    }
+                    # attach the transform to the submodule
+                    transform_name = f"{module_targets[0]}_transform"
+                    setattr(submodule, transform_name, transform)
+
+                    # add relevant transform data to the submodule as well
+                    data = {transform_name: {"apply": apply, "call_args": call_args}}
+
                     if hasattr(submodule, "transform_data"):
                         submodule.transform_data.data.update(data)
                     else:
@@ -150,83 +144,74 @@ def _test_model(model, transform_groups):
     return model
 
 
+def _verify_correct_data(layer: torch.nn.Module):
+    assert hasattr(layer, "transform_data")
+    assert isinstance(layer.transform_data, TransformData)
+
+    # data keys are all the different transforms relevant
+    # to the module
+    transform_data = layer.transform_data
+
+    for k, v in transform_data.data.items():
+        current_transform = getattr(layer, k)
+        assert isinstance(current_transform, torch.nn.Parameter)
+        assert "apply" in v
+        assert "call_args" in v
+
+
 def test_recipe_complex(basic_model, transform_recipe_complex):
     transform_groups = transform_recipe_complex.transform_groups
-    model = _test_model(basic_model, transform_groups)
+    model = _apply_transfoms_to_model(basic_model, transform_groups)
 
     blocks = [model.block1, model.block2]
     for block in blocks:
         for layer in block:
             if isinstance(layer, torch.nn.Linear):
-                assert hasattr(layer, "transform_data")
-                assert isinstance(layer.transform_data, TransformData)
-                weight_transform = layer.transform_data.data.get("weights")
-                assert isinstance(weight_transform.get("transform"), torch.nn.Parameter)
-                output_transform = layer.transform_data.data.get("output_activations")
-                assert isinstance(output_transform.get("transform"), torch.nn.Parameter)
+                _verify_correct_data(layer)
 
 
 def test_recipe_basic(basic_model, transform_recipe_basic):
     transform_groups = transform_recipe_basic.transform_groups
-    model = _test_model(basic_model, transform_groups)
+    model = _apply_transfoms_to_model(basic_model, transform_groups)
 
     blocks = [model.block1, model.block2]
     for block in blocks:
         for layer in block:
             if isinstance(layer, torch.nn.Linear):
-                assert hasattr(layer, "transform_data")
-                assert isinstance(layer.transform_data, TransformData)
-                weight_transform = layer.transform_data.data.get("weights")
-                assert isinstance(weight_transform.get("transform"), torch.nn.Parameter)
+                _verify_correct_data(layer)
 
 
 def test_recipe_complex_multiple(basic_model, transform_recipe_complex_multiple):
     transform_groups = transform_recipe_complex_multiple.transform_groups
-    model = _test_model(basic_model, transform_groups)
+    model = _apply_transfoms_to_model(basic_model, transform_groups)
 
     # Should have the following structure:
     """
-    >> basic_model.embedding.transform_data
-    TransformData(
-        data={
-            <ModuleTarget.OUTPUT_ACTIVATIONS: 'output_activations'>: 
-            {'transform': 
-            Parameter containing:
-             tensor([[ 1.,  1.,  1.,  ...,  1.,  1.,  1.],
-                     [ 1., -1.,  1.,  ..., -1.,  1., -1.],
-                     [ 1.,  1., -1.,  ...,  1., -1., -1.],
-                     ...,
-                     [ 1., -1.,  1.,  ..., -1.,  1., -1.],
-                     [ 1.,  1., -1.,  ...,  1., -1., -1.],
-                     [ 1., -1., -1.,  ..., -1., -1.,  1.]], dtype=torch.bfloat16), 
-            'call_args': None}})
-
-    >> basic_model.block1[0].transform_data
-    TransformData(
-        data={<ModuleTarget.WEIGHTS: 'weights'>: 
-            {'transform': 
-            Parameter containing:
-             tensor([[ 1.,  1.,  1.,  ...,  1.,  1.,  1.],
-                     [ 1., -1.,  1.,  ..., -1.,  1., -1.],
-                     [ 1.,  1., -1.,  ...,  1., -1., -1.],
-                     ...,
-                     [ 1., -1.,  1.,  ..., -1.,  1., -1.],
-                     [ 1.,  1., -1.,  ...,  1., -1., -1.],
-                     [ 1., -1., -1.,  ..., -1., -1.,  1.]], dtype=torch.bfloat16), 
-            'call_args': None}})
+    >> basic_model.embedding.output_activations_transform
+    Parameter containing:
+        tensor([[ 1.,  1.,  1.,  ...,  1.,  1.,  1.],
+                [ 1., -1.,  1.,  ..., -1.,  1., -1.],
+                [ 1.,  1., -1.,  ...,  1., -1., -1.],
+                ...,
+                [ 1., -1.,  1.,  ..., -1.,  1., -1.],
+                [ 1.,  1., -1.,  ...,  1., -1., -1.],
+                [ 1., -1., -1.,  ..., -1., -1.,  1.]], dtype=torch.bfloat16)
+    
+    >> model.embedding.transform_data
+        TransformData(data={'output_activations_transform': 
+            {
+                'apply': <function Hadamard.apply at 0x7c7bcc56caf0>, 
+                'call_args': None
+            }
+        }
+    )
     """
 
     # Verify Embedding layers and Linear Layers have the correct data attached to them
-    assert hasattr(model.embedding, "transform_data")
-    assert isinstance(model.embedding.transform_data, TransformData)
-    activation_transform = model.embedding.transform_data.data.get("output_activations")
-    assert isinstance(activation_transform.get("transform"), torch.nn.Parameter)
+    _verify_correct_data(model.embedding)
 
     blocks = [model.block1, model.block2]
     for block in blocks:
         for layer in block:
             if isinstance(layer, torch.nn.Linear):
-                assert hasattr(layer, "transform_data")
-                assert isinstance(layer.transform_data, TransformData)
-                weight_transform = layer.transform_data.data.get("weights")
-                assert isinstance(weight_transform.get("transform"), torch.nn.Parameter)
+                _verify_correct_data(layer)

--- a/tests/test_transforms/test_transform_args.py
+++ b/tests/test_transforms/test_transform_args.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from compressed_tensors.transforms.transform_args import (
+    ModuleTarget,
+    TransformationArgs,
+)
+
+
+def test_transform_args_basic():
+    targets = ["Embedding"]
+    module_targets = [ModuleTarget.INPUT_ACTIVATIONS]
+    basic_args = TransformationArgs(targets=targets, module_targets=module_targets)
+
+    assert basic_args.targets[0] == "Embedding"
+    assert basic_args.module_targets[0] == ModuleTarget.INPUT_ACTIVATIONS
+    assert basic_args.call_args is None
+    assert len(basic_args.ignore) == 0
+
+
+def test_transform_args_full():
+    targets = ["Linear"]
+    module_targets = ["weights", "input_activations"]
+    ignore = ["model.layers.2"]
+    call_args = {"transpose": True}
+
+    full_args = TransformationArgs(
+        targets=targets,
+        module_targets=module_targets,
+        call_args=call_args,
+        ignore=ignore,
+    )
+
+    full_args.targets = targets
+    full_args.ignore == ignore
+    full_args.module_targets[0] == ModuleTarget.WEIGHTS
+    full_args.module_targets[1] == ModuleTarget.INPUT_ACTIVATIONS
+    assert full_args.call_args.get("transpose")

--- a/tests/test_transforms/test_transform_config.py
+++ b/tests/test_transforms/test_transform_config.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+from compressed_tensors.transforms.transform_args import (
+    ModuleTarget,
+    TransformationArgs,
+)
+from compressed_tensors.transforms.transform_config import TransformationConfig
+from compressed_tensors.transforms.transform_scheme import TransformationScheme
+
+
+@pytest.fixture
+def basic_transform_scheme():
+    targets = ["Embedding"]
+    module_targets = [ModuleTarget.INPUT_ACTIVATIONS]
+    basic_args = TransformationArgs(targets=targets, module_targets=module_targets)
+
+    scheme = TransformationScheme(
+        transform_type="hadamard",
+        groups=[basic_args],
+        transform_creation_args={"size": 1024},
+    )
+    return scheme
+
+
+def test_basic(basic_transform_scheme):
+    config = TransformationConfig(
+        transform_groups={
+            "transform_0": basic_transform_scheme,
+        }
+    )
+    assert isinstance(config.transform_groups.get("transform_0"), TransformationScheme)
+
+
+def test_to_dict(basic_transform_scheme):
+    config = TransformationConfig(
+        transform_groups={
+            "transform_0": basic_transform_scheme,
+        }
+    )
+    config_dict = config.to_dict()
+
+
+def test_multiple_groups():
+    module_targets = [ModuleTarget.WEIGHTS]
+
+    targets_1 = ["model.layers.0.attn.v_proj"]
+    linear_args_1 = TransformationArgs(targets=targets_1, module_targets=module_targets)
+
+    targets_2 = ["model.layers.0.attn.q_proj"]
+    linear_args_2 = TransformationArgs(targets=targets_2, module_targets=module_targets)
+
+    scheme_1 = TransformationScheme(
+        transform_type="hadamard",
+        groups=[linear_args_1],
+        transform_creation_args={"size": 1024},
+    )
+
+    scheme_2 = TransformationScheme(
+        transform_type="hadamard",
+        groups=[linear_args_2],
+        transform_creation_args={"size": 256},
+    )
+    config = TransformationConfig(
+        transform_groups={"transform_0": scheme_1, "transform_1": scheme_2}
+    )

--- a/tests/test_transforms/test_transform_config.py
+++ b/tests/test_transforms/test_transform_config.py
@@ -52,6 +52,7 @@ def test_to_dict(basic_transform_scheme):
         }
     )
     config_dict = config.to_dict()
+    assert "transform_groups" in config_dict.keys()
 
 
 def test_multiple_groups():

--- a/tests/test_transforms/test_transform_scheme.py
+++ b/tests/test_transforms/test_transform_scheme.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from compressed_tensors.transforms.transform_args import (
+    ModuleTarget,
+    TransformationArgs,
+)
+from compressed_tensors.transforms.transform_scheme import TransformationScheme
+
+
+def test_basic_scheme():
+    targets = ["Linear"]
+    module_targets = [ModuleTarget.INPUT_ACTIVATIONS]
+    basic_args = TransformationArgs(targets=targets, module_targets=module_targets)
+
+    scheme = TransformationScheme(
+        transform_type="hadamard",
+        groups=[basic_args],
+        transform_creation_args={"size": 1024},
+    )
+    assert not scheme.global_transform
+    assert scheme.transform_type == "hadamard"
+    assert scheme.transform_creation_args.get("size") == 1024
+    assert len(scheme.groups) == 1
+    assert isinstance(scheme.groups[0], TransformationArgs)
+
+
+def test_multiple_groups_global():
+    targets = ["Embedding"]
+    module_targets = [ModuleTarget.INPUT_ACTIVATIONS]
+    embedding_args = TransformationArgs(targets=targets, module_targets=module_targets)
+
+    targets = ["Linear"]
+    module_targets = [ModuleTarget.WEIGHTS]
+    linear_args = TransformationArgs(targets=targets, module_targets=module_targets)
+
+    # same transform applied to multiple groups
+    scheme = TransformationScheme(
+        transform_type="hadamard",
+        global_transform=True,
+        groups=[embedding_args, linear_args],
+        transform_creation_args={"size": 1024},
+    )
+
+    assert scheme.global_transform
+    assert scheme.transform_type == "hadamard"
+    assert scheme.transform_creation_args.get("size") == 1024
+    assert len(scheme.groups) == 2
+    assert isinstance(scheme.groups[0], TransformationArgs)
+    assert isinstance(scheme.groups[1], TransformationArgs)
+
+
+def test_multiple_groups():
+    groups = []
+    module_targets = [ModuleTarget.WEIGHTS]
+
+    for i in range(20):
+        targets = [f"model.layers.{i}.attn.v_proj", f"model.layers.{i}.attn.o_proj"]
+        args = TransformationArgs(targets=targets, module_targets=module_targets)
+        groups.append(args)
+
+    # global is False, different hadamard transform applied to each group
+    # same dimension/hidden dim
+    scheme = TransformationScheme(
+        transform_type="hadamard",
+        groups=groups,
+        transform_creation_args={"size": 1024},
+    )
+
+    assert not scheme.global_transform
+    assert scheme.transform_type == "hadamard"
+    assert scheme.transform_creation_args.get("size") == 1024
+    assert len(scheme.groups) == 20

--- a/tests/test_transforms/test_transforms.py
+++ b/tests/test_transforms/test_transforms.py
@@ -40,7 +40,7 @@ from compressed_tensors.transforms.hadamard_utils import random_hadamard_matrix
 )
 def test_random_hadamard_transform(size: int, dtype: torch.dtype):
     hadamard_transform = Transforms.load_from_registry(
-        "random_hadamard", size=size, dtype=dtype
+        "random-hadamard", size=size, dtype=dtype
     )
     # check initialize
     assert hadamard_transform is not None
@@ -73,7 +73,7 @@ def test_random_hadamard_transform(size: int, dtype: torch.dtype):
 def test_random_hadamard_rotation(size: int, dtype: torch.dtype):
     rotation = random_hadamard_matrix(size=size).to(dtype)
     hadamard_transform = Transforms.load_from_registry(
-        "random_hadamard", transform=rotation
+        "random-hadamard", transform=rotation
     )
 
     # check initialize
@@ -126,7 +126,7 @@ def test_deterministic_hadamard_transform(size: int, dtype: torch.dtype):
 def test_multiplier_transform(size: int, dtype: torch.dtype):
     multiplier = torch.eye((size), dtype=dtype)
     multiplier_transform = Transforms.load_from_registry(
-        "matrix_mul", transform=multiplier
+        "matrix-mul", transform=multiplier
     )
     assert multiplier_transform is not None
     assert torch.equal(multiplier_transform, multiplier)
@@ -149,9 +149,9 @@ def test_scalar_transform(scalar: Union[int, float]):
     size = 1024
     dtype = torch.float16
     scalar = torch.Tensor([scalar])
-    scalar_transform = Transforms.load_from_registry("scalar_mul", transform=scalar)
-    assert scalar_transform is not None
-    assert torch.equal(scalar_transform, scalar)
+    scalar_transform = Transforms.load_from_registry("scalar-mul", transform=scalar)
+    assert scalar_transform.transform is not None
+    assert torch.equal(scalar_transform.transform, scalar)
 
     x = torch.rand((size, size), dtype=dtype)
     transformed_value = ScalarMultiply.apply(input_tensor=x, transform=scalar_transform)

--- a/tests/test_transforms/test_transforms.py
+++ b/tests/test_transforms/test_transforms.py
@@ -150,8 +150,8 @@ def test_scalar_transform(scalar: Union[int, float]):
     dtype = torch.float16
     scalar = torch.Tensor([scalar])
     scalar_transform = Transforms.load_from_registry("scalar-mul", transform=scalar)
-    assert scalar_transform.transform is not None
-    assert torch.equal(scalar_transform.transform, scalar)
+    assert scalar_transform is not None
+    assert torch.equal(scalar_transform, scalar)
 
     x = torch.rand((size, size), dtype=dtype)
     transformed_value = ScalarMultiply.apply(input_tensor=x, transform=scalar_transform)


### PR DESCRIPTION
# Summary
- Requires #264 
- Introduce Transform Args, Scheme, Config and Data as structures to define recipes to apply transforms 
- Also adds integration tests which shows the flow from recipes --> transform generation --> applying it to a model

#### `TransformationArgs`
- Define which layers should be targeted by a particular transform, as well which of the layer's parameters and/or activations 

#### `TransformationScheme`
- Details about the particular transform (type and arguments needed during initialization) 
- Includes a list of `TransformationArgs` onto which the transformation will be applied

#### `TransformationConfig`
- A dictionary of the different TransformationSchemes that should be applied to a particular model.
-  The keys can be any arbitrary string and a TransformationScheme should be provided for each new transform type.

# Example:
```python

from compressed_tensors.transforms.transform_args import (
    ModuleTarget,
    TransformationArgs,
)
from compressed_tensors.transforms.transform_config import TransformationConfig
from compressed_tensors.transforms.transform_scheme import TransformationScheme

targets = ["Linear"]
module_targets = [ModuleTarget.WEIGHTS]

linear_layer_args = TransformationArgs(
    targets=targets, module_targets=module_targets
)

scheme = TransformationScheme(
    transform_type="hadamard",
    groups=[linear_layer_args],
    transform_creation_args={"size": 64},
)
config = TransformationConfig(
    transform_groups={
        "transform_0": scheme,
    }
)
```


# ToDo / Next Steps:
- TransformData contains relevant information needed during runtime but this could potentially be removed depending on the integration level