### PR TITLE
Model Compression: Set compression status

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -421,6 +421,13 @@ class ModelCompressor:
 
                 module.quantization_status = QuantizationStatus.COMPRESSED
 
+        # TODO: consider sparse compression to also be compression
+        if (
+            self.quantization_config is not None
+            and self.quantization_config.format != CompressionFormat.dense.value
+        ):
+            self.quantization_config.quantization_status = QuantizationStatus.COMPRESSED
+
     def decompress_model(self, model: Module):
         """
         Decompress a model in memory. Because the model structure is modified in place,

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -421,7 +421,6 @@ class ModelCompressor:
 
                 module.quantization_status = QuantizationStatus.COMPRESSED
 
-        # TODO: consider sparse compression to also be compression
         if (
             self.quantization_config is not None
             and self.quantization_config.format != CompressionFormat.dense.value

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -421,6 +421,7 @@ class ModelCompressor:
 
                 module.quantization_status = QuantizationStatus.COMPRESSED
 
+        # TODO: consider sparse compression to also be compression
         if (
             self.quantization_config is not None
             and self.quantization_config.format != CompressionFormat.dense.value


### PR DESCRIPTION
## Purpose ##
* Fix bug where models compressed using the memory compression pathway would be saved in the `frozen` status rather than the `compressed` status

## Changes ##
* Set the compression status of the quantization config after compression
  * This is equivalent to https://github.com/neuralmagic/compressed-tensors/blob/f192f68f1839e0bc93a762b95d2f737789df873a/src/compressed_tensors/compressors/model_compressors/model_compressor.py#L510-L514