### PR TITLE
use fine-grained token for workflow

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -121,7 +121,7 @@ jobs:
             - name: update "nm-pypi" index
               uses: actions/github-script@v6
               with:
-                github-token: ${{ secrets.CICD_GITHUB_PAT }}
+                github-token: ${{ secrets.NM_PYPI_WORKFLOW }}
                 script: |
                   const result = await github.rest.actions.createWorkflowDispatch({
                     owner: 'neuralmagic',


### PR DESCRIPTION
Need to replace the CICD_GITHUB_PAT with a more find-grained and secure token that's only allowed for compressed-tensors and stratus repos with permissions to actions only. The new token also has a 30d life cycle to be updated.