### PR TITLE
Reduce memory requirements of quantized compression

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -517,9 +517,7 @@ class ModelCompressor:
                 update_parameter_data(module, data, param_name)
 
 
-def map_module_to_scheme(
-    model: Module,
-) -> Dict[str, QuantizationScheme]:
+def map_module_to_scheme(model: Module) -> Dict[str, QuantizationScheme]:
     """
     Given a pytorch model, map out the submodule name (usually linear layers)
     to the weight QuantizationArgs. If running input activation quantization, will also

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -519,11 +519,7 @@ class ModelCompressor:
 
 def map_module_to_scheme(model: Module) -> Dict[str, QuantizationScheme]:
     """
-    Given a pytorch model, map out the submodule name (usually linear layers)
-    to the weight QuantizationArgs. If running input activation quantization, will also
-    map to the input QuantizationArgs in a tuple.
-
-    :param model: pytorch model
+    Returns a dictionary which maps quantized module names to their quantization schemes
     """
     quantized_modules_to_args = {}
     for name, submodule in iter_named_leaf_modules(model):

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -41,7 +41,6 @@ from compressed_tensors.quantization import (
     load_pretrained_quantization,
 )
 from compressed_tensors.quantization.lifecycle import expand_target_names
-from compressed_tensors.quantization.quant_args import QuantizationArgs
 from compressed_tensors.quantization.utils import (
     is_module_quantized,
     iter_named_leaf_modules,
@@ -62,7 +61,7 @@ from transformers import AutoConfig
 from transformers.file_utils import CONFIG_NAME
 
 
-__all__ = ["ModelCompressor", "map_modules_to_quant_scheme"]
+__all__ = ["ModelCompressor", "map_module_to_scheme"]
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -373,11 +372,8 @@ class ModelCompressor:
         if state_dict is None:
             state_dict = model.state_dict()
 
-        module_to_scheme: Dict[str, QuantizationScheme] = map_modules_to_quant_scheme(
-            model
-        )
-
         if self.quantization_compressor is not None:
+            module_to_scheme = map_module_to_scheme(model)
             state_dict = self.quantization_compressor.compress(
                 state_dict, names_to_scheme=module_to_scheme
             )
@@ -521,7 +517,7 @@ class ModelCompressor:
                 update_parameter_data(module, data, param_name)
 
 
-def map_modules_to_quant_scheme(
+def map_module_to_scheme(
     model: Module,
 ) -> Dict[str, QuantizationScheme]:
     """

--- a/src/compressed_tensors/compressors/quantized_compressors/base.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/base.py
@@ -76,8 +76,7 @@ class BaseQuantizationCompressor(BaseCompressor):
         """
         Compresses a dense state dict
 
-        :param model_state: state dict of uncompressed model, consumed during
-            compression
+        :param model_state: state dict of uncompressed model, consumed by compression
         :param names_to_scheme: quantization args for each quantized weight, needed for
             quantize function to calculate bit depth
         :return: compressed state dict

--- a/src/compressed_tensors/compressors/quantized_compressors/base.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/base.py
@@ -102,7 +102,7 @@ class BaseQuantizationCompressor(BaseCompressor):
                     model_state[name] = value.to(save_device)
                     continue
 
-                # compress values on cpu. TODO: experiment with different devices
+                # compress values on cpu (memory movement too expensive)
                 quant_args = names_to_scheme[prefix].weights
                 compressed_values = self.compress_weight(
                     weight=value,

--- a/src/compressed_tensors/compressors/quantized_compressors/base.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/base.py
@@ -18,11 +18,12 @@ from typing import Any, Dict, Generator, Tuple, Union
 
 import torch
 from compressed_tensors.compressors.base import BaseCompressor
-from compressed_tensors.quantization import QuantizationArgs
+from compressed_tensors.quantization import QuantizationScheme
 from compressed_tensors.utils import (
     get_nested_mappings_from_state_dict,
     get_nested_weight_mappings,
     merge_names,
+    remove_suffix,
 )
 from safetensors import safe_open
 from torch import Tensor
@@ -69,87 +70,74 @@ class BaseQuantizationCompressor(BaseCompressor):
     def compress(
         self,
         model_state: Dict[str, Tensor],
-        names_to_scheme: Dict[str, QuantizationArgs],
+        names_to_scheme: Dict[str, QuantizationScheme],
         **kwargs,
     ) -> Dict[str, Tensor]:
         """
         Compresses a dense state dict
 
