### PR TITLE
[Performance] Add memory compression and decompression pathways

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -47,6 +47,7 @@ from compressed_tensors.quantization.utils import (
     iter_named_leaf_modules,
 )
 from compressed_tensors.utils import (
+    get_execution_device,
     get_safetensors_folder,
     has_offloaded_params,
     merge_names,
@@ -97,6 +98,9 @@ class ModelCompressor:
     :param sparsity_config: config specifying sparsity compression parameters
     :param quantization_config: config specifying quantization compression parameters
     """
+
+    sparsity_config: Optional[SparsityCompressionConfig] = None
+    quantization_config: Optional[QuantizationConfig] = None
 
     @classmethod
     def from_pretrained(
@@ -261,6 +265,8 @@ class ModelCompressor:
                 quantization_config.format, config=quantization_config
             )
 
+    # ----- used by hf quantizer ----- #
+
     def get_missing_module_keys(self, model: Module) -> List[str]:
         """
         Identifies the expected missing weight keys in the compressed state_dict.
@@ -362,8 +368,117 @@ class ModelCompressor:
 
         return list(unexpected_keys)
 
+    # ----- model memory compression/decompression pathways ----- #
+
+    def compress_model(self, model: Module):
+        """
+        Compress a model in memory. Because the model structure is modified in place,
+        this method is more memory-efficient than `self.compress`
+
+        :param model: model containing parameters to compress
+        """
+        module_to_scheme = map_module_to_scheme(model)
+        sparse_compression_targets: Set[str] = expand_target_names(
+            model=model,
+            targets=self.sparsity_config.targets if self.sparsity_config else [],
+            ignore=self.sparsity_config.ignore if self.sparsity_config else [],
+        )
+
+        for prefix, module in tqdm(model.named_modules(), desc="Compressing model"):
+            if prefix in module_to_scheme or prefix in sparse_compression_targets:
+                state_dict = module.state_dict(prefix=f"{prefix}.")
+                # quantization first
+                if prefix in module_to_scheme:
+                    state_dict = self.quantization_compressor.compress(
+                        state_dict,
+                        names_to_scheme=module_to_scheme,
+                        show_progress=False,
+                    )
+
+                # sparsity second
+                if prefix in sparse_compression_targets:
+                    state_dict = self.sparsity_compressor.compress(
+                        state_dict,
+                        compression_targets=sparse_compression_targets,
+                        show_progress=False,
+                    )
+
+                # remove any existing parameters
+                device = get_execution_device(module)
+                for name, _ in list(module.named_parameters()):
+                    delattr(module, name)
+
+                # replace with compressed parameters
+                for name, value in state_dict.items():
+                    name = name.removeprefix(f"{prefix}.")
+                    value = value.to(device)
+                    param = torch.nn.Parameter(value, requires_grad=False)
+                    register_offload_parameter(module, name, param)
+
+                module.quantization_status = QuantizationStatus.COMPRESSED
+
+    def decompress_model(self, model: Module):
+        """
+        Decompress a model in memory. Because the model structure is modified in place,
+        this method does not require loading some compression parameters from disk
+
+        :param model: model containing parameters to compress
+        """
+        module_to_scheme = map_module_to_scheme(model)
+        sparse_compression_targets: Set[str] = expand_target_names(
+            model=model,
+            targets=self.sparsity_config.targets if self.sparsity_config else [],
+            ignore=self.sparsity_config.ignore if self.sparsity_config else [],
+        )
+
+        for prefix, module in tqdm(model.named_modules(), desc="Decompressing model"):
+            if prefix in module_to_scheme or prefix in sparse_compression_targets:
+                state_dict = module.state_dict(prefix=f"{prefix}.")
+                # sparsity first
+                if prefix in sparse_compression_targets:
+                    # sparse_compression_targets are automatically inferred by this fn
+                    generator = self.sparsity_compressor.decompress_from_state_dict(
+                        state_dict,
+                    )
+                    # generates (param_path, param_val)
+                    # of compressed and unused params
+                    state_dict = {key: value for key, value in generator}
+
+                # quantization second
+                if prefix in module_to_scheme:
+                    generator = self.quantization_compressor.decompress_from_state_dict(
+                        state_dict,
+                        names_to_scheme=module_to_scheme,
+                    )
+                    # generates (mod_path, {param_name, param_val})
+                    # of compressed params only (ignores unused params)
+                    state_dict = {
+                        merge_names(module_path, param_name): param_value
+                        for module_path, compressed_data in generator
+                        for param_name, param_value in compressed_data.items()
+                    }
+
+                # remove any existing parameters
+                device = get_execution_device(module)
+                for name, _ in list(module.named_parameters()):
+                    delattr(module, name)
+
+                # replace with decompressed parameters
+                for name, value in state_dict.items():
+                    name = name.removeprefix(f"{prefix}.")
+                    value = value.to(device)
+                    param = torch.nn.Parameter(value, requires_grad=False)
+                    register_offload_parameter(module, name, param)
+
+                module.quantization_status = QuantizationStatus.FROZEN
+
+    # ----- state dict compression pathways ----- #
+
     def compress(
-        self, model: Module, state_dict: Optional[Dict[str, Tensor]] = None
+        self,
+        model: Module,
+        state_dict: Optional[Dict[str, Tensor]] = None,
+        show_progress: bool = False,
     ) -> Dict[str, Tensor]:
         """
         Compresses a dense state dict or model with sparsity and/or quantization
@@ -379,7 +494,9 @@ class ModelCompressor:
         if self.quantization_compressor is not None:
             module_to_scheme = map_module_to_scheme(model)
             state_dict = self.quantization_compressor.compress(
-                state_dict, names_to_scheme=module_to_scheme
+                state_dict,
+                names_to_scheme=module_to_scheme,
+                show_progress=show_progress,
             )
 
             # TODO: consider sparse compression to also be compression
@@ -397,6 +514,7 @@ class ModelCompressor:
             state_dict = self.sparsity_compressor.compress(
                 state_dict,
                 compression_targets=sparse_compression_targets,
+                show_progress=show_progress,
             )
 
         # HACK: Override the dtype_byte_size function in transformers to
@@ -405,6 +523,8 @@ class ModelCompressor:
         transformers.modeling_utils.dtype_byte_size = new_dtype_byte_size
 
         return state_dict
+
+    # ----- disk decompression pathways ----- #
 
     def decompress(self, model_path: str, model: Module):
         """

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -278,7 +278,6 @@ class ModelCompressor:
         This function determines which weight keys are missing based on the
         applied compression techniques.
 
-
         :param model: The PyTorch model to check for missing keys.
         :return: A list of missing keys expected in the compressed state_dict.
         """
@@ -459,7 +458,8 @@ class ModelCompressor:
                         names_to_scheme=module_to_scheme,
                     )
                     # generates (mod_path, {param_name, param_val})
-                    # of compressed params only (ignores unused params)
+                    # of compressed params and used params, but not unused params
+                    # some used params are removed by get_unexpected_file_keys
                     state_dict = {
                         merge_names(module_path, param_name): param_value
                         for module_path, compressed_data in generator

--- a/src/compressed_tensors/compressors/sparse_compressors/dense.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/dense.py
@@ -40,3 +40,10 @@ class DenseCompressor(BaseCompressor):
         self, path_to_model_or_tensors: str, device: str = "cpu", **kwargs
     ) -> Generator[Tuple[str, Tensor], None, None]:
         return iter([])
+
+    def decompress_from_state_dict(
+        self,
+        state_dict: Dict[str, Tensor],
+    ) -> Generator[Tuple[str, Dict[str, Tensor]], None, None]:
+        for key, value in state_dict.items():
+            yield key, value

--- a/src/compressed_tensors/compressors/sparse_compressors/sparse_24_bitmask.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/sparse_24_bitmask.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Dict, List, Tuple, Union
+from typing import Dict, Generator, List, Tuple, Union
 
 import torch
 from compressed_tensors.compressors.base import BaseCompressor
@@ -202,11 +202,7 @@ def sparse24_bitmask_decompress(
     decompressed_tensor = torch.zeros(original_shape, dtype=values.dtype)
     decompressed_tensor = decompressed_tensor.to(values.device)
     values = values.flatten()
-    if decompressed_tensor.dtype == FP8_DTYPE:
-        decompressed_tensor[bytemasks_unpacked] = values
-        decompressed_tensor = decompressed_tensor.cuda()
-    else:
-        decompressed_tensor[bytemasks_unpacked] = values
+    decompressed_tensor[bytemasks_unpacked] = values
     return decompressed_tensor
 
 

--- a/src/compressed_tensors/compressors/sparse_quantized_compressors/marlin_24.py
+++ b/src/compressed_tensors/compressors/sparse_quantized_compressors/marlin_24.py
@@ -125,6 +125,7 @@ class Marlin24Compressor(BaseCompressor):
         self,
         model_state: Dict[str, Tensor],
         names_to_scheme: Dict[str, QuantizationScheme],
+        show_progress: bool = False,
         **kwargs,
     ) -> Dict[str, Tensor]:
         """
@@ -134,6 +135,7 @@ class Marlin24Compressor(BaseCompressor):
         :param model_state: state dict of uncompressed model
         :param names_to_scheme: quantization scheme for each quantized weight, needed
             for quantize function to calculate bit depth
+        :param show_progress: whether to show tqdm progress
         :return: compressed state dict
         """
         self.validate_quant_compatability(names_to_scheme)
@@ -144,7 +146,9 @@ class Marlin24Compressor(BaseCompressor):
             f"Compressing model with {len(model_state)} parameterized layers..."
         )
 
-        for name, value in tqdm(model_state.items(), desc="Compressing model"):
+        for name, value in tqdm(
+            model_state.items(), desc="Compressing model", disable=(not show_progress)
+        ):
             if name.endswith(weight_suffix):
                 prefix = name[: -(len(weight_suffix))]
                 scale = model_state.get(merge_names(prefix, "weight_scale"), None)

--- a/src/compressed_tensors/linear/compressed_linear.py
+++ b/src/compressed_tensors/linear/compressed_linear.py
@@ -23,6 +23,7 @@ from compressed_tensors.quantization import (
     initialize_module_for_quantization,
 )
 from compressed_tensors.utils import register_offload_parameter
+from compressed_tensors.utils.offload import get_execution_device
 from torch import Tensor
 from torch.nn import Parameter
 from torch.nn.functional import linear
@@ -60,7 +61,7 @@ class CompressedLinear(Linear):
         """
         module.__class__ = CompressedLinear
         module.compressor = BaseCompressor.load_from_registry(quantization_format)
-        device = next(module.parameters()).device
+        init_device = get_execution_device(module)
 
         # this will initialize all the scales and zero points
         initialize_module_for_quantization(
@@ -79,7 +80,7 @@ class CompressedLinear(Linear):
         # populate compressed weights and quantization parameters
         for name, (shape, dtype) in compression_params.items():
             param = Parameter(
-                torch.empty(shape, device=device, dtype=dtype), requires_grad=False
+                torch.empty(shape, device=init_device, dtype=dtype), requires_grad=False
             )
             register_offload_parameter(module, name, param)
 

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -38,7 +38,6 @@ __all__ = [
     "shard_tensor",
     "pack_bitmasks",
     "unpack_bitmasks",
-    "remove_suffix",
 ]
 
 FSDP_WRAPPER_NAME = "_fsdp_wrapped_module"
@@ -329,9 +328,3 @@ def unpack_bitmasks(
     )
 
     return unpacked_bitmasks_torch
-
-
-def remove_suffix(value: str, suffix: str) -> str:
-    # can replace with str.removesuffix in python3.9+
-    assert value.endswith(suffix)
-    return value[: -len(suffix)]

--- a/src/compressed_tensors/utils/safetensors_load.py
+++ b/src/compressed_tensors/utils/safetensors_load.py
@@ -35,6 +35,7 @@ __all__ = [
     "is_quantization_param",
 ]
 
+NestedStateDictType = Dict[str, Dict[str, Tensor]]
 WeightMappingType = Dict[str, str]
 NestedWeightMappingType = Dict[str, WeightMappingType]
 
@@ -234,11 +235,11 @@ def get_nested_weight_mappings(
     for key, file_location in weight_mappings.items():
         matched = False
         for param_name in params_to_nest:
-            dense_param = match_param_name(key, param_name)
-            if dense_param:
-                if dense_param not in nested_weight_mappings:
-                    nested_weight_mappings[dense_param] = {}
-                nested_weight_mappings[dense_param][param_name] = file_location
+            module_path = match_param_name(key, param_name)
+            if module_path:
+                if module_path not in nested_weight_mappings:
+                    nested_weight_mappings[module_path] = {}
+                nested_weight_mappings[module_path][param_name] = file_location
                 matched = True
         if return_unmatched_params and not matched:
             unmatched_params[key] = file_location
@@ -249,8 +250,10 @@ def get_nested_weight_mappings(
 
 
 def get_nested_mappings_from_state_dict(
-    state_dict, params_to_nest: Iterable[str]
-) -> NestedWeightMappingType:
+    state_dict,
+    params_to_nest: Iterable[str],
+    return_unmatched_params: bool = False,
+) -> Union[NestedStateDictType, Tuple[NestedStateDictType, Dict[str, Tensor]]]:
     """
     Takes a state dict and returns a nested mapping from uncompressed
     parameterized layer names to the value of
@@ -266,16 +269,26 @@ def get_nested_mappings_from_state_dict(
     :param state_dict: state dict of the model
     :param params_to_nest: Iterable of parameter names to nest.
     :return: Nested mapping of parameterized layer names to the value of
-        each layer's compression parameters.
+        each layer's compression parameters. If `return_unmatched_params`, then
+        also return a dictionary mapping unused parameter names to their values
     """
     nested_weight_mappings = {}
+    unmatched_params = {}
+
     for key in state_dict.keys():
+        matched = False
         for param_name in params_to_nest:
-            dense_param = match_param_name(key, param_name)
-            if dense_param:
-                if dense_param not in nested_weight_mappings:
-                    nested_weight_mappings[dense_param] = {}
-                nested_weight_mappings[dense_param][param_name] = state_dict[key]
+            module_path = match_param_name(key, param_name)
+            if module_path:
+                if module_path not in nested_weight_mappings:
+                    nested_weight_mappings[module_path] = {}
+                nested_weight_mappings[module_path][param_name] = state_dict[key]
+                matched = True
+        if return_unmatched_params and not matched:
+            unmatched_params[key] = state_dict[key]
+
+    if return_unmatched_params:
+        return nested_weight_mappings, unmatched_params
     return nested_weight_mappings
 
 

--- a/tests/test_compressors/model_compressors/test_model_compressor.py
+++ b/tests/test_compressors/model_compressors/test_model_compressor.py
@@ -21,9 +21,12 @@ import torch
 import torch.nn as nn
 from compressed_tensors.compressors import ModelCompressor
 from compressed_tensors.config import SparsityCompressionConfig
-from compressed_tensors.quantization import QuantizationConfig
+from compressed_tensors.config.sparse_24_bitmask import Sparse24BitMaskConfig
+from compressed_tensors.linear.compressed_linear import CompressedLinear
+from compressed_tensors.quantization import QuantizationConfig, QuantizationStatus
 from safetensors.torch import save_file
 from tests.testing_utils import induce_sparsity, requires_hf_quantizer
+from transformers import AutoModelForCausalLM
 
 
 def sparsity_config():
@@ -365,3 +368,98 @@ def _get_combined_config(s_config, q_config):
         combined["sparsity_config"] = s_config
 
     return combined
+
+
+@pytest.mark.parametrize(
+    "model_stub,q_format,s_config",
+    [
+        (
+            "nm-testing/llama2.c-stories42M-gsm8k-quantized-only-uncompressed",
+            "float-quantized",
+            None,
+        ),
+        (
+            "nm-testing/llama2.c-stories42M-gsm8k-sparse-only-uncompressed",
+            None,
+            "sparse-24-bitmask",
+        ),
+        (
+            "nm-testing/llama2.c-stories42M-gsm8k-stacked-uncompressed",
+            "float-quantized",
+            "sparse-24-bitmask",
+        ),
+    ],
+)
+def test_compress_model(model_stub, q_format, s_config, tmpdir):
+    model = AutoModelForCausalLM.from_pretrained(model_stub, torch_dtype=torch.float32)
+    compressor = ModelCompressor.from_pretrained_model(model, s_config, q_format)
+
+    # compress model by eagerly compressing state dict
+    true_compressed = dict(compressor.compress(model))
+    true_compressed = {key: value.clone() for key, value in true_compressed.items()}
+
+    # compress model directly
+    compressor.compress_model(model)
+    compressed = dict(model.state_dict())
+
+    # equivalent to eagerly compressing state dict
+    assert compressed.keys() == true_compressed.keys()
+    for key in compressed.keys():
+        assert torch.all(compressed[key] == true_compressed[key]), f"{key}"
+
+
+@pytest.mark.parametrize(
+    "model_stub,comp_stub",
+    [
+        (
+            "nm-testing/llama2.c-stories42M-gsm8k-quantized-only-uncompressed",
+            "nm-testing/llama2.c-stories42M-gsm8k-quantized-only-compressed",
+        ),
+        (
+            "nm-testing/llama2.c-stories42M-gsm8k-sparse-only-uncompressed",
+            "nm-testing/llama2.c-stories42M-gsm8k-sparse-only-compressed",
+        ),
+        (
+            "nm-testing/llama2.c-stories42M-gsm8k-stacked-uncompressed",
+            "nm-testing/llama2.c-stories42M-gsm8k-stacked-compressed",
+        ),
+    ],
+)
+def test_decompress_model(model_stub, comp_stub):
+    from transformers.utils.quantization_config import CompressedTensorsConfig
+
+    # decompress from disk
+    # NOTE: transformers adds extra zero points if run_compressed=False or w/ sparsity
+    # https://github.com/huggingface/transformers/blob/main/src/transformers/quantizers/quantizer_compressed_tensors.py#L131-L133
+    # however, decompression does not add zero points in non-asymmetric cases
+    # in order to normalize for this effect in this test, we remove empty weight zps
+    true_decompressed_model = AutoModelForCausalLM.from_pretrained(
+        comp_stub,
+        quantization_config=CompressedTensorsConfig(run_compressed=False),
+        torch_dtype=torch.float32,
+    )
+    true_decompressed = dict(true_decompressed_model.state_dict())
+    true_decompressed = remove_empty_weight_zero_points(true_decompressed)  # see above
+
+    # decompress from memory
+    # NOTE there is no other way to load a compressed model into memory, since
+    # there is no way to turn off decompression for sparse models
+    # https://github.com/huggingface/transformers/blob/main/src/transformers/quantizers/quantizer_compressed_tensors.py#L133
+    model = AutoModelForCausalLM.from_pretrained(model_stub, torch_dtype=torch.float32)
+    compressor = ModelCompressor.from_pretrained(comp_stub)
+    compressor.compress_model(model)
+    compressor.decompress_model(model)
+    decompressed = dict(model.state_dict())
+
+    # equivalent to decompressing from disk
+    assert decompressed.keys() == true_decompressed.keys()
+    for key in decompressed.keys():
+        assert torch.allclose(decompressed[key], true_decompressed[key])
+
+
+def remove_empty_weight_zero_points(state_dict):
+    return {
+        name: value
+        for name, value in state_dict.items()
+        if not (name.endswith("weight_zero_point") and torch.all(value == 0))
+    }

--- a/tests/test_compressors/sparse_compressors/test_sparse_24_bitmask.py
+++ b/tests/test_compressors/sparse_compressors/test_sparse_24_bitmask.py
@@ -47,6 +47,8 @@ def shard_validation():
 
 def validate_compression(dense_matrix, decompressed_tensor):
     """Validate that the decompressed tensor matches the original dense matrix."""
+    if decompressed_tensor.dtype == FP8_DTYPE:
+        decompressed_tensor = decompressed_tensor.to("cuda")
     dense_matrix = dense_matrix.to(decompressed_tensor.device)
     assert dense_matrix.dtype == decompressed_tensor.dtype, "Dtype mismatch"
     assert dense_matrix.shape == decompressed_tensor.shape, "Shape mismatch"


### PR DESCRIPTION
## Purpose ##
* Reduce memory requirements when compressing a model

## Memory Visualization ##

<details><summary>Compression Memory Improvement</summary>

<table>
  <tr>
    <td>Format</td>
    <td>State dict compression</td>
    <td>Model compression</td>
  </tr>
   <tr>
      <td>Quantized</td>
      <td><img src="https://github.com/user-attachments/assets/da44a281-d8b5-43c7-8680-ae25423916ba"></td>
      <td><img src="https://github.com/user-attachments/assets/a485a4c4-560d-40ec-8ade-ea4780f620de"></td>
  </tr>
   <tr>
      <td>Sparse</td>
      <td><img src="https://github.com/user-attachments/assets/d9828c87-c5f7-44ec-b966-4a6a225928c9"></td>
      <td><img src="https://github.com/user-attachments/assets/0c3b5658-067c-497f-ae37-923d6dd04d27"></td>
  </tr>
   <tr>
      <td>Sparse24<br>Stacked</td>
      <td><img src="https://github.com/user-attachments/assets/4624975f-c16e-47ed-92b7-6fb523c8b043"></td>
      <td><img src="https://github.com/user-attachments/assets/5b2964b6-63df-4285-b1ca-1e78fb57d250"></td>
  </tr>
</table>
</details>

<details><summary>Model Compression and Decompression</summary>

<table>
  <tr>
    <td>Format</td>
    <td>Model Compression + Decompression</td>
  </tr>
   <tr>
      <td>Quantized</td>
      <td><img src="https://github.com/user-attachments/assets/664e959b-ecde-44f2-bfb8-58d3f151a786"></td>
  </tr>
   <tr>
      <td>Sparse</td>
      <td><img src="https://github.com/user-attachments/assets/235e9b80-1a4e-4932-a683-fd9ca425bdfc"></td>
  </tr>
   <tr>
      <td>Sparse24<br>Stacked</td>
      <td><img src="https://github.com/user-attachments/assets/b142617c-cf79-479f-a0f1-6e1b6615aa23"></td>
  </tr>
</table>
</details>

<details><summary>Demonstration Script</summary>

```python3
import torch
from pttp import TensorProfiler
from transformers import AutoModelForCausalLM, AutoConfig
from compressed_tensors.compressors import ModelCompressor

for name, model_stub, comp_stub in [
    (
        "quantized-only",
        "nm-testing/llama2.c-stories42M-gsm8k-quantized-only-uncompressed",
        "nm-testing/llama2.c-stories42M-gsm8k-quantized-only-compressed",
    ),
    (
        "sparse-only",
        "nm-testing/llama2.c-stories42M-gsm8k-sparse-only-uncompressed",
        "nm-testing/llama2.c-stories42M-gsm8k-sparse-only-compressed",
    ),
    (
        "stacked",
        "nm-testing/llama2.c-stories42M-gsm8k-stacked-uncompressed",
        "nm-testing/llama2.c-stories42M-gsm8k-stacked-compressed",
    )
]:
    from transformers.utils.quantization_config import CompressedTensorsConfig

    with TensorProfiler() as prof:
        prof.mark_event("Start load")
        config = AutoConfig.from_pretrained(model_stub)
        config.tie_word_embeddings = False
        model = AutoModelForCausalLM.from_pretrained(model_stub, torch_dtype=torch.float32, device_map="cuda:0", config=config)
        compressor = ModelCompressor.from_pretrained(comp_stub)

        prof.mark_event("Start compress")
        compressor.compress_model(model)

        prof.mark_event("Start decompress")
        compressor.decompress_model(model)

    prof.save_memory_timeline(f"cdc_{name}.png")
```
</details>

## Prerequisites ##
* #302 
* #303 

## Changes ##
* Implement `compress_model` and `decompress_model`, which both act on a model in memory rather than a state dict or model on disk
  * Because `compress_model` compresses each module independently, implement `show_progress` on `compress` methods to squelch tqdm prints for each module compression
  * Implement `decompress_from_state_dict` for sparsity compressors
  * Extend `get_nested_mappings_from_state_dict` to support returning unmatched params, similar to `get_nested_weight_mappings`
    * I personally dislike this usage, as I think it leads to multiple sources of truth as to which modules should be compressed. IMO, a module should be (de)compressed if and only if it is listed in the config. This function is used to create another source of truth, which is that a module should be compressed if and only if it has the relevant compression params. Currently, we use both, which means taking the intersection.
* Misc
  * Fix bug on `decompress_from_state_dict` where scheme was gotten instead of weight args
  * Clarify name where variable `weight_name` was referring to a module path, not a weight name
  * Change sparse24 decompressor behavior where the weight was being moved to an arbitrary cuda device in fp8 cases. This violates the assumption that all ops are performed on the cpu
  * Remove `remove_suffix` util which can be replaced with `str.removesuffix` as of python3.9+ (which is the minimum we support, double check with @dsikka @rahul-tuli 
  * Use `get_execution_device` when initing params for `CompressedLinear`
  
## Testing ##
* Added `test_compress_model` which tests that memory compression is equivalent to dict compression
* Added `test_decompress_model` which tests that hfquantizer decompression (from disk) is equivalent to decompression from memory