### PR TITLE
[Transforms] Transform Args, Scheme, and Config

### DIFF
--- a/src/compressed_tensors/transform/__init__.py
+++ b/src/compressed_tensors/transform/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# flake8: noqa
+# isort: skip_file
+
+from .transform_args import *
+from .transform_scheme import *
+from .transform_config import *

--- a/src/compressed_tensors/transform/transform_args.py
+++ b/src/compressed_tensors/transform/transform_args.py
@@ -22,7 +22,7 @@ __all__ = ["TransformArgs"]
 
 class TransformArgs(BaseModel):
     """
-    Arguments which define *how* and where a transform should be applied to a model
+    Arguments which define how and where a transform should be applied to a model
 
     :param targets: list of modules to apply transforms to
     :param location: where to apply transform on module, one of (`input`, `weight`,

--- a/src/compressed_tensors/transform/transform_args.py
+++ b/src/compressed_tensors/transform/transform_args.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, List, Literal
+
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
+
+
+__all__ = ["TransformArgs"]
+
+
+class TransformArgs(BaseModel):
+    """
+    Arguments which define *how* and where a transform should be applied to a model
+
+    :param targets: list of modules to apply transforms to
+    :param location: where to apply transform on module, one of (`input`, `weight`,
+        `output`, `k_cache`, `q_attn`)
+    :param side: determines which side of the value matrix at `location` to apply the
+        transform. Required for `weight` location only.
+    :param ignore: any modules which should be ignored from the targets list
+    """
+
+    targets: List[str]
+    location: Literal["input", "weight", "output", "k_cache", "q_attn"]
+    side: Literal["left", "right"] = Field(default=None)
+    inverse: bool = Field(default=False)
+    ignore: List[str] = Field(default_factory=list)
+
+    @field_validator("targets", "ignore", mode="before")
+    @classmethod
+    def wrap_singleton(cls, value):
+        if isinstance(value, str):
+            return [value]
+        return value
+
+    @model_validator(mode="after")
+    def determine_side(self):
+        if self.location == "input":
+            self._check_and_assign("side", "right")
+        elif self.location == "weight":
+            if self.side not in ("left", "right"):
+                raise ValueError("`side` must be provided for `weight` location")
+        elif self.location == "output":
+            self._check_and_assign("side", "left")
+        elif self.location in ("k_cache", "q_attn"):
+            pass
+        else:
+            raise ValueError(f"Unknown location {self.location}")
+
+        return self
+
+    def _check_and_assign(self, field_name: str, value: Any):
+        existing = getattr(self, field_name)
+        if existing is not None and existing != value:
+            raise ValueError(
+                f"Attempted to set `{field_name}={value}, but "
+                f"user has already set value to {existing}"
+            )
+
+        setattr(self, field_name, value)

--- a/src/compressed_tensors/transform/transform_args.py
+++ b/src/compressed_tensors/transform/transform_args.py
@@ -33,8 +33,9 @@ class TransformArgs(BaseModel):
     """
 
     targets: List[str]
-    location: Literal["input", "weight", "output", "k_cache", "q_attn"]
-    side: Optional[Literal["input", "output"]] = Field(default=None)
+    location: Literal[
+        "input", "weight_input", "weight_output", "output", "k_cache", "q_attn"
+    ]
     inverse: bool = Field(default=False)
     ignore: List[str] = Field(default_factory=list)
 
@@ -44,22 +45,6 @@ class TransformArgs(BaseModel):
         if isinstance(value, str):
             return [value]
         return value
-
-    @model_validator(mode="after")
-    def determine_side(self):
-        if self.location == "input":
-            self._check_and_assign("side", None)
-        elif self.location == "weight":
-            if self.side not in ("input", "output"):
-                raise ValueError("`side` must be provided for `weight` location")
-        elif self.location == "output":
-            self._check_and_assign("side", None)
-        elif self.location in ("k_cache", "q_attn"):
-            pass
-        else:
-            raise ValueError(f"Unknown location {self.location}")
-
-        return self
 
     def _check_and_assign(self, field_name: str, value: Any):
         existing = getattr(self, field_name)

