### PR TITLE
[Accelerate] Remove `align_modules`

### DIFF
--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -78,8 +78,6 @@ __all__ = [
     "delete_offload_parameter",
     "has_offloaded_params",
     "disable_hf_hook",
-    "disable_offload",
-    "align_modules",
     "align_module_device",
     "register_offload_module",
     "delete_offload_module",
@@ -383,45 +381,6 @@ def delete_from_weights_map(
             "Updating offload data not implemented for weights_map of type "
             f"{type(weights_map)}"
         )
-
-
-@check_accelerate(fallback=contextlib.nullcontext())
-@contextlib.contextmanager
-def disable_offload(module: torch.nn.Module):
-    """
-    Context manager to disable module onloading and offloading. Parameters will stay on
-    their current device
-
-    :param module: module to disable offloading for
-    """
-    if has_offloaded_params(module):
-        module._hf_hook.offload = False
-        yield
-        module._hf_hook.offload = True
-    else:
-        yield
-
-
-@check_accelerate(fallback=contextlib.nullcontext())
-@contextlib.contextmanager
-def align_modules(
-    modules: Union[torch.nn.Module, Iterable[torch.nn.Module]],
-    execution_device: Optional[torch.device] = None,
-):
-    """
-    Context manager for onloading modules to a device, and disabling onload and offload
-    attempts triggered by forward calls. Used for sequential onloading of layers
-
-    :param modules: `torch.nn.Module` or iterable of `torch.nn.Module`s to onload
-    :param execution_device: device to onload to
-    """
-    modules = (modules,) if isinstance(modules, torch.nn.Module) else modules
-
-    with contextlib.ExitStack() as stack:
-        for module in modules:
-            stack.enter_context(align_module_device(module, execution_device))
-            stack.enter_context(disable_offload(module))  # disable redundant onloading
-        yield
 
 
 def register_offload_module(base: torch.nn.Module, name: str, module: torch.nn.Module):

--- a/tests/test_utils/test_offload.py
+++ b/tests/test_utils/test_offload.py
@@ -15,7 +15,6 @@ import pytest
 import torch
 from compressed_tensors.utils import (
     align_module_device,
-    align_modules,
     delete_offload_module,
     delete_offload_parameter,
     disable_hf_hook,
@@ -296,35 +295,6 @@ def test_disable_hf_hook_model_recurse():
     assert hasattr(module0, "_hf_hook")
     assert hasattr(module1, "_hf_hook")
     assert hasattr(module2, "_hf_hook")
-
-
-@requires_accelerate()
-def test_align_modules():
-    from accelerate.hooks import attach_align_device_hook
-
-    module0 = ExampleModule()
-    module1 = ExampleModule()
-    module2 = ExampleModule()
-    model = torch.nn.Sequential(module0, torch.nn.Sequential(module1, module2))
-    attach_align_device_hook(
-        model,
-        execution_device=torch.device("cpu"),
-        offload=True,
-        weights_map=model.state_dict(),
-    )
-
-    assert module0.a.device == torch.device("meta")
-    assert module1.a.device == torch.device("meta")
-    assert module2.a.device == torch.device("meta")
-
-    with align_modules((module0, module1)):
-        assert module0.a.device != torch.device("meta")
-        assert module1.a.device != torch.device("meta")
-        assert module2.a.device == torch.device("meta")
-
-    assert module0.a.device == torch.device("meta")
-    assert module1.a.device == torch.device("meta")
-    assert module2.a.device == torch.device("meta")
 
 
 @requires_accelerate()


### PR DESCRIPTION
## Purpose ##
* Remove `align_modules` in favor of `disable_offloading`

## Prerequisites ##
* https://github.com/vllm-project/llm-compressor/pull/1554

## Changes ##
* Remove `align_modules`
* Remove `disable_offload` (only used by `align_modules`)