-        :param model_state: state dict of uncompressed model
+        :param model_state: state dict of uncompressed model, consumed during
+            compression
         :param names_to_scheme: quantization args for each quantized weight, needed for
             quantize function to calculate bit depth
         :return: compressed state dict
         """
-        compressed_dict = {}
-        weight_suffix = ".weight"
-        input_zp_suffix = ".input_zero_point"
-        weight_zp_suffix = ".weight_zero_point"
-        _LOGGER.debug(
-            f"Compressing model with {len(model_state)} parameterized layers..."
-        )
+        save_device = "cpu"
 
-        for name, value in tqdm(model_state.items(), desc="Quantized Compression"):
-            # check if the parameter we're compressing is the weight zp
-            # or the input zp
-            is_weight_zp = name.endswith(weight_zp_suffix)
-            is_input_zp = name.endswith(input_zp_suffix)
+        uncompressed_names = list(model_state.keys())
+        for name in tqdm(uncompressed_names, desc="Compressing with quantization"):
+            value = model_state[name]
 
-            # if we're saving the weight zp, fetch weight quant args
-            if is_weight_zp:
-                quant_args_zp = names_to_scheme.get(name[: -(len(weight_zp_suffix))])
-                if isinstance(quant_args_zp, tuple):
-                    # If tuple, first value is weight args, second is input args
-                    quant_args_zp = quant_args_zp[0]
+            # compress weights
+            if name.endswith(".weight"):
+                prefix = remove_suffix(name, ".weight")
 
-            # if we're saving the input zp, fetch input quant args
-            if is_input_zp:
-                input_args_zp = names_to_scheme.get(name[: -(len(input_zp_suffix))])
-                if isinstance(input_args_zp, tuple):
-                    # If tuple, first value is weight args, second is input args
-                    input_args_zp = input_args_zp[-1]
-
-            if name.endswith(weight_suffix):
-                prefix = name[: -(len(weight_suffix))]
+                # gather qparams
                 scale = model_state.get(merge_names(prefix, "weight_scale"), None)
-                zp = model_state.get(merge_names(prefix, "weight_zero_point"), None)
                 g_idx = model_state.get(merge_names(prefix, "weight_g_idx"), None)
-                if scale is not None:
-                    # weight is quantized, compress it
-                    if isinstance(names_to_scheme[prefix], tuple):
-                        quant_args = names_to_scheme[prefix][0]
-                    else:
-                        quant_args = names_to_scheme[prefix]
+                zp = model_state.get(merge_names(prefix, "weight_zero_point"), None)
 
-                    compressed_data = self.compress_weight(
-                        weight=value,
-                        scale=scale,
-                        zero_point=zp,
-                        g_idx=g_idx,
-                        quantization_args=quant_args,
-                        device="cpu",
-                    )
-                    for key, value in compressed_data.items():
-                        compressed_dict[merge_names(prefix, key)] = value
-                else:
-                    compressed_dict[name] = value.to("cpu")
-            # only save if asym
-            elif is_weight_zp and quant_args_zp.symmetric:
-                continue
-            # only save if asym
-            elif is_input_zp and input_args_zp.symmetric:
-                continue
-            elif name.endswith("g_idx") and torch.any(value <= -1):
-                continue
+                # is scale does not exist, then weight cannot be compressed
+                if scale is None:
+                    model_state[name] = value.to(save_device)
+                    continue
+
+                # compress values on cpu. TODO: experiment with different devices
+                quant_args = names_to_scheme[prefix].weights
+                compressed_values = self.compress_weight(
+                    weight=value,
+                    scale=scale,
+                    zero_point=zp,
+                    g_idx=g_idx,
+                    quantization_args=quant_args,
+                    device="cpu",
+                )
+
+                # update state dict
+                del model_state[name]
+                for key, value in compressed_values.items():
+                    model_state[merge_names(prefix, key)] = value.to(save_device)
+
             else:
-                compressed_dict[name] = value.to("cpu")
+                # omit saving zero points for symmetric quantization
+                if name.endswith("zero_point") and _is_symmetric(name, names_to_scheme):
+                    del model_state[name]
 
-        return compressed_dict
+                # omit saving for g_idx if uninitialized
+                # TODO: does this case actually occur?
+                elif name.endswith("g_idx") and torch.any(value <= -1):
+                    del model_state[name]
+
+                else:
+                    model_state[name] = value.to(save_device)
+
+        return model_state
 
     def decompress(
         self,
         path_to_model_or_tensors: Union[str, Path, Dict[str, Any]],
-        names_to_scheme: Dict[str, QuantizationArgs],
-        device: str = "cpu",
+        names_to_scheme: Dict[str, QuantizationScheme],
+        device: torch.device = "cpu",
     ) -> Generator[Tuple[str, Tensor], None, None]:
         """
         Reads a compressed state dict located at path_to_model_or_tensors
