### PR TITLE
[NVFP4] Enable Fp4 Quantization; introduce / apply global_scales

### DIFF
--- a/src/compressed_tensors/compressors/quantized_compressors/base.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/base.py
@@ -96,6 +96,7 @@ class BaseQuantizationCompressor(BaseCompressor):
                 scale = model_state.get(prefix + "weight_scale", None)
                 g_idx = model_state.get(prefix + "weight_g_idx", None)
                 zp = model_state.get(prefix + "weight_zero_point", None)
+                global_scale = model_state.get(prefix + "weight_global_scale", None)
 
                 # is scale does not exist, then weight cannot be compressed
                 if scale is None:
@@ -109,6 +110,7 @@ class BaseQuantizationCompressor(BaseCompressor):
                     weight=value,
                     scale=scale,
                     zero_point=zp,
+                    global_scale=global_scale,
                     g_idx=g_idx,
                     quantization_args=quant_args,
                     device="cpu",

--- a/src/compressed_tensors/compressors/quantized_compressors/naive_quantized.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/naive_quantized.py
@@ -78,6 +78,7 @@ class NaiveQuantizationCompressor(BaseQuantizationCompressor):
         zero_point: Optional[Tensor] = None,
         g_idx: Optional[torch.Tensor] = None,
         device: Optional[torch.device] = None,
+        global_scale: Optional[torch.Tensor] = None,
     ) -> Dict[str, torch.Tensor]:
         """
         Compresses a single uncompressed weight
@@ -90,6 +91,11 @@ class NaiveQuantizationCompressor(BaseQuantizationCompressor):
         :param device: optional device to move compressed output to
         :return: dictionary of compressed weight data
         """
+        if global_scale is not None:
+            raise ValueError(
+                "global_scale is not supported for the NaiveQuantizationCompressor"
+            )
+
         if can_quantize(weight, quantization_args):
             quantized_weight = quantize(
                 x=weight,

--- a/src/compressed_tensors/compressors/quantized_compressors/pack_quantized.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/pack_quantized.py
@@ -94,6 +94,7 @@ class PackedQuantizationCompressor(BaseQuantizationCompressor):
         zero_point: Optional[Tensor] = None,
         g_idx: Optional[torch.Tensor] = None,
         device: Optional[torch.device] = None,
+        global_scale: Optional[torch.Tensor] = None,
     ) -> Dict[str, torch.Tensor]:
         """
         Compresses a single uncompressed weight
@@ -106,6 +107,11 @@ class PackedQuantizationCompressor(BaseQuantizationCompressor):
         :param device: optional device to move compressed output to
         :return: dictionary of compressed weight data
         """
+        if global_scale is not None:
+            raise ValueError(
+                "global_scale is not supported for the PackQuantizationCompressor"
+            )
+
         compressed_dict = {}
         if can_quantize(weight, quantization_args):
             quantized_weight = quantize(

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -27,8 +27,14 @@ from compressed_tensors.quantization.lifecycle.compressed import (
 )
 from compressed_tensors.quantization.lifecycle.initialize import (
     initialize_module_for_quantization,
+    update_fused_layer_weight_global_scales,
 )
-from compressed_tensors.quantization.quant_args import QuantizationArgs
+from compressed_tensors.quantization.quant_args import (
+    FP4_E2M1_DATA,
+    FP8_E4M3_DATA,
+    QuantizationArgs,
+    QuantizationType,
+)
 from compressed_tensors.quantization.quant_config import (
     QuantizationConfig,
     QuantizationStatus,
@@ -265,6 +271,9 @@ def apply_quantization_status(model: Module, status: QuantizationStatus):
                 module, force_zero_point=force_zero_point_init, scale_dtype=scale_dtype
             )
         )
