### PR TITLE
Update default observer to be `MSE`

### DIFF
--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -224,7 +224,7 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
                 observer = None
 
         elif observer is None:
-            # default to minmax for non-dynamic cases
+            # default to mse for non-dynamic cases
             observer = "mse"
 
         # write back modified values

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -225,7 +225,7 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
 
         elif observer is None:
             # default to minmax for non-dynamic cases
-            observer = "minmax"
+            observer = "mse"
 
         # write back modified values
         model.strategy = strategy


### PR DESCRIPTION
**Description**
This PR addresses the following [issue](https://github.com/vllm-project/llm-compressor/issues/1222). Update such that the MSE is used as the default observer as opposed to MinMax.

**Testing**
Ran `examples/quantization_w4a16` and inspected the observer. See `QuantizationArgs`:
```
weights=QuantizationArgs(num_bits=4, type='int', symmetric=True, group_size=128, strategy='group', block_structure=None, dynamic=False, actorder=None, observer='mse', observer_kwargs={})
```
More details:
<img width="1279" alt="Screenshot 2025-04-15 at 3 50 43 PM" src="https://github.com/user-attachments/assets/d5553604-d368-4829-b3ab-9be687735be5" />
**Concern**
@anmarques @eldarkurtic Wanted to reach out to confirm if this is what we wanted : )