### PR TITLE
Update: CompressedLinear to decompress once

### DIFF
--- a/src/compressed_tensors/linear/compressed_linear.py
+++ b/src/compressed_tensors/linear/compressed_linear.py
@@ -38,6 +38,10 @@ class CompressedLinear(Linear):
     :param quantization_format: compression format module is stored as
     """
 
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.is_decompressed_ = False
+
     @classmethod
     @torch.no_grad()
     def from_linear(
@@ -86,5 +90,8 @@ class CompressedLinear(Linear):
         """
         Decompresses the weight, then runs the wrapped forward pass
         """
-        uncompressed_weight = self.compressor.decompress_module(self)
-        return linear(input, uncompressed_weight, self.bias)
+        if not self.is_decompressed_:
+            self.weight = self.compressor.decompress_module(self)
+            self.is_decompressed_ = True
+
+        return linear(input, self.weight, self.bias)

--- a/src/compressed_tensors/linear/compressed_linear.py
+++ b/src/compressed_tensors/linear/compressed_linear.py
@@ -40,7 +40,7 @@ class CompressedLinear(Linear):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.is_decompressed_ = False
+        self._is_compressed = True
 
     @classmethod
     @torch.no_grad()
@@ -90,8 +90,8 @@ class CompressedLinear(Linear):
         """
         Decompresses the weight, then runs the wrapped forward pass
         """
-        if not self.is_decompressed_:
+        if self._is_compressed:
             self.weight = self.compressor.decompress_module(self)
-            self.is_decompressed_ = True
+            self._is_compressed = False
 
         return linear(input, self.weight, self.bias)


### PR DESCRIPTION
Signed-off-by: Rahul Tuli <rahul@neuralmagic.com>
For: https://github.com/neuralmagic/compressed-tensors/issues/267

Before this PR CompressedLinear would decompress the compressed weights on every forward pass. This PR adds a flag to check if weights have been decompressed, if yes then decompression is not run again.