--- a/src/compressed_tensors/transform/transform_args.py
+++ b/src/compressed_tensors/transform/transform_args.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, List, Literal
+from typing import Any, List, Literal, Optional
 
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
@@ -22,7 +22,7 @@ __all__ = ["TransformArgs"]
 
 class TransformArgs(BaseModel):
     """
-    Arguments which define how and where a transform should be applied to a model
+    Arguments which define *how* and where a transform should be applied to a model
 
     :param targets: list of modules to apply transforms to
     :param location: where to apply transform on module, one of (`input`, `weight`,
@@ -34,7 +34,7 @@ class TransformArgs(BaseModel):
 
     targets: List[str]
     location: Literal["input", "weight", "output", "k_cache", "q_attn"]
-    side: Literal["left", "right"] = Field(default=None)
+    side: Optional[Literal["input", "output"]] = Field(default=None)
     inverse: bool = Field(default=False)
     ignore: List[str] = Field(default_factory=list)
 
@@ -48,12 +48,12 @@ class TransformArgs(BaseModel):
     @model_validator(mode="after")
     def determine_side(self):
         if self.location == "input":
-            self._check_and_assign("side", "right")
+            self._check_and_assign("side", None)
         elif self.location == "weight":
-            if self.side not in ("left", "right"):
+            if self.side not in ("input", "output"):
                 raise ValueError("`side` must be provided for `weight` location")
         elif self.location == "output":
-            self._check_and_assign("side", "left")
+            self._check_and_assign("side", None)
         elif self.location in ("k_cache", "q_attn"):
             pass
         else:

--- a/src/compressed_tensors/transform/transform_args.py
+++ b/src/compressed_tensors/transform/transform_args.py
@@ -37,8 +37,7 @@ class TransformArgs(BaseModel):
     :param targets: list of modules to apply transforms to
     :param location: where to apply transform on module, one of (`input`, `weight`,
         `output`, `k_cache`, `q_attn`)
-    :param side: determines which side of the value matrix at `location` to apply the
-        transform. Required for `weight` location only.
+    :param inverse: whether or not to apply the inverse of a transform
     :param ignore: any modules which should be ignored from the targets list
     """
 
@@ -53,13 +52,3 @@ class TransformArgs(BaseModel):
         if isinstance(value, str):
             return [value]
         return value
-
-    def _check_and_assign(self, field_name: str, value: Any):
-        existing = getattr(self, field_name)
-        if existing is not None and existing != value:
-            raise ValueError(
-                f"Attempted to set `{field_name}={value}, but "
-                f"user has already set value to {existing}"
-            )
-
-        setattr(self, field_name, value)

--- a/src/compressed_tensors/transform/transform_args.py
+++ b/src/compressed_tensors/transform/transform_args.py
@@ -12,12 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, List, Literal, Optional
+from enum import Enum
+from typing import Any, List
 
-from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator
 
 
 __all__ = ["TransformArgs"]
+
+
+class TransformLocation(str, Enum):
+    INPUT = "input"
+    WEIGHT_INPUT = "weight_input"
+    WEIGHT_OUTPUT = "weight_output"
+    OUTPUT = "output"
+    K_CACHE = "k_cache"
+    Q_ATTN = "q_attn"
 
 
 class TransformArgs(BaseModel):
