### PR TITLE
[Misc] Remove unused config name definitions

### DIFF
--- a/src/compressed_tensors/base.py
+++ b/src/compressed_tensors/base.py
@@ -14,7 +14,5 @@
 
 SPARSITY_CONFIG_NAME = "sparsity_config"
 QUANTIZATION_CONFIG_NAME = "quantization_config"
-COMPRESSION_CONFIG_NAME = "compression_config"
-KV_CACHE_SCHEME_NAME = "kv_cache_scheme"
 COMPRESSION_VERSION_NAME = "version"
 QUANTIZATION_METHOD_NAME = "quant_method"


### PR DESCRIPTION
## Purpose ##
* Remove unused/ misleading code

## Changes ##
* Remove `COMPRESSION_CONFIG_NAME` and `KV_CACHE_SCHEME_NAME` definitions, which are no longer supported unused

```bash
grep -r -E 'COMPRESSION_CONFIG_NAME|KV_CACHE_SCHEME_NAME' ../llm-compressor/src ../llm-compressor/tests/ ../llm-compressor/examples/
```