### PR TITLE
[Hotfix] Implement quantization compressor methods on dense compressor

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -30,8 +30,12 @@ from compressed_tensors.base import (
     QUANTIZATION_METHOD_NAME,
     SPARSITY_CONFIG_NAME,
 )
-from compressed_tensors.compressors.base import BaseCompressor
-from compressed_tensors.compressors.sparse_compressors import DenseCompressor
+from compressed_tensors.compressors import (
+    BaseCompressor,
+    BaseQuantizationCompressor,
+    BaseSparseCompressor,
+    DenseCompressor,
+)
 from compressed_tensors.config import CompressionFormat, SparsityCompressionConfig
 from compressed_tensors.quantization import (
     DEFAULT_QUANTIZATION_METHOD,
@@ -257,7 +261,9 @@ class ModelCompressor:
         self.sparsity_config = sparsity_config
         self.quantization_config = quantization_config
         self.sparsity_compressor = None
-        self.quantization_compressor = None
+        self.quantization_compressor: Optional[
+            Union[BaseQuantizationCompressor, BaseSparseCompressor]
+        ] = None
 
         if sparsity_config is not None:
             self.sparsity_compressor = BaseCompressor.load_from_registry(

--- a/src/compressed_tensors/compressors/sparse_compressors/base.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/base.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import logging
-from typing import Dict, Generator, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Dict, Generator, Optional, Set, Tuple
 
+import torch
 from compressed_tensors.compressors.base import BaseCompressor
 from compressed_tensors.utils import (
     get_nested_mappings_from_state_dict,
@@ -24,6 +25,10 @@ from compressed_tensors.utils import (
 from safetensors import safe_open
 from torch import Tensor
 from tqdm import tqdm
+
+
+if TYPE_CHECKING:
+    from compressed_tensors.quantization import QuantizationScheme
 
 
 __all__ = ["BaseSparseCompressor"]
@@ -200,3 +205,16 @@ class BaseSparseCompressor(BaseCompressor):
         return (
             name.endswith(".weight") and name[: -(len(".weight"))] in expanded_targets
         )
+
+    def decompress_module_from_state_dict(
+        self,
+        prefix: str,
+        state_dict: Dict[str, torch.Tensor],
+        scheme: QuantizationScheme,
+    ) -> Dict[str, torch.Tensor]:
+        """
+        This function is implemented as a workaround because of how
+        `ModelCompressor.quantization_compressor` can be set to either
+        an instance of `BaseQuantizationCompressor` or `BaseSparseCompressor`.
+        """
+        return state_dict.copy()


### PR DESCRIPTION
## Background ##
* The typing of ModelCompressor.quantization_compressor is less narrow than I expected when implementing #301

## Purpose ##
* Fix model decompression in cases where the quantization compressor is a dense compressor
  * https://github.com/vllm-project/llm-compressor/pull/1528

## Changes ##
* Implement `decompress_module_from_state_dict` on DenseCompressor