@@ -33,9 +43,7 @@ class TransformArgs(BaseModel):
     """
 
     targets: List[str]
-    location: Literal[
-        "input", "weight_input", "weight_output", "output", "k_cache", "q_attn"
-    ]
+    location: TransformLocation
     inverse: bool = Field(default=False)
     ignore: List[str] = Field(default_factory=list)
 

--- a/src/compressed_tensors/transform/transform_config.py
+++ b/src/compressed_tensors/transform/transform_config.py
@@ -69,75 +69,7 @@ QUIP = TransformConfig(
     }
 )
 
-# spinquant
-LLAMA_SPINQUANT = TransformConfig(
-    transform_groups={
-        "R1": TransformScheme(
-            type="hadamard",
-            apply=[
-                TransformArgs(
-                    targets=["embed_tokens", "o_proj", "down_proj"],
-                    location="weight",
-                    side="output",
-                ),
-                TransformArgs(
-                    targets=[
-                        "q_proj",
-                        "k_proj",
-                        "v_proj",
-                        "up_proj",
-                        "gate_proj",
-                        "lm_head",
-                    ],
-                    location="weight",
-                    side="input",
-                    inverse=True,
-                ),
-            ],
-        ),
-        "R2": TransformScheme(
-            type="hadamard",
-            apply=[
-                TransformArgs(
-                    targets=["v_proj"],
-                    location="weight",
-                    side="output",
-                ),
-                TransformArgs(
-                    targets=["o_proj"], location="weight", side="input", inverse=True
-                ),
-            ],
-        ),
-        "R3": TransformScheme(
-            type="hadamard",
-            apply=[
-                TransformArgs(
-                    targets=["self_attn"],
-                    location="k_cache",
-                ),
-                TransformArgs(
-                    targets=["self_attn"],
-                    location="q_attn",
-                ),
-            ],
-        ),
-        "R4": TransformScheme(
-            type="hadamard",
-            apply=[
-                TransformArgs(
-                    targets=["down_proj"],
-                    location="input",
-                ),
-                TransformArgs(
-                    targets=["down_proj"], location="weight", side="input", inverse=True
-                ),
-            ],
-        ),
-    }
-)
-
 
 PRESET_CONFIGS = {
     "QUIP": QUIP,
-    "LLAMA_SPINQUANT": LLAMA_SPINQUANT,
 }

--- a/src/compressed_tensors/transform/transform_config.py
+++ b/src/compressed_tensors/transform/transform_config.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict
+
+from compressed_tensors.transform import TransformArgs, TransformScheme
+from pydantic import BaseModel
+
+
+__all__ = ["TransformsConfig"]
+
+
+class TransformsConfig(BaseModel):
+    """
+    Configuration of transforms to be applied to a model. This config is to be
+    serialized within a model's `config.json` file
+
+    :param transform_groups: A dictionary of `TransformSchemes` that should be applied
+        to a particular model. The keys can be any arbitrary string
+    """
+
+    transform_groups: Dict[str, TransformScheme]
+
+
+# quip / quip sharp
+QUIP = TransformsConfig(
+    transform_groups={
+        "u": TransformScheme(
+            type="hadamard",
+            apply=[
+                TransformArgs(
+                    targets=["Linear"], location="output", inverse=True  # non-mergable
+                ),
+                TransformArgs(
+                    targets=["Linear"],
+                    location="weight",
+                    side="left",
+                ),
+            ],
+            randomize_modules=True,
+        ),
+        "v": TransformScheme(
+            type="hadamard",
+            apply=[
+                TransformArgs(
+                    targets=["Linear"],
+                    location="weight",
+                    side="right",
+                    inverse=True,
+                ),
+                TransformArgs(
+                    targets=["Linear"],
+                    location="input",  # non-mergable
+                ),
+            ],
+            randomize_modules=True,
+        ),
+    }
+)
+
+# spinquant
+LLAMA_SPINQUANT = TransformsConfig(
+    transform_groups={
+        "R1": TransformScheme(
+            type="hadamard",
+            apply=[
+                TransformArgs(
+                    targets=["embed_tokens", "o_proj", "down_proj"],
+                    location="weight",
+                    side="right",
+                ),
+                TransformArgs(
+                    targets=[
+                        "q_proj",
+                        "k_proj",
+                        "v_proj",
+                        "up_proj",
+                        "gate_proj",
+                        "lm_head",
+                    ],
+                    location="weight",
+                    side="left",
+                    inverse=True,
+                ),
+            ],
+        ),
+        "R2": TransformScheme(
+            type="hadamard",
+            apply=[
+                TransformArgs(
+                    targets=["v_proj"],
+                    location="weight",
+                    side="right",
+                ),
+                TransformArgs(
+                    targets=["o_proj"], location="weight", side="left", inverse=True
+                ),
+            ],
+        ),
+        "R3": TransformScheme(
+            type="hadamard",
+            apply=[
+                TransformArgs(
+                    targets=["self_attn"],
+                    location="k_cache",
+                ),
+                TransformArgs(
+                    targets=["self_attn"],
+                    location="q_attn",
+                ),
+            ],
+        ),
+        "R4": TransformScheme(
+            type="hadamard",
+            apply=[
+                TransformArgs(
+                    targets=["down_proj"],
+                    location="input",
+                ),
+                TransformArgs(
+                    targets=["down_proj"], location="weight", side="left", inverse=True
+                ),
+            ],
+        ),
+    }
+)
+
+
+PRESET_CONFIGS = {
+    "QUIP": QUIP,
+    "LLAMA_SPINQUANT": LLAMA_SPINQUANT,
+}

--- a/src/compressed_tensors/transform/transform_config.py
+++ b/src/compressed_tensors/transform/transform_config.py
@@ -18,10 +18,10 @@ from compressed_tensors.transform import TransformArgs, TransformScheme
 from pydantic import BaseModel
 
 
-__all__ = ["TransformsConfig"]
+__all__ = ["TransformConfig"]
 
 
-class TransformsConfig(BaseModel):
+class TransformConfig(BaseModel):
     """
     Configuration of transforms to be applied to a model. This config is to be
     serialized within a model's `config.json` file
