### PR TITLE
[NVFP4] Add `tensor_group` strategy; enable NVFP4 Activations

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -421,7 +421,6 @@ def _dequantize(
     scale: torch.Tensor,
     zero_point: torch.Tensor = None,
     dtype: Optional[torch.dtype] = None,
-    args: QuantizationArgs = None,
     global_scale: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
 

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -398,18 +398,11 @@ def _quantize(
     if global_scale:
         scale = scale.to(global_scale.dtype) / global_scale
 
-    """
-    if args.strategy == QuantizationStrategy.TENSOR_GROUP:
-        group_size = args.group_size
-        x = torch.reshape(x, (x.shape[0], x.shape[1] // group_size, group_size))
-        scale = scale.unsqueeze(-1)
-    """
-
     scaled = x / scale
-    """
+
     if zero_point is not None:
         scaled += zero_point.to(x.dtype)
-    """
+
     # clamp first because cast isn't guaranteed to be saturated (ie for fp8)
     clamped_value = torch.clamp(
         scaled,
@@ -441,24 +434,12 @@ def _dequantize(
 
     dequant_value = x_q.to(scale.dtype)
 
-    """
-    if args and args.strategy == QuantizationStrategy.TENSOR_GROUP:
-        scale = scale.unsqueeze(-1)
-
-  
     if zero_point is not None:
         dequant_value = dequant_value - zero_point.to(scale.dtype)
-    """
+
     dequant_value = dequant_value * scale
 
     if dtype is not None:
         dequant_value = dequant_value.to(dtype)
 
-    """
-    if args and args.strategy == QuantizationStrategy.TENSOR_GROUP:
-        # last dimension should be the group_size
-        dequant_value = dequant_value.reshape(
-            x_q.shape[0], x_q.shape[1] * args.group_size
-        )
-    """
     return dequant_value

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -352,9 +352,11 @@ def forward_quantize(
     g_idx = getattr(module, "weight_g_idx", None)
     global_scale = getattr(module, f"{base_name}_global_scale", None)
 
-    if args.dynamic:
+    if args.dynamic or args.strategy == QuantizationStrategy.TENSOR_GROUP:
         # dynamic quantization - determine the scale/zp on the fly
-        scale, zero_point = compute_dynamic_scales_and_zp(value=value, args=args)
+        scale, zero_point = compute_dynamic_scales_and_zp(
+            value=value, args=args, module=module
+        )
     else:
         # static quantization - get scale and zero point from layer
         scale = getattr(module, f"{base_name}_scale")

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -276,8 +276,6 @@ def _process_quantization(
                 scale=scale,
                 zero_point=zero_point,
                 global_scale=global_scale,
-                dtype=dtype,
-                args=args,
             )
 
     return output

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -365,7 +365,7 @@ def forward_quantize(
     if args.dynamic or args.strategy == QuantizationStrategy.TENSOR_GROUP:
         # dynamic quantization - determine the scale/zp on the fly
         scale, zero_point = compute_dynamic_scales_and_zp(
-            value=value, args=args, module=module
+            value=value, args=args, module=module, global_scale=global_scale
         )
     else:
         # static quantization - get scale and zero point from layer
@@ -455,6 +455,6 @@ def _dequantize(
     if args and args.strategy == QuantizationStrategy.TENSOR_GROUP:
         # last dimension should be the group_size
         dequant_value = dequant_value.reshape(
-            x_q.shape[0], x_q.shape[1] * arg.group_size
+            x_q.shape[0], x_q.shape[1] * args.group_size
         )
     return dequant_value

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -201,13 +201,18 @@ def _initialize_scale_zero_point(
         scale_dtype = torch.float16
 
     # initializes empty scale, zero point, and g_idx parameters for the module
+    if base_name == "input":
+        scale_dtype = torch.float32
+
     init_scale = Parameter(
         torch.empty(expected_shape, dtype=scale_dtype, device=device),
         requires_grad=False,
     )
 
-    if quantization_args.strategy == TENSOR_GROUP:
+    if quantization_args.strategy == QuantizationStrategy.TENSOR_GROUP:
         register_offload_parameter(module, f"{base_name}_global_scale", init_scale)
+    else:
+        register_offload_parameter(module, f"{base_name}_scale", init_scale)
 
     if force_zero_point or not quantization_args.symmetric:
         if is_fp4(quantization_args=quantization_args):

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -181,6 +181,7 @@ def _initialize_scale_zero_point(
     # there is likely bug
 
     if is_fp4(quantization_args=quantization_args) and base_name == "weight":
+        assert quantization_args.strategy == QuantizationStrategy.GROUP
         scale_dtype = FP8_E4M3_DATA.dtype
         # When applying weight-only FP4 quantization, generate a global_scale
         # This scale is applied during runtime to ensure that the generated
@@ -195,6 +196,7 @@ def _initialize_scale_zero_point(
 
     # initializes empty scale, zero point, and g_idx parameters for the module
     if is_fp4(quantization_args=quantization_args) and base_name == "input":
+        assert quantization_args.strategy == QuantizationStrategy.TENSOR_GROUP
         scale_dtype = torch.float32
         scale_name = f"{base_name}_global_scale"
     else:

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -205,7 +205,9 @@ def _initialize_scale_zero_point(
         torch.empty(expected_shape, dtype=scale_dtype, device=device),
         requires_grad=False,
     )
-    register_offload_parameter(module, f"{base_name}_scale", init_scale)
+
+    if quantization_args.strategy == TENSOR_GROUP:
+        register_offload_parameter(module, f"{base_name}_global_scale", init_scale)
 
     if force_zero_point or not quantization_args.symmetric:
         if is_fp4(quantization_args=quantization_args):

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import warnings
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional, Union
 
@@ -77,6 +78,17 @@ class FP8_E4M3_DATA(FloatArgs):
 
 # TODO: Remove soon in favour of a more descriptive FloatArgs
 FP8_DTYPE = torch.float8_e4m3fn
+
+FP8_E4M3_DATA = FloatArgs(
+    exponent=4,
+    mantissa=3,
+    bits=8,
+    max=torch.finfo(torch.float8_e4m3fn).max,
+    min=torch.finfo(torch.float8_e4m3fn).min,
+    dtype=torch.float8_e4m3fn,
+)
+
+FP4_E2M1_DATA = FloatArgsFP4E2M1(exponent=2, mantissa=1, bits=4, max=6.0, min=-6.0)
 
 
 class QuantizationType(str, Enum):
@@ -278,6 +290,8 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
         return model
 
     def pytorch_dtype(self) -> torch.dtype:
+        # TODO: required for the compressor
+        # Add FP4_nvfp4 type when updating naive_compressor
         if self.type == QuantizationType.FLOAT:
             if self.num_bits == 8:
                 return FP8_E4M3_DATA.dtype
@@ -313,10 +327,16 @@ def round_to_quantized_type(
     if args.type == QuantizationType.FLOAT:
         if args.num_bits == 8:
             rounded = tensor.to(FP8_E4M3_DATA.dtype)
+<<<<<<< HEAD
         elif args.num_bits == 4:
             rounded = FP4_E2M1_DATA.cast_to_fp4(tensor)
         else:
             raise NotImplementedError("Only num_bits in (4, 8) are supported")
+=======
+        else:
+            assert args.num_bits == 4
+            rounded = FP4_E2M1_DATA.cast_to_fp4(tensor)
+>>>>>>> e02527c (add nvfp4 args)
     elif args.type == QuantizationType.INT:
         rounded = torch.round(tensor)
     else:

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import warnings
-from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Optional, Union
 

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -88,7 +88,8 @@ FP8_E4M3_DATA = FloatArgs(
     dtype=torch.float8_e4m3fn,
 )
 
-FP4_E2M1_DATA = FloatArgsFP4E2M1(exponent=2, mantissa=1, bits=4, max=6.0, min=-6.0)
+# TODO: Remove soon in favour of a more descriptive FloatArgs
+FP8_DTYPE = torch.float8_e4m3fn
 
 
 class QuantizationType(str, Enum):
@@ -290,8 +291,6 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
         return model
 
     def pytorch_dtype(self) -> torch.dtype:
-        # TODO: required for the compressor
-        # Add FP4_nvfp4 type when updating naive_compressor
         if self.type == QuantizationType.FLOAT:
             if self.num_bits == 8:
                 return FP8_E4M3_DATA.dtype
@@ -327,16 +326,10 @@ def round_to_quantized_type(
     if args.type == QuantizationType.FLOAT:
         if args.num_bits == 8:
             rounded = tensor.to(FP8_E4M3_DATA.dtype)
-<<<<<<< HEAD
         elif args.num_bits == 4:
             rounded = FP4_E2M1_DATA.cast_to_fp4(tensor)
         else:
             raise NotImplementedError("Only num_bits in (4, 8) are supported")
-=======
-        else:
-            assert args.num_bits == 4
-            rounded = FP4_E2M1_DATA.cast_to_fp4(tensor)
->>>>>>> e02527c (add nvfp4 args)
     elif args.type == QuantizationType.INT:
         rounded = torch.round(tensor)
     else:

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -240,7 +240,8 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
         if (
             group_size is not None
             and group_size > 0
-            and strategy != QuantizationStrategy.GROUP
+            and strategy
+            not in (QuantizationStrategy.GROUP, QuantizationStrategy.TENSOR_GROUP)
         ):
             raise ValueError("group_size requires strategy to be set to 'group'")
 

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -79,18 +79,6 @@ class FP8_E4M3_DATA(FloatArgs):
 # TODO: Remove soon in favour of a more descriptive FloatArgs
 FP8_DTYPE = torch.float8_e4m3fn
 
-FP8_E4M3_DATA = FloatArgs(
-    exponent=4,
-    mantissa=3,
-    bits=8,
-    max=torch.finfo(torch.float8_e4m3fn).max,
-    min=torch.finfo(torch.float8_e4m3fn).min,
-    dtype=torch.float8_e4m3fn,
-)
-
-# TODO: Remove soon in favour of a more descriptive FloatArgs
-FP8_DTYPE = torch.float8_e4m3fn
-
 
 class QuantizationType(str, Enum):
     """

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -98,6 +98,7 @@ class QuantizationStrategy(str, Enum):
     GROUP = "group"
     BLOCK = "block"
     TOKEN = "token"
+    TENSOR_GROUP = "tensor_group"
 
 
 class ActivationOrdering(Aliasable, str, Enum):

--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -113,7 +113,8 @@ NVFP4A16 = dict(
 
 # TODO: the local scales are dynamic, the global scale is static/calibrated
 # We could potentially extend the dynamic kwarg so that is goes
-# beyond being just a boolean
+# beyond being just a boolean - however we may also want a dynamically
+# generated global scale, so we could use that to separate between the two
 NVFP4 = dict(
     weights=QuantizationArgs(
         num_bits=4,
@@ -128,6 +129,7 @@ NVFP4 = dict(
         type=QuantizationType.FLOAT,
         strategy=QuantizationStrategy.TENSOR_GROUP,
         symmetric=True,
+        dynamic=False,
         group_size=16,
     ),
 )

--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -111,6 +111,27 @@ NVFP4A16 = dict(
     )
 )
 
+# TODO: the local scales are dynamic, the global scale is static/calibrated
+# We need to capture that in a new field/set dynamic to something that isn't a boolean
+# Potentially swap dynamic to be an enum/not a boolean
+NVFP4 = dict(
+    weights=QuantizationArgs(
+        num_bits=4,
+        type=QuantizationType.FLOAT,
+        strategy=QuantizationStrategy.GROUP,
+        symmetric=True,
+        dynamic=False,
+        group_size=16,
+    ),
+    input_activations=QuantizationArgs(
+        num_bits=4,
+        type=QuantizationType.FLOAT,
+        strategy=QuantizationStrategy.TENSOR_GROUP,
+        symmetric=True,
+        group_size=16,
+    ),
+)
+
 # 8 bit integer weights and 8 bit activations quantization
 INT8_W8A8 = dict(
     weights=QuantizationArgs(
@@ -237,4 +258,5 @@ PRESET_SCHEMES = {
     "FP8": FP8,
     "FP8_DYNAMIC": FP8_DYNAMIC,
     "NVFP4A16": NVFP4A16,
+    "NVFP4": NVFP4,
 }

--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -112,8 +112,8 @@ NVFP4A16 = dict(
 )
 
 # TODO: the local scales are dynamic, the global scale is static/calibrated
-# We need to capture that in a new field/set dynamic to something that isn't a boolean
-# Potentially swap dynamic to be an enum/not a boolean
+# We could potentially extend the dynamic kwarg so that is goes
+# beyond being just a boolean
 NVFP4 = dict(
     weights=QuantizationArgs(
         num_bits=4,

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-from math import ceil
 from typing import Generator, List, Optional, Tuple
 
 import torch

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import math
 from typing import Generator, List, Optional, Tuple
 
 import torch
@@ -177,7 +178,12 @@ def compute_dynamic_scales_and_zp(
         reduce_dims = tuple(idx for idx in range(3) if idx not in dim)
         keep_dims = False
         value = torch.reshape(
-            value, (value.shape[0], value.shape[1] // args.group_size, args.group_size)
+            value,
+            (
+                value.shape[0],
+                math.ceil(value.shape[1] / args.group_size),
+                args.group_size,
+            ),
         )
     else:
         raise ValueError(

--- a/tests/test_quantization/lifecycle/test_initialize.py
+++ b/tests/test_quantization/lifecycle/test_initialize.py
@@ -29,7 +29,6 @@ from compressed_tensors.quantization import (
 from compressed_tensors.quantization.lifecycle.initialize import (
     initialize_module_for_quantization,
 )
-from compressed_tensors.quantization.utils import generate_global_scale
 from tests.testing_utils import requires_accelerate
 from torch.nn import Linear
 
@@ -222,12 +221,3 @@ def test_initialize_quantization_parameters(weights, input_activations):
             assert getattr(layer, f"{q_param_name}_g_idx").shape == (
                 layer.weight.shape[1],
             )
-
-
-def test_fused_global_scales():
-    layer = Linear(7, 8)
-    max_tensor_value = torch.abs(layer.weight.data).max()
-    # use defaults
-    global_scale = generate_global_scale(layer.weight)
-    # max value should be = (448 * 6) / global_scale
-    assert max_tensor_value == (FP4_E2M1_DATA.max * FP8_E4M3_DATA.max) / global_scale

--- a/tests/test_quantization/lifecycle/test_initialize.py
+++ b/tests/test_quantization/lifecycle/test_initialize.py
@@ -160,10 +160,6 @@ def test_initialize_module_for_quantization_offloaded(
             None,
         ),
         (
-            QuantizationArgs(strategy="group", group_size=16, type="float", num_bits=4),
-            None,
-        ),
-        (
             QuantizationArgs(strategy="block"),
             QuantizationArgs(strategy="block"),
         ),

--- a/tests/test_quantization/lifecycle/test_initialize.py
+++ b/tests/test_quantization/lifecycle/test_initialize.py
@@ -155,6 +155,11 @@ def test_initialize_module_for_quantization_offloaded(
             QuantizationArgs(strategy="group", group_size=2, actorder="weight"),
             None,
         ),
+        # Ensure no global scale if not fp4
+        (
+            QuantizationArgs(strategy="group", group_size=16, type="float", num_bits=4),
+            None,
+        ),
         (
             QuantizationArgs(strategy="group", group_size=16, type="float", num_bits=4),
             None,
@@ -217,3 +222,6 @@ def test_initialize_quantization_parameters(weights, input_activations):
             assert getattr(layer, f"{q_param_name}_g_idx").shape == (
                 layer.weight.shape[1],
             )
+
+def test_fused_global_scales():
+    pass 


### PR DESCRIPTION
# Summary
- Adds the `NVFP4` preset scheme which has both FP4 weight quantization and input activation quantization 
- Extends the dynamic scale generation function to generate per group scales (previously only done for per-tensor, per-token strategies)
- Makes use of a new `tensor_group` strategy which is used by the activations
  - The activations are generated per-group (for group_size 16) 
  - The activation are dynamic 
  - The activations make use of a global_scale 
- The name `tensor_group` was selected as like FP4 weight quantization, a global scale is also generated on a per tensor basis (through calibration) which is then used to scale the local quantization group scales, which are generated and applied dynamically
- We may dynamically generate the global scale in the future as a variation

# Testing
- Need to add tests for the new strategy 
- Need to add dynamic group scale generation tests