### PR TITLE
[Bugfix] Only update direct params in `disable_offloading`

### DIFF
--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -594,7 +594,7 @@ def disable_offloading():
     # update any parameters which may have changed
     for module, (hook, offload) in onloaded_modules.items():
         hook.offload = offload
-        for name, param in module.named_parameters():
+        for name, param in module.named_parameters(recurse=False):
             update_offload_parameter(module, name, param.data)
         hook.post_forward(module, None)
 


### PR DESCRIPTION
## Purpose ##
* Fix failure where some modules have their offloading disabled, but have parameters which are not direct parameters to the module

## Changes ##
* When updating parameters, only update directly parameters (not submodule parameters)