### PR TITLE
Fix `_initialize_scale_zero_point` initializing on the wrong device

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -31,6 +31,7 @@ from compressed_tensors.quantization.quant_scheme import QuantizationScheme
 from compressed_tensors.quantization.utils import is_kv_cache_quant_scheme
 from compressed_tensors.utils import (
     disable_hf_hook,
+    get_execution_device,
     has_offloaded_params,
     register_offload_parameter,
 )
@@ -141,12 +142,7 @@ def _initialize_scale_zero_point(
         return
 
     # initialize on execution device to avoid performing quantized ops on cpu
-    params_device = next(module.parameters()).device
-    device = (
-        module._hf_hook.execution_device
-        if has_offloaded_params(module)
-        else params_device
-    )
+    device = get_execution_device(module)
 
     # infer expected scale/zero point shape
     if quantization_args.strategy == QuantizationStrategy.TOKEN:

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -144,7 +144,7 @@ def _initialize_scale_zero_point(
     # in the offloaded case, there's no point moving tensors to the execution device
     # if they're going to be immediately offloaded by `register_offload_parameter`
     params_device = next(module.parameters()).device
-    device = "cpu" if has_offloaded_params(module) else params_device
+    device = module._hf_hook.execution_device if has_offloaded_params(module) else params_device
 
     # infer expected scale/zero point shape
     if quantization_args.strategy == QuantizationStrategy.TOKEN:

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -140,11 +140,13 @@ def _initialize_scale_zero_point(
     if quantization_args.dynamic:
         return
 
-    # begin on the same device as other parameters or cpu if offloaded.
-    # in the offloaded case, there's no point moving tensors to the execution device
-    # if they're going to be immediately offloaded by `register_offload_parameter`
+    # initialize on execution device to avoid performing quantized ops on cpu
     params_device = next(module.parameters()).device
-    device = module._hf_hook.execution_device if has_offloaded_params(module) else params_device
+    device = (
+        module._hf_hook.execution_device
+        if has_offloaded_params(module)
+        else params_device
+    )
 
     # infer expected scale/zero point shape
     if quantization_args.strategy == QuantizationStrategy.TOKEN:

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -32,7 +32,6 @@ from compressed_tensors.quantization.utils import is_kv_cache_quant_scheme
 from compressed_tensors.utils import (
     disable_hf_hook,
     get_execution_device,
-    has_offloaded_params,
     register_offload_parameter,
 )
 from torch.nn import Module, Parameter


### PR DESCRIPTION
Thanks to @kylesayrs for figuring out this root issue and fix. Here is his explanation:

`qparams` follow the offloading behavior of their weight. If the module is offloaded, we assume that it should initialize on the cpu. In reality, it's not the offload device that matters (cpu), but the execution device (gpu). It makes initialization a little bit slower, but is more technically correct (all ops should happen on execution device, including initialization).
