### PR TITLE
Fix error on import whenever accelerate is absent

### DIFF
--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -87,13 +87,15 @@ def check_accelerate(fallback: Any):
         if not _has_accelerate:
 
             if fallback == "error":
-                raise ValueError(
-                    "Please install `accelerate` in order to use this function"
-                )
-
-            @wraps(func)
-            def fallback_fn(*args, **kwargs):
-                return fallback
+                @wraps(func)
+                def fallback_fn(*args, **kwargs):
+                    raise ValueError(
+                        "Please install `accelerate` in order to use this function"
+                    )
+            else:
+                @wraps(func)
+                def fallback_fn(*args, **kwargs):
+                    return fallback
 
             return fallback_fn
 


### PR DESCRIPTION
Before, if accelerate is absent, the `check_accelerate` decorator would generate an error at import time whenever `@check_accelerate(fallback="error")` is specified. After it fails only if the particular function is called.