### PR TITLE
Remove redundant call

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -183,9 +183,7 @@ def apply_quantization_config(
                         replace_module(model, name, compressed_linear)
 
             # target matched - add layer and scheme to target list
-            submodule.quantization_scheme = _scheme_from_targets(
-                target_to_scheme, targets, name
-            )
+            submodule.quantization_scheme = scheme
 
             names_to_scheme[name] = submodule.quantization_scheme
 


### PR DESCRIPTION
Unless I am missing something, this call into `_scheme_from_targets` is redundant. It can be used from L172