### PR TITLE
fix signatures on model_validator functions

### DIFF
--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -162,7 +162,7 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
         return value
 
     @model_validator(mode="after")
-    def validate_model_after(model: "QuantizationArgs") -> Dict[str, Any]:
+    def validate_model_after(model: "QuantizationArgs") -> "QuantizationArgs":
         # extract user-passed values from dictionary
         strategy = model.strategy
         group_size = model.group_size

--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -48,7 +48,7 @@ class QuantizationScheme(BaseModel):
     output_activations: Optional[QuantizationArgs] = None
 
     @model_validator(mode="after")
-    def validate_model_after(model: "QuantizationArgs") -> Dict[str, Any]:
+    def validate_model_after(model: "QuantizationScheme") -> "QuantizationScheme":
         inputs = model.input_activations
         outputs = model.output_activations
 


### PR DESCRIPTION
When looking at our usage of `pydantic.model_validator`, I noticed a couple incorrect signatures for when `mode="after"`. 