### PR TITLE
[Bugfix] Fix shape calculation for group quantization

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -162,7 +162,7 @@ def _initialize_scale_zero_point(
             # (output_channels, 1)
             expected_shape = (weight_shape[0], 1)
         elif quantization_args.strategy == QuantizationStrategy.GROUP:
-            num_groups = weight_shape[1] // quantization_args.group_size
+            num_groups = torch.ceil(weight_shape[1] / quantization_args.group_size)
             expected_shape = (weight_shape[0], max(num_groups, 1))
 
     scale_dtype = scale_dtype if scale_dtype is not None else module.weight.dtype

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -14,6 +14,7 @@
 
 
 import logging
+import math
 from enum import Enum
 from typing import Optional
 
@@ -162,7 +163,7 @@ def _initialize_scale_zero_point(
             # (output_channels, 1)
             expected_shape = (weight_shape[0], 1)
         elif quantization_args.strategy == QuantizationStrategy.GROUP:
-            num_groups = torch.ceil(weight_shape[1] / quantization_args.group_size)
+            num_groups = math.ceil(weight_shape[1] / quantization_args.group_size)
             expected_shape = (weight_shape[0], max(num_groups, 1))
 
     scale_dtype = scale_dtype if scale_dtype is not None else module.weight.dtype

--- a/tests/test_quantization/lifecycle/test_initialize.py
+++ b/tests/test_quantization/lifecycle/test_initialize.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import math
+
 import pytest
 from compressed_tensors.quantization import (
     ActivationOrdering,
@@ -183,7 +185,7 @@ def test_initialize_quantization_parameters(weights, input_activations):
             expected_shape = (layer.weight.shape[0], 1)
 
         elif args.strategy == QuantizationStrategy.GROUP:  # only weight
-            num_groups = layer.weight.shape[1] // args.group_size
+            num_groups = math.ceil(layer.weight.shape[1] / args.group_size)
             expected_shape = (layer.weight.shape[0], max(num_groups, 1))
 
         elif args.strategy == QuantizationStrategy.BLOCK:


### PR DESCRIPTION
## Purpose ##
* Fix shape calculation for group quantization
* This was uncovered while attempting to quantize the vision tower of qwen2.5 model. This likely went unnoticed, since most model shapes are powers of two, something that is not true of weights in the qwen 2.5 vision tower

## Changes ##
* Use the ceil of num columns / group_size in order to reflect that the remainder columns are a group

## Testing ##
* The test added by https://github.com/vllm-project/llm-compressor/pull/1401 fails without these changes, but succeeds with them