@@ -157,7 +145,7 @@ class BaseQuantizationCompressor(BaseCompressor):
         dense state dict
         :param path_to_model_or_tensors: path to compressed safetensors model (directory
             with one or more safetensors files) or compressed tensors file
-        :param names_to_scheme: quantization args for each quantized weight
+        :param names_to_scheme: quantization scheme for each quantized weight
         :param device: optional device to load intermediate weights into
         :return: compressed state dict
         """
@@ -171,7 +159,12 @@ class BaseQuantizationCompressor(BaseCompressor):
                 path_to_model_or_tensors, names_to_scheme
             )
 
-    def _decompress_from_path(self, path_to_model, names_to_scheme, device):
+    def _decompress_from_path(
+        self,
+        path_to_model: Union[str, Path, Dict[str, Any]],
+        names_to_scheme: Dict[str, QuantizationScheme],
+        device: torch.device,
+    ):
         weight_mappings = get_nested_weight_mappings(
             path_to_model, self.compression_param_names
         )
@@ -182,13 +175,17 @@ class BaseQuantizationCompressor(BaseCompressor):
                 with safe_open(safe_path, framework="pt", device=device) as f:
                     weight_data[param_name] = f.get_tensor(full_name)
             if "weight_scale" in weight_data:
-                quant_args = names_to_scheme[weight_name]
+                quant_args = names_to_scheme[weight_name].weights
                 decompressed = self.decompress_weight(
                     compressed_data=weight_data, quantization_args=quant_args
                 )
                 yield merge_names(weight_name, "weight"), decompressed
 
-    def _decompress_from_state_dict(self, state_dict, names_to_scheme):
+    def _decompress_from_state_dict(
+        self,
+        state_dict: Dict[str, torch.Tensor],
+        names_to_scheme: Dict[str, QuantizationScheme],
+    ):
         weight_mappings = get_nested_mappings_from_state_dict(
             state_dict, self.compression_param_names
         )
@@ -198,8 +195,23 @@ class BaseQuantizationCompressor(BaseCompressor):
                 weight_data[param_name] = param_value
 
             if "weight_scale" in weight_data:
-                quant_args = names_to_scheme[weight_name]
+                quant_args = names_to_scheme[weight_name].weights
                 decompressed = self.decompress_weight(
                     compressed_data=weight_data, quantization_args=quant_args
                 )
                 yield merge_names(weight_name, "weight"), decompressed
+
+
+def _is_symmetric(name: str, names_to_scheme: Dict[str, QuantizationScheme]) -> bool:
+    weight_name, zp_name = name.rsplit(".", 1)
+    scheme = names_to_scheme[weight_name]
+
+    if zp_name == "weight_zero_point":
+        quant_args = scheme.weights
+    if zp_name == "input_zero_point":
+        quant_args = scheme.input_activations
+    if zp_name == "output_zero_point":
+        quant_args = scheme.output_activations
+
+    assert quant_args is not None
+    return quant_args.symmetric

--- a/src/compressed_tensors/compressors/sparse_compressors/base.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/base.py
@@ -76,7 +76,7 @@ class BaseSparseCompressor(BaseCompressor):
         _LOGGER.debug(
             f"Compressing model with {len(model_state)} parameterized layers..."
         )
-        for name, value in tqdm(model_state.items(), desc="Compressing model"):
+        for name, value in tqdm(model_state.items(), desc="Compressing with sparsity"):
             if not self.should_compress(name, compression_targets):
                 compressed_dict[name] = value
                 continue

--- a/src/compressed_tensors/compressors/sparse_quantized_compressors/marlin_24.py
+++ b/src/compressed_tensors/compressors/sparse_quantized_compressors/marlin_24.py
@@ -19,7 +19,11 @@ import numpy as np
 import torch
 from compressed_tensors.compressors.base import BaseCompressor
 from compressed_tensors.config import CompressionFormat
-from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationScheme,
+    QuantizationStrategy,
+)
 from compressed_tensors.quantization.lifecycle.forward import quantize
 from compressed_tensors.utils import (
     get_permutations_24,
@@ -44,19 +48,25 @@ class Marlin24Compressor(BaseCompressor):
 
     @staticmethod
     def validate_quant_compatability(
-        model_quant_args: Dict[str, QuantizationArgs]
+        names_to_scheme: Dict[str, QuantizationScheme]
     ) -> bool:
         """
         Checks if every quantized module in the model is compatible with Marlin24
         compression. Quantization must be channel or group strategy with group_size
         of 128. Only symmetric quantization is supported
 