@@ -34,34 +34,34 @@ class TransformsConfig(BaseModel):
 
 
 # quip / quip sharp
-QUIP = TransformsConfig(
+QUIP = TransformConfig(
     transform_groups={
-        "u": TransformScheme(
-            type="hadamard",
-            apply=[
-                TransformArgs(
-                    targets=["Linear"], location="output", inverse=True  # non-mergable
-                ),
-                TransformArgs(
-                    targets=["Linear"],
-                    location="weight",
-                    side="left",
-                ),
-            ],
-            randomize_modules=True,
-        ),
         "v": TransformScheme(
             type="hadamard",
             apply=[
                 TransformArgs(
                     targets=["Linear"],
-                    location="weight",
-                    side="right",
-                    inverse=True,
+                    location="input",  # non-mergable
                 ),
                 TransformArgs(
                     targets=["Linear"],
-                    location="input",  # non-mergable
+                    location="weight",
+                    side="input",
+                    inverse=True,
+                ),
+            ],
+            randomize_modules=True,
+        ),
+        "u": TransformScheme(
+            type="hadamard",
+            apply=[
+                TransformArgs(
+                    targets=["Linear"],
+                    location="weight",
+                    side="output",
+                ),
+                TransformArgs(
+                    targets=["Linear"], location="output", inverse=True  # non-mergable
                 ),
             ],
             randomize_modules=True,
@@ -70,7 +70,7 @@ QUIP = TransformsConfig(
 )
 
 # spinquant
-LLAMA_SPINQUANT = TransformsConfig(
+LLAMA_SPINQUANT = TransformConfig(
     transform_groups={
         "R1": TransformScheme(
             type="hadamard",
@@ -78,7 +78,7 @@ LLAMA_SPINQUANT = TransformsConfig(
                 TransformArgs(
                     targets=["embed_tokens", "o_proj", "down_proj"],
                     location="weight",
-                    side="right",
+                    side="output",
                 ),
                 TransformArgs(
                     targets=[
@@ -90,7 +90,7 @@ LLAMA_SPINQUANT = TransformsConfig(
                         "lm_head",
                     ],
                     location="weight",
-                    side="left",
+                    side="input",
                     inverse=True,
                 ),
             ],
@@ -101,10 +101,10 @@ LLAMA_SPINQUANT = TransformsConfig(
                 TransformArgs(
                     targets=["v_proj"],
                     location="weight",
-                    side="right",
+                    side="output",
                 ),
                 TransformArgs(
-                    targets=["o_proj"], location="weight", side="left", inverse=True
+                    targets=["o_proj"], location="weight", side="input", inverse=True
                 ),
             ],
         ),
@@ -129,7 +129,7 @@ LLAMA_SPINQUANT = TransformsConfig(
                     location="input",
                 ),
                 TransformArgs(
-                    targets=["down_proj"], location="weight", side="left", inverse=True
+                    targets=["down_proj"], location="weight", side="input", inverse=True
                 ),
             ],
         ),

--- a/src/compressed_tensors/transform/transform_config.py
+++ b/src/compressed_tensors/transform/transform_config.py
@@ -26,16 +26,16 @@ class TransformConfig(BaseModel):
     Configuration of transforms to be applied to a model. This config is to be
     serialized within a model's `config.json` file
 
-    :param transform_groups: A dictionary of `TransformSchemes` that should be applied
+    :param config_groups: A dictionary of `TransformSchemes` that should be applied
         to a particular model. The keys can be any arbitrary string
     """
 
-    transform_groups: Dict[str, TransformScheme]
+    config_groups: Dict[str, TransformScheme]
 
 
 # quip / quip sharp
 QUIP = TransformConfig(
-    transform_groups={
+    config_groups={
         "v": TransformScheme(
             type="hadamard",
             apply=[
@@ -45,8 +45,7 @@ QUIP = TransformConfig(
                 ),
                 TransformArgs(
                     targets=["Linear"],
-                    location="weight",
-                    side="input",
+                    location="weight_input",
                     inverse=True,
                 ),
             ],
@@ -57,8 +56,7 @@ QUIP = TransformConfig(
             apply=[
                 TransformArgs(
                     targets=["Linear"],
-                    location="weight",
-                    side="output",
+                    location="weight_output",
                 ),
                 TransformArgs(
                     targets=["Linear"], location="output", inverse=True  # non-mergable

--- a/src/compressed_tensors/transform/transform_scheme.py
+++ b/src/compressed_tensors/transform/transform_scheme.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+from compressed_tensors.transform import TransformArgs
+from pydantic import BaseModel, Field
+
+
+__all__ = ["TransformScheme"]
+
+
+class TransformScheme(BaseModel):
+    """
+    Scheme used to parameterize a particular transform type and specify how and where it
+    should be applied to the model
+
+    :param type: string indicating the particular transform type that should be created
+        and applied. This should be one of the registered transform types
+        (see `Transforms.registered_names()`)
+    :param apply: list of TransformationArgs containing the information about the
+        modules that should be targeted by the specified transform
+    :param randomize_modules: True if unique transforms should be applied to each
+        unique module targeted by `apply`, otherwise reuse transform weights where
+        applicable
+    :param requires_grad: True if weights include gradients for training
+    """
+
+    type: str
+    apply: List[TransformArgs] = Field(default_factory=list)
+    randomize_modules: bool = Field(default=False)
+    requires_grad: bool = Field(default=False)

--- a/tests/test_transform/test_transform_args.py
+++ b/tests/test_transform/test_transform_args.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 from compressed_tensors.transform import TransformArgs
 
 

--- a/tests/test_transform/test_transform_args.py
+++ b/tests/test_transform/test_transform_args.py
@@ -29,7 +29,7 @@ def test_basic():
 def test_args_full():
     targets = ["Linear"]
     location = "weight"
-    side = "left"
+    side = "input"
     inverse = True
     ignore = ["model.layers.2"]
 
@@ -63,23 +63,23 @@ def test_side():
     tar = ["Linear"]
 
     # input
-    assert TransformArgs(targets=tar, location="input").side == "right"
+    assert TransformArgs(targets=tar, location="input").side is None
     with pytest.raises(ValueError):
-        TransformArgs(targets=tar, location="input", side="left")
+        TransformArgs(targets=tar, location="input", side="output")
     with pytest.raises(ValueError):
         TransformArgs(targets=tar, location="input", side="invalid")
 
     # output
-    assert TransformArgs(targets=tar, location="output").side == "left"
+    assert TransformArgs(targets=tar, location="output").side is None
     with pytest.raises(ValueError):
-        TransformArgs(targets=tar, location="output", side="right")
+        TransformArgs(targets=tar, location="output", side="input")
     with pytest.raises(ValueError):
         TransformArgs(targets=tar, location="output", side="invalid")
 
     # weight
     with pytest.raises(ValueError):
         TransformArgs(targets=tar, location="weight")
-    assert TransformArgs(targets=tar, location="weight", side="left").side == "left"
-    assert TransformArgs(targets=tar, location="weight", side="right").side == "right"
+    assert TransformArgs(targets=tar, location="weight", side="input").side == "input"
+    assert TransformArgs(targets=tar, location="weight", side="output").side == "output"
     with pytest.raises(ValueError):
         TransformArgs(targets=tar, location="weight", side="invalid")

--- a/tests/test_transform/test_transform_args.py
+++ b/tests/test_transform/test_transform_args.py
@@ -28,22 +28,19 @@ def test_basic():
 
 def test_args_full():
     targets = ["Linear"]
-    location = "weight"
-    side = "input"
+    location = "weight_input"
     inverse = True
     ignore = ["model.layers.2"]
 
     args = TransformArgs(
         targets=targets,
         location=location,
-        side=side,
         inverse=inverse,
         ignore=ignore,
     )
 
     args.targets = targets
     args.location == location
-    args.side == side
     args.inverse == inverse
     args.ignore == ignore
 
@@ -57,29 +54,3 @@ def test_singleton_targets():
     assert args.targets == [target]
     assert args.location == location
     assert args.ignore == [ignore]
-
-
-def test_side():
-    tar = ["Linear"]
-
-    # input
-    assert TransformArgs(targets=tar, location="input").side is None
-    with pytest.raises(ValueError):
-        TransformArgs(targets=tar, location="input", side="output")
-    with pytest.raises(ValueError):
-        TransformArgs(targets=tar, location="input", side="invalid")
-
-    # output
-    assert TransformArgs(targets=tar, location="output").side is None
-    with pytest.raises(ValueError):
-        TransformArgs(targets=tar, location="output", side="input")
-    with pytest.raises(ValueError):
-        TransformArgs(targets=tar, location="output", side="invalid")
-
-    # weight
-    with pytest.raises(ValueError):
-        TransformArgs(targets=tar, location="weight")
-    assert TransformArgs(targets=tar, location="weight", side="input").side == "input"
-    assert TransformArgs(targets=tar, location="weight", side="output").side == "output"
-    with pytest.raises(ValueError):
-        TransformArgs(targets=tar, location="weight", side="invalid")

--- a/tests/test_transform/test_transform_args.py
+++ b/tests/test_transform/test_transform_args.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from compressed_tensors.transform import TransformArgs
+
+
+def test_basic():
+    targets = ["Embedding"]
+    location = "input"
+    args = TransformArgs(targets=targets, location=location)
+
+    assert args.targets == targets
+    assert args.location == location
+    assert len(args.ignore) == 0
+
+
+def test_args_full():
+    targets = ["Linear"]
+    location = "weight"
+    side = "left"
+    inverse = True
+    ignore = ["model.layers.2"]
+
+    args = TransformArgs(
+        targets=targets,
+        location=location,
+        side=side,
+        inverse=inverse,
+        ignore=ignore,
+    )
+
+    args.targets = targets
+    args.location == location
+    args.side == side
+    args.inverse == inverse
+    args.ignore == ignore
+
+
+def test_singleton_targets():
+    target = "target"
+    location = "input"
+    ignore = "ignore"
+    args = TransformArgs(targets=target, location=location, ignore=ignore)
+
+    assert args.targets == [target]
+    assert args.location == location
+    assert args.ignore == [ignore]
+
+
+def test_side():
+    tar = ["Linear"]
+
+    # input
+    assert TransformArgs(targets=tar, location="input").side == "right"
+    with pytest.raises(ValueError):
+        TransformArgs(targets=tar, location="input", side="left")
+    with pytest.raises(ValueError):
+        TransformArgs(targets=tar, location="input", side="invalid")
+
+    # output
+    assert TransformArgs(targets=tar, location="output").side == "left"
+    with pytest.raises(ValueError):
+        TransformArgs(targets=tar, location="output", side="right")
+    with pytest.raises(ValueError):
+        TransformArgs(targets=tar, location="output", side="invalid")
+
+    # weight
+    with pytest.raises(ValueError):
+        TransformArgs(targets=tar, location="weight")
+    assert TransformArgs(targets=tar, location="weight", side="left").side == "left"
+    assert TransformArgs(targets=tar, location="weight", side="right").side == "right"
+    with pytest.raises(ValueError):
+        TransformArgs(targets=tar, location="weight", side="invalid")

--- a/tests/test_transform/test_transform_config.py
+++ b/tests/test_transform/test_transform_config.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+from compressed_tensors.transform import (
+    TransformArgs,
+    TransformScheme,
+    TransformsConfig,
+)
+
+
+@pytest.fixture
+def basic_transform_scheme():
+    targets = ["Embedding"]
+    location = "input"
+    basic_args = TransformArgs(targets=targets, location=location)
+
+    return TransformScheme(
+        type="hadamard",
+        apply=[basic_args],
+    )
+
+
+def test_basic(basic_transform_scheme):
+    config = TransformsConfig(
+        transform_groups={
+            "transform_0": basic_transform_scheme,
+        }
+    )
+    assert isinstance(config.transform_groups.get("transform_0"), TransformScheme)
+
+
+def test_to_dict(basic_transform_scheme):
+    config = TransformsConfig(
+        transform_groups={
+            "transform_0": basic_transform_scheme,
+        }
+    )
+    config_dict = config.model_dump()
+    assert "transform_groups" in config_dict.keys()
+
+
+def test_multiple_groups():
+    location = "weight"
+    side = "left"
+
+    targets_1 = ["model.layers.0.attn.v_proj"]
+    linear_args_1 = TransformArgs(targets=targets_1, location=location, side=side)
+
+    targets_2 = ["model.layers.0.attn.q_proj"]
+    linear_args_2 = TransformArgs(targets=targets_2, location=location, side=side)
+
+    scheme_1 = TransformScheme(
+        type="hadamard",
+        apply=[linear_args_1],
+    )
+
+    scheme_2 = TransformScheme(
+        type="hadamard",
+        apply=[linear_args_2],
+    )
+    config = TransformsConfig(
+        transform_groups={"transform_0": scheme_1, "transform_1": scheme_2}
+    )

--- a/tests/test_transform/test_transform_config.py
+++ b/tests/test_transform/test_transform_config.py
@@ -14,11 +14,7 @@
 
 
 import pytest
-from compressed_tensors.transform import (
-    TransformArgs,
-    TransformScheme,
-    TransformsConfig,
-)
+from compressed_tensors.transform import TransformArgs, TransformConfig, TransformScheme
 
 
 @pytest.fixture
@@ -34,7 +30,7 @@ def basic_transform_scheme():
 
 
 def test_basic(basic_transform_scheme):
-    config = TransformsConfig(
+    config = TransformConfig(
         transform_groups={
             "transform_0": basic_transform_scheme,
         }
@@ -43,7 +39,7 @@ def test_basic(basic_transform_scheme):
 
 
 def test_to_dict(basic_transform_scheme):
-    config = TransformsConfig(
+    config = TransformConfig(
         transform_groups={
             "transform_0": basic_transform_scheme,
         }
@@ -54,7 +50,7 @@ def test_to_dict(basic_transform_scheme):
 
 def test_multiple_groups():
     location = "weight"
-    side = "left"
+    side = "input"
 
     targets_1 = ["model.layers.0.attn.v_proj"]
     linear_args_1 = TransformArgs(targets=targets_1, location=location, side=side)
@@ -71,6 +67,6 @@ def test_multiple_groups():
         type="hadamard",
         apply=[linear_args_2],
     )
-    config = TransformsConfig(
+    config = TransformConfig(
         transform_groups={"transform_0": scheme_1, "transform_1": scheme_2}
     )

--- a/tests/test_transform/test_transform_config.py
+++ b/tests/test_transform/test_transform_config.py
@@ -31,32 +31,31 @@ def basic_transform_scheme():
 
 def test_basic(basic_transform_scheme):
     config = TransformConfig(
-        transform_groups={
+        config_groups={
             "transform_0": basic_transform_scheme,
         }
     )
-    assert isinstance(config.transform_groups.get("transform_0"), TransformScheme)
+    assert isinstance(config.config_groups.get("transform_0"), TransformScheme)
 
 
 def test_to_dict(basic_transform_scheme):
     config = TransformConfig(
-        transform_groups={
+        config_groups={
             "transform_0": basic_transform_scheme,
         }
     )
     config_dict = config.model_dump()
-    assert "transform_groups" in config_dict.keys()
+    assert "config_groups" in config_dict.keys()
 
 
 def test_multiple_groups():
-    location = "weight"
-    side = "input"
+    location = "weight_input"
 
     targets_1 = ["model.layers.0.attn.v_proj"]
-    linear_args_1 = TransformArgs(targets=targets_1, location=location, side=side)
+    linear_args_1 = TransformArgs(targets=targets_1, location=location)
 
     targets_2 = ["model.layers.0.attn.q_proj"]
-    linear_args_2 = TransformArgs(targets=targets_2, location=location, side=side)
+    linear_args_2 = TransformArgs(targets=targets_2, location=location)
 
     scheme_1 = TransformScheme(
         type="hadamard",
@@ -68,5 +67,5 @@ def test_multiple_groups():
         apply=[linear_args_2],
     )
     config = TransformConfig(
-        transform_groups={"transform_0": scheme_1, "transform_1": scheme_2}
+        config_groups={"transform_0": scheme_1, "transform_1": scheme_2}
     )

--- a/tests/test_transform/test_transform_scheme.py
+++ b/tests/test_transform/test_transform_scheme.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from compressed_tensors.transform import TransformArgs, TransformScheme
+
+
+def test_basic_scheme():
+    targets = ["Linear"]
+    location = "input"
+    basic_args = TransformArgs(targets=targets, location=location)
+
+    scheme = TransformScheme(
+        type="hadamard",
+        apply=[basic_args],
+    )
+    assert not scheme.randomize_modules
+    assert scheme.type == "hadamard"
+    assert len(scheme.apply) == 1
+    assert isinstance(scheme.apply[0], TransformArgs)
+
+
+def test_multiple_groups_global():
+    targets = ["Embedding"]
+    location = "input"
+    embedding_args = TransformArgs(targets=targets, location=location)
+
+    targets = ["Linear"]
+    location = "weight"
+    side = "left"
+    linear_args = TransformArgs(targets=targets, location=location, side=side)
+
+    # same transform applied to multiple groups
+    scheme = TransformScheme(
+        type="hadamard",
+        apply=[embedding_args, linear_args],
+        randomize_modules=True,
+    )
+
+    assert scheme.randomize_modules
+    assert scheme.type == "hadamard"
+    assert len(scheme.apply) == 2
+    assert isinstance(scheme.apply[0], TransformArgs)
+    assert isinstance(scheme.apply[1], TransformArgs)
+
+
+def test_multiple_groups():
+    apply = []
+    location = "weight"
+    side = "left"
+
+    for i in range(20):
+        targets = [f"model.layers.{i}.attn.v_proj", f"model.layers.{i}.attn.o_proj"]
+        args = TransformArgs(targets=targets, location=location, side=side)
+        apply.append(args)
+
+    # global is False, different hadamard transform applied to each group
+    # same dimension/hidden dim
+    scheme = TransformScheme(
+        type="hadamard",
+        apply=apply,
+    )
+
+    assert not scheme.randomize_modules
+    assert scheme.type == "hadamard"
+    assert len(scheme.apply) == 20

--- a/tests/test_transform/test_transform_scheme.py
+++ b/tests/test_transform/test_transform_scheme.py
@@ -37,7 +37,7 @@ def test_multiple_groups_global():
 
     targets = ["Linear"]
     location = "weight"
-    side = "left"
+    side = "input"
     linear_args = TransformArgs(targets=targets, location=location, side=side)
 
     # same transform applied to multiple groups
@@ -57,7 +57,7 @@ def test_multiple_groups_global():
 def test_multiple_groups():
     apply = []
     location = "weight"
-    side = "left"
+    side = "output"
 
     for i in range(20):
         targets = [f"model.layers.{i}.attn.v_proj", f"model.layers.{i}.attn.o_proj"]

--- a/tests/test_transform/test_transform_scheme.py
+++ b/tests/test_transform/test_transform_scheme.py
@@ -36,9 +36,8 @@ def test_multiple_groups_global():
     embedding_args = TransformArgs(targets=targets, location=location)
 
     targets = ["Linear"]
-    location = "weight"
-    side = "input"
-    linear_args = TransformArgs(targets=targets, location=location, side=side)
+    location = "weight_input"
+    linear_args = TransformArgs(targets=targets, location=location)
 
     # same transform applied to multiple groups
     scheme = TransformScheme(
@@ -56,12 +55,11 @@ def test_multiple_groups_global():
 
 def test_multiple_groups():
     apply = []
-    location = "weight"
-    side = "output"
+    location = "weight_output"
 
     for i in range(20):
         targets = [f"model.layers.{i}.attn.v_proj", f"model.layers.{i}.attn.o_proj"]
-        args = TransformArgs(targets=targets, location=location, side=side)
+        args = TransformArgs(targets=targets, location=location)
         apply.append(args)
 
     # global is False, different hadamard transform applied to each group


### PR DESCRIPTION
# Summary
- Introduce Transform Args, Scheme, Config and Data as structures to define recipes to apply transforms 
- When compared to https://github.com/neuralmagic/compressed-tensors/pull/275, the requirement for `ModuleTarget`, and `TransformData` has been removed as well as the `transform_creation_args` and `call_args` fields
- Supports spinquant-like transform configs which target non-linear modules such as `q_attn` and `k_cache`

#### `TransformArgs`
- Arguments which define how and where a transform should be applied to a model

#### `TransformScheme`
- Scheme used to parameterize a particular transform type and specify how and where it should be applied to the model
- Includes a list of `TransformationArgs` onto which the transformation will be applied

#### `TransformConfig`
- Configuration of transforms to be applied to a model. This config is to be serialized within a model's `config.json` file
- The keys can be any arbitrary string and a TransformationScheme should be provided for each new transform type.
- Include preset configs for QUIP/QUIP# and Llama-SpinQuant

# Example:
```python
from compressed_tensors.transform import TransformArgs, TransformScheme, TransformsConfig

forward_args = TransformArgs(targets=["Linear"], location="input")  # non-mergable
inverse_args = TransformArgs(targets=["Linear"], location="weight_input", inverse=True)

scheme = TransformScheme(
    type="hadamard",
    apply=[forward_args, inverse_args],
    randomize_modules=True
)

config = TransformsConfig(transform_groups={"v_transform": scheme}
```

```
# [transform locations] and {quant locations}:
# input  <- {input @ [input]}
# weight <- {[weight_output] @ weight @ [weight_input]}
# output <- {input @ weight.T @ [output]}
```