### PR TITLE
[Transform] [Bugfix] Fix enum value serialization in python>=3.11

### DIFF
--- a/src/compressed_tensors/transform/factory/base.py
+++ b/src/compressed_tensors/transform/factory/base.py
@@ -97,7 +97,7 @@ class TransformFactory(RegistryMixin, ABC):
         :param args: defines how the transform will be applied to the target module
         """
         # create transform as submodule
-        transform_name = f"{self.name}_{args.location}"
+        transform_name = f"{self.name}_{args.location.value}"
         transform = self.create_transform(module, args)
         register_offload_module(module, transform_name, transform)  # (1)
 


### PR DESCRIPTION
## Background ##
* In python3.11 a lot changed about Enum types. While the [documentation](https://docs.python.org/3/library/enum.html) doesn't explicitly state it, I've observed that casting to string via fstrings has different behavior starting in python3.11

Python3.10
```python3
>>> f"{TransformLocation.WEIGHT_INPUT}" 
'weight_input'
```

Python3.11
```python3
>>> f"{TransformLocation.WEIGHT_INPUT}"
'TransformLocation.WEIGHT_INPUT'
```

## Purpose ##
* Fix names given to transform submodules

## Changes ##
* Use enum value property when assigning submodule names. This property is a safe representation across python versions

## Testing ##
Python3.10
```python3
>>> f"{TransformLocation.WEIGHT_INPUT}" 
'weight_input'
```

Python3.11
```python3
>>> f"{TransformLocation.WEIGHT_INPUT}"
'weight_input'
```