### PR TITLE
Some fixes for AWQ

### DIFF
--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -199,6 +199,18 @@ FP8_DYNAMIC = dict(
     ),
 )
 
+# AWQ quantization
+AWQ = dict(
+    weights=QuantizationArgs(
+        num_bits=4,
+        type=QuantizationType.INT,
+        strategy=QuantizationStrategy.GROUP,
+        symmetric=False,
+        dynamic=False,
+        group_size=128,
+    ),
+)
+
 PRESET_SCHEMES = {
     # Unquantized (no-op)
     "UNQUANTIZED": UNQUANTIZED,
@@ -212,4 +224,5 @@ PRESET_SCHEMES = {
     # Float weight and activation schemes
     "FP8": FP8,
     "FP8_DYNAMIC": FP8_DYNAMIC,
+    "AWQ": AWQ,
 }

--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -142,6 +142,18 @@ W4A16 = dict(
     ),
 )
 
+# 4 bit integer weights only asymmetric quantization
+W4A16_ASYM = dict(
+    weights=QuantizationArgs(
+        num_bits=4,
+        type=QuantizationType.INT,
+        strategy=QuantizationStrategy.GROUP,
+        group_size=128,
+        symmetric=False,
+        dynamic=False,
+    ),
+)
+
 # 4 bit integer weights and 8 bit activations quantization
 INT8_W4A8 = dict(
     weights=QuantizationArgs(
@@ -199,24 +211,13 @@ FP8_DYNAMIC = dict(
     ),
 )
 
-# AWQ quantization
-AWQ = dict(
-    weights=QuantizationArgs(
-        num_bits=4,
-        type=QuantizationType.INT,
-        strategy=QuantizationStrategy.GROUP,
-        symmetric=False,
-        dynamic=False,
-        group_size=128,
-    ),
-)
-
 PRESET_SCHEMES = {
     # Unquantized (no-op)
     "UNQUANTIZED": UNQUANTIZED,
     # Integer weight only schemes
     "W8A16": W8A16,
     "W4A16": W4A16,
+    "W4A16_ASYM": W4A16_ASYM,
     # Integer weight and activation schemes
     "W8A8": INT8_W8A8,
     "INT8": INT8_W8A8,  # alias for W8A8
@@ -224,5 +225,4 @@ PRESET_SCHEMES = {
     # Float weight and activation schemes
     "FP8": FP8,
     "FP8_DYNAMIC": FP8_DYNAMIC,
-    "AWQ": AWQ,
 }

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -80,7 +80,7 @@ def calculate_qparams(
         zero_points = torch.zeros(scales.shape, device=device, dtype=min_vals.dtype)
     else:
         scales = (max_vals - min_vals) / float(bit_range)
-        scales = torch.clamp(scales, min=1e-5)
+        scales = torch.clamp(scales, min=torch.finfo(torch.float32).eps)
         zero_points = bit_min - (min_vals / scales)
         zero_points = torch.clamp(torch.round(zero_points), bit_min, bit_max)
 

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -84,9 +84,12 @@ def calculate_qparams(
         scales = (max_vals - min_vals) / float(bit_range)
         scales = torch.clamp(scales, min=torch.finfo(torch.float32).eps)
         zero_points = bit_min - (min_vals / scales)
-        zero_points = torch.clamp(torch.round(zero_points), bit_min, bit_max)
+        zero_points = torch.clamp(zero_points, bit_min, bit_max)
 
     # match zero-points to quantized type
+    # if casting to int, use round instead of truncate
+    if quantization_args.type == QuantizationType.INT:
+        zero_points = torch.round(zero_points)
     zero_points = zero_points.to(zp_dtype)
 
     if scales.ndim == 0:


### PR DESCRIPTION
This aligns the logic for asymmetric quantization with the implementation found in AutoAWQ's [`pseudo_quantize_tensor`](https://github.com/casper-hansen/AutoAWQ/blob/23d584c25d80381671293d2f08a9fadfa5a8986a/awq/quantize/quantizer.py#L74) function. This is some core logic here so we should all make sure we're in agreement with the changes before merging in.

To be reviewed/merged in conjunction with https://github.com/vllm-project/llm-compressor/pull/1177