### PR TITLE
[NVFP4] Skip fused global scale calculation if already fused

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -304,6 +304,9 @@ def update_fused_layer_weight_global_scales(model: torch.nn.Module):
     ):
 
         if _is_attention_module(submodule):
+            # already fused/treated as one layer
+            if hasattr(submodule, "qkv_proj"):
+                continue
 
             if not _valid_fp4_quant(
                 [submodule.q_proj, submodule.v_proj, submodule.k_proj]


### PR DESCRIPTION
- Solves failing e2e nightly tests for Phi models 
- No need to recalculate the global scale if the layer is already fused