### PR TITLE
Remove compression_ratio calculation

### DIFF
--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -230,10 +230,6 @@ class QuantizationConfig(BaseModel):
             group_name = "group_" + str(idx)
             config_groups[group_name] = scheme
 
-        # TODO: this is incorrect in compressed mode, since we are overwriting the
-        # original weight we lose the uncompressed bit_depth indo
-        compression_ratio = calculate_compression_ratio(model)
-
         if format is None:
             if quantization_status == QuantizationStatus.COMPRESSED:
                 format = CompressionFormat.int_quantized.value
@@ -244,7 +240,7 @@ class QuantizationConfig(BaseModel):
             config_groups=config_groups,
             quantization_status=quantization_status,
             kv_cache_scheme=kv_cache_scheme,
-            global_compression_ratio=compression_ratio,
+            global_compression_ratio=None,
             format=format,
             ignore=consolidated_ignore,
         )

--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -184,8 +184,9 @@ def test_serialize_config_tinyllama():
     assert serialized_config.format == CompressionFormat.dense.value
     assert serialized_config.quant_method == DEFAULT_QUANTIZATION_METHOD
     assert serialized_config.ignore == ["model.layers.1.mlp.down_proj"]
-    assert serialized_config.global_compression_ratio > 1.0
-    assert serialized_config.global_compression_ratio < 8.0
+    if serialized_config.global_compression_ratio is not None:
+        assert serialized_config.global_compression_ratio > 1.0
+        assert serialized_config.global_compression_ratio < 8.0
 
 
 def _test_layer_quantization_status(


### PR DESCRIPTION
# Summary:
- Remove calculation for compression-ratio which is long running potentially also incorrect
- If we were to fix the calculation/if it were useful to users, we could enable it again but will otherwise look into removing the field in a follow-up if it does not hurt backwards compat with vLLM (it shouldn't)