### PR TITLE
[Decompression] Keep unused parameters when decompressing from memory

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -460,18 +460,13 @@ class ModelCompressor:
 
                 # quantization second
                 if prefix in module_to_scheme:
-                    generator = self.quantization_compressor.decompress_from_state_dict(
-                        state_dict,
-                        names_to_scheme=module_to_scheme,
+                    state_dict = (
+                        self.quantization_compressor.decompress_module_from_state_dict(
+                            prefix,
+                            state_dict,
+                            scheme=module_to_scheme[prefix],
+                        )
                     )
-                    # generates (mod_path, {param_name, param_val})
-                    # of compressed params and used params, but not unused params
-                    # some used params are removed by get_unexpected_file_keys
-                    state_dict = {
-                        merge_names(module_path, param_name): param_value
-                        for module_path, compressed_data in generator
-                        for param_name, param_value in compressed_data.items()
-                    }
 
                 # remove any existing parameters
                 device = get_execution_device(module)

--- a/src/compressed_tensors/compressors/quantized_compressors/base.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/base.py
@@ -239,7 +239,16 @@ class BaseQuantizationCompressor(BaseCompressor):
         prefix: str,
         state_dict: Dict[str, torch.Tensor],
         scheme: QuantizationScheme,
-    ) -> Generator[Tuple[str, Dict[str, torch.Tensor]], None, None]:
+    ) -> Dict[str, torch.Tensor]:
+        """
+        Only used by in-memory decompression pathways to decompress the parameters of
+        one module
+
+        :param prefix: prefix of state_dict, typically the path to the module
+        :param state_dict: state dict containing module parameter values
+        :param scheme: quantization scheme of module to decompress
+        :return: state dict with weight decompressed if applicable
+        """
         state_dict = {
             key.removeprefix(f"{prefix}."): value for key, value in state_dict.items()
         }


### PR DESCRIPTION
## Background ##
Unlike the sparse decompressor, the quantized decompressor does not yield unused parameters. Infact, the standard `decompress_from_state_dict` function cannot yield unused parameters without significantly modifying the `get_nested_mappings_from_state_dict` function. Because of this contract inflexibility and fundamental difference between the return types of sparsity decompressors and quantization decompressors, it's more conceptually simple to add a separate function `decompress_module_from_state_dict` for handling quantized decompression of module state dicts.

## Changes ##
* Add `decompress_module_from_state_dict` which decompresses a module's static dict
* Simplify some code in `decompress_from_state_dict`
* Modify model compressor to use new `decompress_module_from_state_dict` function

## Testing ##
* Locally tested that decompression works with unused params