### PR TITLE
Use different runner for UPLOAD job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -59,7 +59,7 @@ jobs:
         needs: [TEST]
         uses: ./.github/workflows/upload.yml
         with:
-            label: k8s-util
+            label: gcp-k8s-util
             timeout: 40
             run_id: ${{ github.run_id }}
             push_to_pypi: ${{ inputs.push_to_pypi }}


### PR DESCRIPTION
Use the `gcp-k8s-util` runner for the “UPLOAD” job, rather than `k8s-util`. This runner is not showing the same issues currently affecting `k8s-util`, and was able to complete the “UPLOAD” job successfully: https://github.com/neuralmagic/compressed-tensors/actions/runs/15326172818/job/43121574349