+
+        if status == QuantizationStatus.INITIALIZED:
+            update_fused_layer_weight_global_scales(model)
 
     if current_status < status >= QuantizationStatus.COMPRESSED > current_status:
         model.apply(compress_quantized_weights)

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -379,6 +379,8 @@ def _quantize(
     global_scale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
 
+    # if a global scale is optionally provided, use it
+    # to further scale the local `scale` parameter
     if global_scale:
         scale = scale.to(global_scale.dtype) / global_scale
 
@@ -408,6 +410,8 @@ def _dequantize(
     global_scale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
 
+    # if a global scale is optionally provided, use it
+    # to further scale the local `scale` parameter
     if global_scale:
         scale = scale.to(global_scale.dtype) / global_scale
 

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -65,6 +65,7 @@ def quantize(
     :param args: quantization args dictating how to quantize x
     :param dtype: optional dtype to cast the quantized output to
     :param g_idx: optional mapping from column index to group index
+    :param global_scale: optional constant to scale the quantization scale during QDQ
     :return: fake quantized tensor
     """
 
@@ -101,6 +102,7 @@ def dequantize(
     :param args: quantization args used to quantize x_q
     :param dtype: optional dtype to cast the dequantized output to
     :param g_idx: optional mapping from column index to group index
+    :param global_scale: optional constant to scale the quantization scale during QDQ
     :return: dequantized float tensor
     """
     if args is None:
@@ -157,6 +159,7 @@ def fake_quantize(
     :param zero_point: zero point tensor
     :param args: quantization args dictating how to quantize x
     :param g_idx: optional mapping from column index to group index
+    :param global_scale: optional constant to scale the quantization scale during QDQ
     :return: fake quantized tensor
     """
     return _process_quantization(

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -20,6 +20,7 @@ import torch
 from compressed_tensors.quantization.quant_args import (
     QuantizationArgs,
     QuantizationStrategy,
+    QuantizationType,
     round_to_quantized_type,
 )
 from compressed_tensors.quantization.quant_config import QuantizationStatus
@@ -49,6 +50,7 @@ def quantize(
     args: QuantizationArgs,
     dtype: Optional[torch.dtype] = None,
     g_idx: Optional[torch.Tensor] = None,
+    global_scale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     Quantize the input tensor x using the QuantizationStrategy specified in args.
@@ -75,6 +77,7 @@ def quantize(
         do_quantize=True,
         do_dequantize=False,
         g_idx=g_idx,
+        global_scale=global_scale,
     )
 
 
@@ -86,6 +89,7 @@ def dequantize(
     args: Optional[QuantizationArgs] = None,
     dtype: Optional[torch.dtype] = None,
     g_idx: Optional[torch.Tensor] = None,
+    global_scale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     Dequantize a quantized input tensor x_q based on the strategy specified in args. If
@@ -128,6 +132,7 @@ def dequantize(
         do_dequantize=True,
         dtype=dtype,
         g_idx=g_idx,
+        global_scale=global_scale,
     )
 
 
@@ -138,6 +143,7 @@ def fake_quantize(
     zero_point: torch.Tensor,
     args: QuantizationArgs,
     g_idx: Optional[torch.Tensor] = None,
+    global_scale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     Fake quantize the input tensor x by quantizing then dequantizing with
@@ -161,6 +167,7 @@ def fake_quantize(
         do_quantize=True,
         do_dequantize=True,
         g_idx=g_idx,
+        global_scale=global_scale,
     )
 
 
@@ -174,6 +181,7 @@ def _process_quantization(
     dtype: Optional[torch.dtype] = None,
     do_quantize: bool = True,
     do_dequantize: bool = True,
+    global_scale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     q_min, q_max = calculate_range(args, x.device)
     group_size = args.group_size
@@ -221,18 +229,21 @@ def _process_quantization(
             end = start + group_count
             if do_quantize:
                 output[:, start:end] = _quantize(
-                    x[:, start:end],
-                    sc,
-                    zp,
-                    q_min,
-                    q_max,
-                    args,
+                    x=x[:, start:end],
+                    scale=sc,
+                    zero_point=zp,
+                    q_min=q_min,
+                    q_max=q_max,
+                    args=args,
                     dtype=dtype,
+                    global_scale=global_scale,
                 )
 
             if do_dequantize:
                 input = output[:, start:end] if do_quantize else x[:, start:end]
-                output[:, start:end] = _dequantize(input, sc, zp)
+                output[:, start:end] = _dequantize(
+                    x_q=input, scale=sc, zero_point=zp, global_scale=global_scale
+                )
 
         if not is_column_order:
             output = safe_permute(output, torch.argsort(perm), dim=1)
@@ -240,16 +251,22 @@ def _process_quantization(
     else:  # covers channel, token and tensor strategies
         if do_quantize:
             output = _quantize(
-                x,
-                scale,
-                zero_point,
-                q_min,
-                q_max,
-                args,
+                x=x,
+                scale=scale,
+                zero_point=zero_point,
+                q_min=q_min,
+                q_max=q_max,
+                args=args,
                 dtype=dtype,
+                global_scale=global_scale,
             )
         if do_dequantize:
-            output = _dequantize(output if do_quantize else x, scale, zero_point)
+            output = _dequantize(
+                output if do_quantize else x,
+                scale=scale,
+                zero_point=zero_point,
+                global_scale=global_scale,
+            )
 
     return output
 
@@ -330,6 +347,7 @@ def forward_quantize(
         return value
 
     g_idx = getattr(module, "weight_g_idx", None)
+    global_scale = getattr(module, f"{base_name}_global_scale", None)
 
     if args.dynamic:
         # dynamic quantization - determine the scale/zp on the fly
@@ -345,6 +363,7 @@ def forward_quantize(
         zero_point=zero_point,
         args=args,
         g_idx=g_idx,
+        global_scale=global_scale,
     )
 
 
@@ -357,11 +376,16 @@ def _quantize(
     q_max: torch.Tensor,
     args: QuantizationArgs,
     dtype: Optional[torch.dtype] = None,
+    global_scale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
+
+    if global_scale:
+        scale = scale.to(global_scale.dtype) / global_scale
 
     scaled = x / scale
     if zero_point is not None:
         scaled += zero_point.to(x.dtype)
+
     # clamp first because cast isn't guaranteed to be saturated (ie for fp8)
     clamped_value = torch.clamp(
         scaled,
@@ -381,7 +405,12 @@ def _dequantize(
     scale: torch.Tensor,
     zero_point: torch.Tensor = None,
     dtype: Optional[torch.dtype] = None,
+    global_scale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
+
+    if global_scale:
+        scale = scale.to(global_scale.dtype) / global_scale
+
     dequant_value = x_q.to(scale.dtype)
 
     if zero_point is not None:

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -177,7 +177,8 @@ def _initialize_scale_zero_point(
     scale_dtype = scale_dtype if scale_dtype is not None else module.weight.dtype
     # TODO: consider erroring out in the future as if the dtype if not one fo these,
     # there is likely bug
-
+    # TODO: maybe add a short cutting utility so we don't have a ton of if/else
+    # everywhere
     if (
         quantization_args.num_bits == 4
         and quantization_args.type == QuantizationType.FLOAT
@@ -194,12 +195,10 @@ def _initialize_scale_zero_point(
             module, f"{base_name}_global_scale", init_global_scale
         )
 
-    if scale_dtype not in [
-        torch.float16,
-        torch.bfloat16,
-        torch.float32,
-        FP8_E4M3_DATA.dtype,
-    ]:
+    if scale_dtype not in [torch.float16, torch.bfloat16, torch.float32,] and not (
+        quantization_args.num_bits == 4
+        and quantization_args.type == QuantizationType.FLOAT
+    ):
         scale_dtype = torch.float16
 
     # initializes empty scale, zero point, and g_idx parameters for the module

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -257,9 +257,20 @@ def _initialize_attn_scales(module: Module) -> None:
     register_offload_parameter(module, KVCacheScaleType.VALUE.value, init_scale)
 
 
-# TODO: Introduce an argument to turn this off
-# Only relevant for NVFP4 currently
-def update_fused_layer_weight_global_scales(model):
+# TODO: Potentially introduce an argument to turn this off
+# Only relevant for NVFP4A16 currently
+def update_fused_layer_weight_global_scales(model: torch.nn.Module):
+    """
+    When running NVFP4A16 quantization, update the global scale
+    such that q,k,v layers are treated as one tensor with the same
+    global_scale and gate_proj/up_proj layers are treated as one tensor
+    with the same global scale. This is requirement currently being set
+    by vLLM and may be removed in the future OR potentially make it
+    an optional step.
+
+    :param model: model to quantize
+    """
+
     def _is_attention_module(module: Module):
         return "attention" in module.__class__.__name__.lower() and (
             hasattr(module, "k_proj")

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -35,6 +35,7 @@ from compressed_tensors.quantization.quant_scheme import QuantizationScheme
 from compressed_tensors.quantization.utils import (
     generate_global_scale,
     is_kv_cache_quant_scheme,
+    iter_named_quantizable_modules,
 )
 from compressed_tensors.utils import (
     disable_hf_hook,

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -179,8 +179,7 @@ def _initialize_scale_zero_point(
     scale_dtype = scale_dtype if scale_dtype is not None else module.weight.dtype
     # TODO: consider erroring out in the future as if the dtype if not one fo these,
     # there is likely bug
-    # TODO: maybe add a short cutting utility so we don't have a ton of if/else
-    # everywhere
+
     if is_fp4(quantization_args=quantization_args) and base_name == "weight":
         scale_dtype = FP8_E4M3_DATA.dtype
         # When applying weight-only FP4 quantization, generate a global_scale

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -184,6 +184,7 @@ def _initialize_scale_zero_point(
         and quantization_args.type == QuantizationType.FLOAT
         and base_name == "weight"
     ):
+        scale_dtype = FP8_E4M3_DATA.dtype
         # When applying weight-only FP4 quantization, generate a global_scale
         # This scale is applied during runtime to ensure that the generated
         # local scale falls properly within the FP8 range (i.e max value is FP8_max)

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -291,6 +291,9 @@ def update_fused_layer_weight_global_scales(model: torch.nn.Module):
 
             weight_quant_args = scheme.weights
 
+            if weight_quant_args is None:
+                return False
+
             if not is_fp4(quantization_args=weight_quant_args):
                 return False
         return True

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -281,7 +281,7 @@ def update_fused_layer_weight_global_scales(model: torch.nn.Module):
 
     def _is_mlp_module(module: Module):
         return "mlp" in module.__class__.__name__.lower() and (
-            hasattr(module, "gate_proj") or hasattr(module, "up_porj")
+            hasattr(module, "gate_proj") or hasattr(module, "up_proj")
         )
 
     def _valid_fp4_quant(layer_list: List[torch.nn.Linear]):

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -26,6 +26,7 @@ __all__ = [
     "FP8_DTYPE",
     "FP8_E4M3_DATA",
     "FP4_E2M1_DATA",
+    "FloatArgs",
     "QuantizationType",
     "QuantizationStrategy",
     "QuantizationArgs",

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import warnings
-from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional, Union
 

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -78,18 +78,6 @@ class FP8_E4M3_DATA(FloatArgs):
 # TODO: Remove soon in favour of a more descriptive FloatArgs
 FP8_DTYPE = torch.float8_e4m3fn
 
-FP8_E4M3_DATA = FloatArgs(
-    exponent=4,
-    mantissa=3,
-    bits=8,
-    max=torch.finfo(torch.float8_e4m3fn).max,
-    min=torch.finfo(torch.float8_e4m3fn).min,
-    dtype=torch.float8_e4m3fn,
-)
-
-# TODO: Remove soon in favour of a more descriptive FloatArgs
-FP8_DTYPE = torch.float8_e4m3fn
-
 
 class QuantizationType(str, Enum):
     """

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -87,7 +87,8 @@ FP8_E4M3_DATA = FloatArgs(
     dtype=torch.float8_e4m3fn,
 )
 
-FP4_E2M1_DATA = FloatArgsFP4E2M1(exponent=2, mantissa=1, bits=4, max=6.0, min=-6.0)
+# TODO: Remove soon in favour of a more descriptive FloatArgs
+FP8_DTYPE = torch.float8_e4m3fn
 
 
 class QuantizationType(str, Enum):
@@ -289,8 +290,6 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
         return model
 
     def pytorch_dtype(self) -> torch.dtype:
-        # TODO: required for the compressor
-        # Add FP4_nvfp4 type when updating naive_compressor
         if self.type == QuantizationType.FLOAT:
             if self.num_bits == 8:
                 return FP8_E4M3_DATA.dtype
@@ -326,16 +325,10 @@ def round_to_quantized_type(
     if args.type == QuantizationType.FLOAT:
         if args.num_bits == 8:
             rounded = tensor.to(FP8_E4M3_DATA.dtype)
-<<<<<<< HEAD
         elif args.num_bits == 4:
             rounded = FP4_E2M1_DATA.cast_to_fp4(tensor)
         else:
             raise NotImplementedError("Only num_bits in (4, 8) are supported")
-=======
-        else:
-            assert args.num_bits == 4
-            rounded = FP4_E2M1_DATA.cast_to_fp4(tensor)
->>>>>>> e02527c (add nvfp4 args)
     elif args.type == QuantizationType.INT:
         rounded = torch.round(tensor)
     else:

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import warnings
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional, Union
 
@@ -76,6 +77,17 @@ class FP8_E4M3_DATA(FloatArgs):
 
 # TODO: Remove soon in favour of a more descriptive FloatArgs
 FP8_DTYPE = torch.float8_e4m3fn
+
+FP8_E4M3_DATA = FloatArgs(
+    exponent=4,
+    mantissa=3,
+    bits=8,
+    max=torch.finfo(torch.float8_e4m3fn).max,
+    min=torch.finfo(torch.float8_e4m3fn).min,
+    dtype=torch.float8_e4m3fn,
+)
+
+FP4_E2M1_DATA = FloatArgsFP4E2M1(exponent=2, mantissa=1, bits=4, max=6.0, min=-6.0)
 
 
 class QuantizationType(str, Enum):
@@ -277,6 +289,8 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
         return model
 
     def pytorch_dtype(self) -> torch.dtype:
+        # TODO: required for the compressor
+        # Add FP4_nvfp4 type when updating naive_compressor
         if self.type == QuantizationType.FLOAT:
             if self.num_bits == 8:
                 return FP8_E4M3_DATA.dtype
@@ -312,10 +326,16 @@ def round_to_quantized_type(
     if args.type == QuantizationType.FLOAT:
         if args.num_bits == 8:
             rounded = tensor.to(FP8_E4M3_DATA.dtype)
+<<<<<<< HEAD
         elif args.num_bits == 4:
             rounded = FP4_E2M1_DATA.cast_to_fp4(tensor)
         else:
             raise NotImplementedError("Only num_bits in (4, 8) are supported")
+=======
+        else:
+            assert args.num_bits == 4
+            rounded = FP4_E2M1_DATA.cast_to_fp4(tensor)
+>>>>>>> e02527c (add nvfp4 args)
     elif args.type == QuantizationType.INT:
         rounded = torch.round(tensor)
     else:

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -110,7 +110,9 @@ def calculate_qparams(
             # torch.clamp not supported for FP8
             # use the next largest fp8 value from 0
             scales = torch.where(
-                scales == 0, torch.tensor(0.125, dtype=FP8_E4M3_DATA.dtype), scales
+                scales == 0,
+                torch.tensor(0.125, dtype=FP8_E4M3_DATA.dtype, device=device),
+                scales,
             )
         else:
             scales = torch.clamp(scales, min=torch.finfo(torch.float32).eps)

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -19,6 +19,7 @@ import torch
 from compressed_tensors.quantization.quant_args import (
     FP4_E2M1_DATA,
     FP8_E4M3_DATA,
+    FloatArgs,
     QuantizationArgs,
     QuantizationStrategy,
     QuantizationType,
@@ -448,10 +449,10 @@ def parse_out_kv_cache_args(
 
 
 def generate_global_scale(
-    scale_data: FP8_E4M3_DATA,
-    quant_data: FP4_E2M1_DATA,
     input_tensor: torch.Tensor,
-    dtype=torch.float32,
+    scale_data: Optional[FloatArgs] = FP8_E4M3_DATA,
+    quant_data: Optional[FloatArgs] = FP4_E2M1_DATA,
+    dtype: Optional[torch.dtype] = torch.float32,
 ):
     """
     Generate a global scale for an entire tensor (input_tensor).

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -66,7 +66,11 @@ def calculate_qparams(
     :param max_vals: tensor of max value(s) to calculate scale(s) and zero point(s)
         from
     :param quantization_args: settings to quantization
-    :return: tuple of the calculated scale(s) and zero point(s)
+    :param global_scale: additional global scale to scale the locally generated scale
+        currently only applied/supported for Fp4
+
+    :return: tuple of the calculated scale(s) and zero point(s). For FP4, the calculated
+        scale if of dtype FP8
     """
     # based on the implementations for consuming quantized values,
     # 0.0 must always be representable within the quantized range
@@ -94,6 +98,7 @@ def calculate_qparams(
             and quantization_args.type == QuantizationType.FLOAT
             and global_scale is not None
         ):
+            # Conditionally scale the generated local scale by a global_scale
             scales = global_scale * (max_val_pos / FP4_E2M1_DATA.max)
             scales = scales.to(FP8_E4M3_DATA.dtype)
         else:

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -123,7 +123,9 @@ def calculate_qparams(
             quantization_args.num_bits == 4
             and quantization_args.type == QuantizationType.FLOAT
         ):
-            raise NotImplementedError("Asymmetric Quantization is not support for FP4")
+            raise NotImplementedError(
+                "Asymmetric Quantization is not supported for FP4"
+            )
 
         scales = (max_vals - min_vals) / float(bit_range)
         scales = torch.clamp(scales, min=torch.finfo(torch.float32).eps)
@@ -461,7 +463,7 @@ def generate_global_scale(
     Goal of the scale is to ensure that the quantization (local) scale
     falls into the approproiate dtype range.
 
-    E.g. for NVFp4, group (local) scales are in dtype FP8. The global_scale
+    E.g. for NVFP4, group (local) scales are in dtype FP8. The global_scale
     attempts to use the entire FP8 dtype range while mapping a per-group max
     to the FP4 max.
     """

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -453,8 +453,16 @@ def generate_global_scale(
     input_tensor: torch.Tensor,
     dtype=torch.float32,
 ):
+    """
+    Generate a global scale for an entire tensor (input_tensor).
+    Goal of the scale is to ensure that the quantization (local) scale
+    falls into the approproiate dtype range.
+
+    E.g. for NVFp4, group (local) scales are in dtype FP8. The global_scale
+    attempts to use the entire FP8 dtype range while mapping a per-group max
+    to the FP4 max.
+    """
     scale_dtype = scale_data.dtype
     tensor_amax = torch.abs(input_tensor.data).max().to(dtype)
-    value = scale_data.max * quant_data.max / tensor_amax
-    value = value.to(dtype)
-    return value
+    global_scale = scale_data.max * quant_data.max / tensor_amax
+    return global_scale.to(dtype)

--- a/tests/test_quantization/lifecycle/test_initialize.py
+++ b/tests/test_quantization/lifecycle/test_initialize.py
@@ -18,7 +18,6 @@ import math
 import pytest
 import torch
 from compressed_tensors.quantization import (
-    FP4_E2M1_DATA,
     FP8_E4M3_DATA,
     ActivationOrdering,
     QuantizationArgs,
@@ -30,7 +29,6 @@ from compressed_tensors.quantization import (
 from compressed_tensors.quantization.lifecycle.initialize import (
     initialize_module_for_quantization,
 )
-from compressed_tensors.quantization.utils import generate_global_scale
 from tests.testing_utils import requires_accelerate
 from torch.nn import Linear
 
@@ -219,12 +217,3 @@ def test_initialize_quantization_parameters(weights, input_activations):
             assert getattr(layer, f"{q_param_name}_g_idx").shape == (
                 layer.weight.shape[1],
             )
-
-
-def test_fused_global_scales():
-    layer = Linear(7, 8)
-    max_tensor_value = torch.abs(layer.weight.data).max()
-    # use defaults
-    global_scale = generate_global_scale(layer.weight)
-    # max value should be = (448 * 6) / global_scale
-    assert max_tensor_value == (FP4_E2M1_DATA.max * FP8_E4M3_DATA.max) / global_scale

--- a/tests/test_quantization/lifecycle/test_initialize.py
+++ b/tests/test_quantization/lifecycle/test_initialize.py
@@ -152,6 +152,11 @@ def test_initialize_module_for_quantization_offloaded(
             QuantizationArgs(strategy="group", group_size=2, actorder="weight"),
             None,
         ),
+        # Ensure no global scale if not fp4
+        (
+            QuantizationArgs(strategy="group", group_size=16, type="float", num_bits=4),
+            None,
+        ),
         (
             QuantizationArgs(strategy="block"),
             QuantizationArgs(strategy="block"),
@@ -202,3 +207,6 @@ def test_initialize_quantization_parameters(weights, input_activations):
             assert getattr(layer, f"{q_param_name}_g_idx").shape == (
                 layer.weight.shape[1],
             )
+
+def test_fused_global_scales():
+    pass 

--- a/tests/test_quantization/test_utils/test_helpers.py
+++ b/tests/test_quantization/test_utils/test_helpers.py
@@ -14,8 +14,16 @@
 
 import pytest
 import torch
-from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
-from compressed_tensors.quantization.utils import calculate_qparams
+from compressed_tensors.quantization import (
+    FP4_E2M1_DATA,
+    FP8_E4M3_DATA,
+    QuantizationArgs,
+    QuantizationStrategy,
+)
+from compressed_tensors.quantization.utils import (
+    calculate_qparams,
+    generate_global_scale,
+)
 
 
 @pytest.mark.parametrize(
@@ -58,6 +66,10 @@ def test_calculate_qparams(keepdims, strategy, exp_shape):
         assert zp.shape == exp_shape
 
 
-def test_global_scale():
-    # add test for global scale calculation
-    pass
+def test_fused_global_scales():
+    layer = torch.nn.Linear(7, 8)
+    max_tensor_value = torch.abs(layer.weight.data).max()
+    # use defaults
+    global_scale = generate_global_scale(layer.weight)
+    # max value should be = (448 * 6) / global_scale
+    assert max_tensor_value == (FP4_E2M1_DATA.max * FP8_E4M3_DATA.max) / global_scale

--- a/tests/test_quantization/test_utils/test_helpers.py
+++ b/tests/test_quantization/test_utils/test_helpers.py
@@ -56,3 +56,7 @@ def test_calculate_qparams(keepdims, strategy, exp_shape):
         scale, zp = calculate_qparams(min_val, max_val, args)
         assert scale.shape == exp_shape
         assert zp.shape == exp_shape
+
+def test_global_scale():
+    # add test for global scale calculation
+    pass 

--- a/tests/test_quantization/test_utils/test_helpers.py
+++ b/tests/test_quantization/test_utils/test_helpers.py
@@ -72,4 +72,6 @@ def test_fused_global_scales():
     # use defaults
     global_scale = generate_global_scale(layer.weight)
     # max value should be = (448 * 6) / global_scale
-    assert max_tensor_value == (FP4_E2M1_DATA.max * FP8_E4M3_DATA.max) / global_scale
+    assert max_tensor_value == pytest.approx(
+        FP4_E2M1_DATA.max * FP8_E4M3_DATA.max / global_scale, abs=0.001
+    )

--- a/tests/test_quantization/test_utils/test_helpers.py
+++ b/tests/test_quantization/test_utils/test_helpers.py
@@ -57,6 +57,7 @@ def test_calculate_qparams(keepdims, strategy, exp_shape):
         assert scale.shape == exp_shape
         assert zp.shape == exp_shape
 
+
 def test_global_scale():
     # add test for global scale calculation
-    pass 
+    pass


### PR DESCRIPTION
# Summary
- Add / Apply Fp4 quantization support
- Introduce global_scale - this scale conditionally scales the quantization weight scale during run time and is saved to disk as part of the model checkpoint.
- Update quant/dequant to apply the global_scale during calibration / observer calls 

# Testing
- Add additional test cases
- Tested e2e end with the llmcompressor branch which enables FP4 Quantization 