### PR TITLE
[Utils] add align_modules

### DIFF
--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -28,7 +28,7 @@ Utilities associated with offloading functionality provided by `accelerate`.
 import contextlib
 import warnings
 from functools import wraps
-from typing import Any, Callable, Dict, Literal, Optional, Union
+from typing import Any, Callable, Dict, Iterable, Literal, Optional, Union
 
 import torch
 
@@ -67,6 +67,7 @@ __all__ = [
     "delete_offload_parameter",
     "has_offloaded_params",
     "disable_hf_hook",
+    "align_modules",
     "align_module_device",
 ]
 
@@ -339,6 +340,31 @@ def delete_from_weights_map(
             "Updating offload data not implemented for weights_map of type "
             f"{type(weights_map)}"
         )
+
+
+@contextlib.contextmanager
+def align_modules(
+    modules: Iterable[torch.nn.Module], execution_device: Optional[torch.device] = None
+):
+    original_devices = {}
+    can_offload = [module for module in modules if has_offloaded_params(module)]
+
+    for module in can_offload:
+        if execution_device is not None:
+            module._hf_hook.execution_device = execution_device
+            original_devices[module] = module._hf_hook.execution_device
+
+        module._hf_hook.pre_forward(module)
+        module._hf_hook.offload = False
+
+    yield
+
+    for module in can_offload:
+        if execution_device is not None:
+            module._hf_hook.execution_device = original_devices[module]
+
+        module._hf_hook.offload = True
+        module._hf_hook.post_forward(module, None)
 
 
 """ Upstreamed Functions """

--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -359,7 +359,6 @@ def disable_offload(module: torch.nn.Module):
         yield
 
 
-# TODO remove after https://github.com/neuralmagic/compressed-tensors/pull/282 lands
 @contextlib.contextmanager
 def align_modules(
     modules: Union[torch.nn.Module, Iterable[torch.nn.Module]],

--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -346,8 +346,8 @@ def delete_from_weights_map(
 @contextlib.contextmanager
 def disable_offload(module: torch.nn.Module):
     """
-    Disable module onloading and offloading. Parameters will stay on their current
-    device
+    Context manager to disable module onloading and offloading. Parameters will stay on
+    their current device
 
     :param module: module to disable offloading for
     """
@@ -365,7 +365,8 @@ def align_modules(
     execution_device: Optional[torch.device] = None,
 ):
     """
-    Onload modules to a device, disable onload attempts triggered by forward calls
+    Context manager for onloading modules to a device, and disabling onload and offload
+    attempts triggered by forward calls. Used for sequential onloading of layers
 
     :param modules: `torch.nn.Module` or iterable of `torch.nn.Module`s to onload
     :param execution_device: device to onload to
@@ -375,7 +376,7 @@ def align_modules(
     with contextlib.ExitStack() as stack:
         for module in modules:
             stack.enter_context(align_module_device(module, execution_device))
-            stack.enter_context(disable_offload(module))  # disable redudant onloading
+            stack.enter_context(disable_offload(module))  # disable redundant onloading
         yield
 
 

--- a/tests/test_utils/test_offload.py
+++ b/tests/test_utils/test_offload.py
@@ -15,6 +15,7 @@ import pytest
 import torch
 from compressed_tensors.utils import (
     align_module_device,
+    align_modules,
     delete_offload_parameter,
     disable_hf_hook,
     has_offloaded_params,
@@ -201,6 +202,35 @@ def test_disable_hf_hook_model_recurse():
     assert hasattr(module0, "_hf_hook")
     assert hasattr(module1, "_hf_hook")
     assert hasattr(module2, "_hf_hook")
+
+
+@requires_accelerate()
+def test_align_modules():
+    from accelerate.hooks import attach_align_device_hook
+
+    module0 = ExampleModule()
+    module1 = ExampleModule()
+    module2 = ExampleModule()
+    model = torch.nn.Sequential(module0, torch.nn.Sequential(module1, module2))
+    attach_align_device_hook(
+        model,
+        execution_device=torch.device("cpu"),
+        offload=True,
+        weights_map=model.state_dict(),
+    )
+
+    assert module0.a.device == torch.device("meta")
+    assert module1.a.device == torch.device("meta")
+    assert module2.a.device == torch.device("meta")
+
+    with align_modules((module0, module1)):
+        assert module0.a.device != torch.device("meta")
+        assert module1.a.device != torch.device("meta")
+        assert module2.a.device == torch.device("meta")
+
+    assert module0.a.device == torch.device("meta")
+    assert module1.a.device == torch.device("meta")
+    assert module2.a.device == torch.device("meta")
 
 
 @requires_accelerate()


### PR DESCRIPTION
## Purpose ##
* Implement utility used by https://github.com/vllm-project/llm-compressor/pull/1263
  * Nice grouping of accelerate utilities

## Changes ##
* Implement `align_modules`, which allows for multiple modules to be onloaded/offloaded at the same time
```python3
for layer in layers:
    with align_modules(layer.modules()):
        layer(batch)
```

## Testing ##
* Added test in `tests/test_utils/test_offload.py`