### PR TITLE
[Accelerate] Extend functionality of `register_offload_parameter`

### DIFF
--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -205,6 +205,7 @@ def register_offload_parameter(
     module.register_parameter(name, parameter)
 
     # do everything AlignDevicesHook.init_hook does
+    # https://github.com/huggingface/accelerate/blob/main/src/accelerate/hooks.py#L281
     if has_offloaded_params(module):
         hook: AlignDevicesHook = module._hf_hook
         assert hook.weights_map is not None

--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -204,9 +204,23 @@ def register_offload_parameter(
     has_onload = any(p.device != torch.device("meta") for p in module.parameters())
     module.register_parameter(name, parameter)
 
+    # do everything AlignDevicesHook.init_hook does
     if has_offloaded_params(module):
-        weights_map = module._hf_hook.weights_map
-        offload_to_weights_map(weights_map, name, parameter.data, offload_device)
+        hook: AlignDevicesHook = module._hf_hook
+        assert hook.weights_map is not None
+
+        # append to original_devices
+        hook.original_devices[name] = parameter.device
+
+        # append to weights map
+        offload_to_weights_map(hook.weights_map, name, parameter.data, offload_device)
+
+        # append to tied_params_map
+        offloaded = hook.weights_map[name]
+        if hook.tied_params_map is not None:
+            hook.tied_params_map[offloaded.data_ptr()] = {}  # (1)
+
+        # perform offloading
         if not has_onload:
             set_module_tensor_to_device(module, name, "meta")
 
@@ -420,7 +434,6 @@ def register_offload_module(base: torch.nn.Module, name: str, module: torch.nn.M
         hook: AlignDevicesHook = base._hf_hook
         assert hook.offload
         assert hook.weights_map is not None
-        assert hook.tied_params_map is not None
 
         # offloading kwargs for submodule
         place_submodules = False
@@ -435,7 +448,8 @@ def register_offload_module(base: torch.nn.Module, name: str, module: torch.nn.M
             module, include_buffers=offload_buffers, recurse=place_submodules
         ):
             offloaded = param.to(offload_device)
-            hook.tied_params_map[offloaded.data_ptr()] = {}  # (1)
+            if hook.tied_params_map is not None:
+                hook.tied_params_map[offloaded.data_ptr()] = {}  # (1)
             offload_to_weights_map(hook.weights_map, f"{name}.{param_name}", offloaded)
 
             # if the parent places submodules, offload here
@@ -462,9 +476,6 @@ def register_offload_module(base: torch.nn.Module, name: str, module: torch.nn.M
             add_hook_to_module(module, submodule_hook)
 
     base.register_module(name, module)
-
-    # (1): Since we cannot know which pointers are shared when we add parameters in an
-    # online way, assume that all pointers are shared. This comes at no runtime cost
 
 
 def delete_offload_module(base: torch.nn.Module, name: str):
@@ -589,3 +600,7 @@ def align_module_device(
 
     else:
         yield
+
+
+# (1): Since we cannot know which pointers are shared when we add parameters in an
+# online way, assume that all pointers are shared. This has virtually no runtime cost

--- a/tests/test_utils/test_offload.py
+++ b/tests/test_utils/test_offload.py
@@ -149,6 +149,48 @@ def test_register_offload_parameter():
 
 
 @requires_accelerate()
+@requires_gpu
+def test_register_offload_parameter_hook_replacement():
+    module = ExampleModule()
+    parameter_c = torch.nn.Parameter(torch.tensor(1.0, device="cuda"))
+    parameter_d = torch.nn.Parameter(torch.tensor(1.0, device="cpu"))
+
+    offloaded_dispatch(module, "cuda")
+    register_offload_parameter(module, "c", parameter_c)
+    register_offload_parameter(module, "d", parameter_d)
+
+    with disable_hf_hook(module):
+        assert module.a.device == torch.device("cpu")
+        assert module.b.device == torch.device("cpu")
+        assert module.c.device == torch.device("cuda:0")
+        assert module.d.device == torch.device("cpu")
+
+    assert module.a.device == torch.device("meta")
+    assert module.b.device == torch.device("meta")
+    assert module.c.device == torch.device("meta")
+    assert module.d.device == torch.device("meta")
+    assert module._hf_hook.weights_map["a"].device == torch.device("cpu")
+    assert module._hf_hook.weights_map["b"].device == torch.device("cpu")
+    assert module._hf_hook.weights_map["c"].device == torch.device("cpu")
+    assert module._hf_hook.weights_map["d"].device == torch.device("cpu")
+
+
+@requires_accelerate()
+@requires_gpu
+def test_register_offload_parameter_shared():
+    module = ExampleModule()
+    parameter = torch.nn.Parameter(torch.tensor(1.0))
+
+    offloaded_dispatch(module, "cuda")
+    register_offload_parameter(module, "c", parameter)
+    register_offload_parameter(module, "d", parameter)
+
+    with align_module_device(module):
+        breakpoint()
+        assert module.c is module.d
+
+
+@requires_accelerate()
 def test_update_offload_parameter():
     from accelerate.hooks import attach_align_device_hook
 

--- a/tests/test_utils/test_offload.py
+++ b/tests/test_utils/test_offload.py
@@ -186,7 +186,6 @@ def test_register_offload_parameter_shared():
     register_offload_parameter(module, "d", parameter)
 
     with align_module_device(module):
-        breakpoint()
         assert module.c is module.d
 
 


### PR DESCRIPTION
## Purpose ##
* Fix offloading bug reported by @logos-mhr  https://github.com/vllm-project/llm-compressor/pull/1263#issuecomment-2962012381

## Background ##
Accelerate's `AlignModuleDevices` hook has a `original_devices` attribute which it uses to track the device a parameter was on before it was offloaded. That way, when the hook is removed, the parameter can be placed back on the original device it started on.

This consideration was missing from the original `register_offload_parameter` implementation. This caused newly added parameters (qparams) to stay meta device when `disable_hf_hook` was called (during the quantization wrapper).

This wasn't a problem, since they'd be re-replaced on the correct device when the hook was reapplied, but this did mean that the hook recorded the original device as "meta", hence causing issues if hook was removed for the second time.

## Changes ##
* Append to `hook.original_devices` when registering a new parameter
* Append to `hook.tied_params_map` when registering a new parameter
  * This isn't currently used, since we don't share any memory between qparams, but is implemented and tested for completeness

## Testing ##
* Added tests for unplacing and placing newly added parameters
* Added tests for sharing memory between newly added parameters