### PR TITLE
reference updated reportportal_submit_execution_results action

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -120,7 +120,7 @@ jobs:
               shell: bash
 
             - name: report to reportportal
-              uses: neuralmagic/nm-actions/actions/reportportal_submit_execution_results@dmk/use_action_path
+              uses: neuralmagic/nm-actions/actions/reportportal_submit_execution_results@v1.22.0
               with:
                 droute_username: ${{ secrets.DROUTE_USERNAME }}
                 droute_password: ${{ secrets.DROUTE_PASSWORD }}


### PR DESCRIPTION
the `nm-actions reportportal_submit_execution_results` action was updated to find the report portal template file in the specific location.  this fixes the REPORT job in nightly runs.