### PR TITLE
[Bugfix] Fix saving of models dispatched by `offloaded_dispatch`

### DIFF
--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -499,8 +499,8 @@ def offloaded_dispatch(
     :param offload_device: device that module parameters will offload to
     :return: module with offloading device hooks
     """
-    if offload_device != torch.device("cpu"):
-        raise NotImplementedError("Only CPU offloading is supported")
+    if offload_device == "disk":
+        raise NotImplementedError("Disk offloading is not currently supported")
 
     # remove any existing hooks
     remove_hook_from_module(module, recurse=True)

--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -499,8 +499,8 @@ def offloaded_dispatch(
     :param offload_device: device that module parameters will offload to
     :return: module with offloading device hooks
     """
-    if offload_device == "disk":
-        raise NotImplementedError("Disk offloading is not currently supported")
+    if offload_device != torch.device("cpu"):
+        raise NotImplementedError("Only CPU offloading is supported")
 
     # create weights map
     state_dict = module.state_dict()

--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -503,7 +503,7 @@ def offloaded_dispatch(
         raise NotImplementedError("Disk offloading is not currently supported")
 
     # remove any existing hooks
-    remove_hook_from_module(module, recurse=True)
+    remove_dispatch(module)
 
     # create weights map
     state_dict = module.state_dict()
@@ -538,6 +538,20 @@ def offloaded_dispatch(
     # because this function always offloads, disregard actual devices and
     # always use `cpu` and `cuda:0` to guarantee this condition passes
     setattr(module, "hf_device_map", {"fake_offload": "cpu", "fake_exec": "cuda:0"})
+
+    return module
+
+
+def remove_dispatch(module: torch.nn.Module) -> torch.nn.Module:
+    """
+    Remove any existing dispatches from module
+
+    :param module: module which may be dispatched with hf hooks
+    :return: module without dispatch
+    """
+    remove_hook_from_module(module, recurse=True)
+    if hasattr(module, "hf_device_map"):
+        delattr(module, "hf_device_map")
 
     return module
 

--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -502,6 +502,9 @@ def offloaded_dispatch(
     if offload_device != torch.device("cpu"):
         raise NotImplementedError("Only CPU offloading is supported")
 
+    # remove any existing hooks
+    remove_hook_from_module(module, recurse=True)
+
     # create weights map
     state_dict = module.state_dict()
     state_dict = {key: val.to(offload_device) for key, val in state_dict.items()}

--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -85,6 +85,7 @@ __all__ = [
     "delete_offload_module",
     "offloaded_dispatch",
     "disable_offloading",
+    "remove_dispatch",
 ]
 
 

--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -535,11 +535,9 @@ def offloaded_dispatch(
     #     and ("cpu" in self.hf_device_map.values()
     #          or "disk" in self.hf_device_map.values())
     # ):
-    setattr(
-        module,
-        "hf_device_map",
-        {"offload_device": str(offload_device), "exec_device": str(execution_device)},
-    )
+    # because this function always offloads, disregard actual devices and
+    # always use `cpu` and `cuda:0` to guarantee this condition passes
+    setattr(module, "hf_device_map", {"fake_offload": "cpu", "fake_exec": "cuda:0"})
 
     return module
 

--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -523,6 +523,21 @@ def offloaded_dispatch(
         weights_map=weights_map,
         tied_params_map=tied_params_map,
     )
+
+    # when saving a model, `PretrainedModel.save_pretrained` will only
+    # onload weights if the following requirements are met
+    # if (
+    #     hasattr(self, "hf_device_map")
+    #     and len(set(self.hf_device_map.values())) > 1
+    #     and ("cpu" in self.hf_device_map.values()
+    #          or "disk" in self.hf_device_map.values())
+    # ):
+    setattr(
+        module,
+        "hf_device_map",
+        {"offload_device": str(offload_device), "exec_device": str(execution_device)},
+    )
+
     return module
 
 


### PR DESCRIPTION
## Purpose ##
* Fix saving models which have been dispatched by `offloaded_dispatch`
* Add util to remove hooks before dispatching in order to guarantee successful dispatch

## Background ##
Attempting to save a model which has been dispatched by `offloaded_dispatch` will fail because HF transformers will not onload weights for saving unless it detects a `device_map` attribute. See [here](https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py#L3619-L3623),  [here](https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py#L3685), and [here](https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py#L3814).

This change is mostly inconsequential for typical LLM Compressor examples, since offloading hooks are anyways removed before saving, but this change exists for completeness and foolproofing. We cannot use a real device map in this case, because the hf_device_map is set up such that at least one module must be onloaded in order for the model to be considered offloaded (so called "full offloading" is not possible. A device map of only cpu is treated as if the model executes on the cpu as well. This lack of functionality in hf `accelerate` is why the `offloaded_dispatch` function exists).

I've audited the `accelerate` and `transformers` libraries and haven't found any unintended consequences of creating a device map with fake module keys.

## Changes ##
* Remove any existing hooks before applying offloaded dispatch
* Add a fake `hf_device_map` attribute which guarantees that the model is treated as offloaded when saving
* Implement `remove_dispatch`

## Testing ##
```python3
from transformers import AutoModelForCausalLM
from compressed_tensors import offloaded_dispatch

model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-3.2-1B-instruct")
offloaded_dispatch(model, execution_device="cuda:0")
model.save_pretrained("tmp")
```