-        :param model_quant_args: dictionary of mapping module names to their
-            quantization configuration
+        :param names_to_scheme: dictionary of mapping module names to their
+            quantization schemes
         :return: True if all modules are compatible with Marlin24 compression, raises
             a ValueError otherwise
         """
-        for name, quant_args in model_quant_args.items():
+        for name, scheme in names_to_scheme.items():
+            quant_args = scheme.weights
+            if quant_args is None:
+                raise ValueError(
+                    "Marlin24 Compressor is only valid for weight quantization schemes"
+                )
+
             strategy = quant_args.strategy
             group_size = quant_args.group_size
             symmetric = quant_args.symmetric
@@ -114,7 +124,7 @@ class Marlin24Compressor(BaseCompressor):
     def compress(
         self,
         model_state: Dict[str, Tensor],
-        names_to_scheme: Dict[str, QuantizationArgs],
+        names_to_scheme: Dict[str, QuantizationScheme],
         **kwargs,
     ) -> Dict[str, Tensor]:
         """
@@ -122,8 +132,8 @@ class Marlin24Compressor(BaseCompressor):
         with the Marlin24 kernel
 
         :param model_state: state dict of uncompressed model
-        :param names_to_scheme: quantization args for each quantized weight, needed for
-           quantize function to calculate bit depth
+        :param names_to_scheme: quantization scheme for each quantized weight, needed
+            for quantize function to calculate bit depth
         :return: compressed state dict
         """
         self.validate_quant_compatability(names_to_scheme)
@@ -146,7 +156,7 @@ class Marlin24Compressor(BaseCompressor):
                     value = value.to(torch.float16)
 
                     # quantize weight, keeping it as a float16 for now
-                    quant_args = names_to_scheme[prefix]
+                    quant_args = names_to_scheme[prefix].weights
                     value = quantize(
                         x=value, scale=scale, zero_point=zp, args=quant_args
                     )
@@ -215,7 +225,7 @@ def pack_weight_24(
     weight: Tensor,
     quantization_args: QuantizationArgs,
     tile: int = 16,
-):
+) -> torch.Tensor:
     size_k = weight.shape[0]
     size_n = weight.shape[1]
     num_bits = quantization_args.num_bits
@@ -236,7 +246,9 @@ def pack_weight_24(
     return q_packed
 
 
-def pack_scales_24(scales, quantization_args, w_shape):
+def pack_scales_24(
+    scales: torch.Tensor, quantization_args: QuantizationArgs, w_shape: torch.Size
+) -> torch.Tensor:
     size_k = w_shape[0]
     size_n = w_shape[1]
     num_bits = quantization_args.num_bits

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -38,6 +38,7 @@ __all__ = [
     "shard_tensor",
     "pack_bitmasks",
     "unpack_bitmasks",
+    "remove_suffix",
 ]
 
 FSDP_WRAPPER_NAME = "_fsdp_wrapped_module"
@@ -328,3 +329,9 @@ def unpack_bitmasks(
     )
 
     return unpacked_bitmasks_torch
+
+
+def remove_suffix(value: str, suffix: str) -> str:
+    # can replace with str.removesuffix in python3.9+
+    assert value.endswith(suffix)
+    return value[: -len(suffix)]

--- a/tests/test_compressors/quantized_compressors/test_pack_quant.py
+++ b/tests/test_compressors/quantized_compressors/test_pack_quant.py
@@ -39,7 +39,7 @@ from torch.nn.modules import Linear, Sequential
 
 def get_dummy_quant_config(
     num_bits=4, strategy=None, group_size=None, actorder=None, symmetric=True
-):
+) -> QuantizationConfig:
     config_groups = {
         "group_1": QuantizationScheme(
             targets=["Linear"],
@@ -81,9 +81,9 @@ def test_quant_format(shape):
     quant_config = get_dummy_quant_config()
 
     compressor = PackedQuantizationCompressor(config=quant_config)
-    quantized_modules_to_args = {"dummy": quant_config.config_groups["group_1"].weights}
+    quantized_modules_to_scheme = {"dummy": quant_config.config_groups["group_1"]}
     compressed_state_dict = compressor.compress(
-        dense_state_dict, names_to_scheme=quantized_modules_to_args
+        dense_state_dict, names_to_scheme=quantized_modules_to_scheme
     )
 
     # compressed state_dict adds one entry for shape
@@ -156,25 +156,21 @@ def test_reload_match(tmp_path, num_bits):
 
     # pack-compressor only needs the number of bits from the quant-args to decompress
     # all other information is extracted from the compressed data directly
-    names_to_scheme = {
-        "dummy": QuantizationArgs(num_bits=num_bits),
-        "dummy2": QuantizationArgs(num_bits=num_bits),
-    }
     quant_config = get_dummy_quant_config(num_bits, symmetric=False)
 
     compressor = PackedQuantizationCompressor(config=quant_config)
-    quantized_modules_to_args = {
-        "dummy": quant_config.config_groups["group_1"].weights,
-        "dummy2": quant_config.config_groups["group_1"].weights,
+    quantized_modules_to_scheme = {
+        "dummy": quant_config.config_groups["group_1"],
+        "dummy2": quant_config.config_groups["group_1"],
     }
 
     compressed_state_dict = compressor.compress(
-        dense_state_dict, names_to_scheme=quantized_modules_to_args
+        dense_state_dict.copy(), names_to_scheme=quantized_modules_to_scheme
     )
     save_file(compressed_state_dict, tmp_path / "model.safetensors")
 
     reconstructed_dense_gen = compressor.decompress(
-        tmp_path, names_to_scheme=names_to_scheme
+        tmp_path, names_to_scheme=quantized_modules_to_scheme
     )
     reconstructed_dense = {}
     for name, value in reconstructed_dense_gen:
@@ -184,7 +180,7 @@ def test_reload_match(tmp_path, num_bits):
         dense_state_dict["dummy.weight"],
         scale=dense_state_dict["dummy.weight_scale"],
         zero_point=dense_state_dict["dummy.weight_zero_point"],
-        args=quantized_modules_to_args["dummy"],
+        args=quantized_modules_to_scheme["dummy"].weights,
     )
     assert torch.equal(
         fake_quant_dummy, reconstructed_dense["dummy.weight"].to(torch.float32)
@@ -194,7 +190,7 @@ def test_reload_match(tmp_path, num_bits):
         dense_state_dict["dummy2.weight"],
         scale=dense_state_dict["dummy2.weight_scale"],
         zero_point=dense_state_dict["dummy2.weight_zero_point"],
-        args=quantized_modules_to_args["dummy2"],
+        args=quantized_modules_to_scheme["dummy2"].weights,
     )
     assert torch.equal(
         fake_quant_dummy2, reconstructed_dense["dummy2.weight"].to(torch.float32)
@@ -231,17 +227,17 @@ def test_actorder_reload_match(actorder, tmp_path, mock_per_group_calibration):
 
     # compress
     compressor = PackedQuantizationCompressor(config=quant_config)
-    quantized_modules_to_args = {
-        "dummy": quant_config.config_groups["group_1"].weights,
+    quantized_modules_to_scheme = {
+        "dummy": quant_config.config_groups["group_1"],
     }
     compressed_state_dict = compressor.compress(
-        model.state_dict(), names_to_scheme=quantized_modules_to_args
+        model.state_dict(), names_to_scheme=quantized_modules_to_scheme
     )
     save_file(compressed_state_dict, tmp_path / "model.safetensors")
 
     # decompress
     reconstructed_dense_gen = compressor.decompress(
-        tmp_path, names_to_scheme=quantized_modules_to_args
+        tmp_path, names_to_scheme=quantized_modules_to_scheme
     )
     reconstructed_dense = {}
     for name, value in reconstructed_dense_gen:
@@ -252,7 +248,7 @@ def test_actorder_reload_match(actorder, tmp_path, mock_per_group_calibration):
         scale=model.dummy.weight_scale,
         zero_point=model.dummy.weight_zero_point,
         g_idx=getattr(model.dummy, "weight_g_idx", None),
-        args=quantized_modules_to_args["dummy"],
+        args=quantized_modules_to_scheme["dummy"].weights,
     )
     assert torch.equal(fake_quant_dummy, reconstructed_dense["dummy.weight"])
 

--- a/tests/test_compressors/sparse_quantized_compressors/test_marlin_24.py
+++ b/tests/test_compressors/sparse_quantized_compressors/test_marlin_24.py
@@ -19,7 +19,7 @@ import torch
 from compressed_tensors.compressors import (
     BaseCompressor,
     Marlin24Compressor,
-    map_modules_to_quant_args,
+    map_module_to_scheme,
 )
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization import (
@@ -92,9 +92,9 @@ def test_marlin24_format(
     assert f"{NOT_QUANT_NAME}.weight_scale" not in state_dict
     assert f"{QUANT_NAME}.weight_scale" in state_dict
 
-    model_to_quant_args = map_modules_to_quant_args(model)
+    module_to_scheme = map_module_to_scheme(model)
     compressor = Marlin24Compressor()
-    compressor.validate_quant_compatability(model_to_quant_args)
+    compressor.validate_quant_compatability(module_to_scheme)
     compressor.validate_sparsity_structure(
         QUANT_NAME, state_dict[f"{QUANT_NAME}.weight"]
     )
@@ -104,7 +104,7 @@ def test_marlin24_format(
         )
 
     compressor = Marlin24Compressor()
-    compressed_state_dict = compressor.compress(state_dict, model_to_quant_args)
+    compressed_state_dict = compressor.compress(state_dict, module_to_scheme)
 
     assert len(compressed_state_dict) == 4
     assert torch.equal(


### PR DESCRIPTION
## Purpose ##
* Reduce memory requirements of quantized compression by *not* duplicating tensors when compressing values
* Simplify quantized compression logic

## Changes ##
* `map_modules_to_quant_args` -> `map_module_to_scheme`
  * Rather than conditionally returning `scheme.weights` or a tuple of `(scheme.weights, scheme.input_activations)`, this function now returns the `scheme` directly
  * This both narrows the return type and provides more flexibility for activation-only/ output quantization
  * Update `Marlin24Compressor` to validate use schemes
* Reduce `BaseQuantizationCompressor.compress` reduce peak memory usage
  * By consuming the original state dict, this function no longer requires extra memory for a `model_state` and a `compressed_state_dict`
  * All logic for detecting symmetric zero points is now replaced by one line