### PR TITLE
[Bugfix] Fix `find_name_or_class_matches` return type

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -331,12 +331,10 @@ def find_name_or_class_matches(
         3. matches on module names
     """
     targets = sorted(targets, key=lambda x: ("re:" in x, x))
-    if isinstance(targets, Iterable):
-        matches = _find_matches(name, targets) + _find_matches(
-            module.__class__.__name__, targets, check_contains
-        )
-        matches = [match for match in matches if match is not None]
-        return matches
+    matches = _find_matches(name, targets) + _find_matches(
+        module.__class__.__name__, targets, check_contains
+    )
+    return [match for match in matches if match is not None]
 
 
 def _find_matches(


### PR DESCRIPTION
## Background ##
* This check was initially added by #79 with no reasoning given. Given that this function should error if a non-iterable is passed anyways (`sorted` call should error first if not iterable), I believe they are safe to make without breaking anything. If errors to occur, they should be fixed upstream, not in this function.

## Changes ##
* Remove unnecessary type check which would have resulted in the function returning `None`, which breaks its function contract