### PR TITLE
[Accelerate] Expand `get_execution_device` to support models

### DIFF
--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -181,7 +181,7 @@ def get_execution_device(module: torch.nn.Module) -> torch.device:
         if has_offloaded_params(module):
             return module._hf_hook.execution_device
 
-        param = next(module.parameters(), None)
+        param = next(module.parameters(recurse=False), None)
         if param is not None:
             return param.device
 

--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -186,7 +186,7 @@ def get_execution_device(module: torch.nn.Module) -> torch.device:
             return param.device
 
     warnings.warn(
-        f"Unable able to infer execution device of {module}, falling back to CPU"
+        f"Unable able to get execution device of {module}, falling back to CPU"
     )
     return torch.device("cpu")
 

--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -171,13 +171,8 @@ def update_parameter_data(
 
 def get_execution_device(module: torch.nn.Module) -> torch.device:
     """
-    Get the device which inputs should be moved to before module execution
-
-    If a model is offloaded, assume that modules execute in the same order
-    that they are returned by `model.modules()`
-
-    If a model is not offloaded, assume that parameters are used in the same order
-    that they are returned by `model.parameters()`
+    Get the device which inputs should be moved to before module execution.
+    Assume that modules execute in the same order as returned by `model.modules()`
 
     :param module: module to check, may be offloaded
     :return: onload device of module
@@ -186,14 +181,14 @@ def get_execution_device(module: torch.nn.Module) -> torch.device:
         if has_offloaded_params(module):
             return module._hf_hook.execution_device
 
-    first_param = next(module.parameters(), None)
-    if first_param is None:
-        warnings.warn(
-            f"Unable able to infer execution device of {module}, falling back to CPU"
-        )
-        return torch.device("cpu")
+        param = next(module.parameters(), None)
+        if param is not None:
+            return param.device
 
-    return first_param.device
+    warnings.warn(
+        f"Unable able to infer execution device of {module}, falling back to CPU"
+    )
+    return torch.device("cpu")
 
 
 def register_offload_parameter(

--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -173,11 +173,18 @@ def get_execution_device(module: torch.nn.Module) -> torch.device:
     """
     Get the device which inputs should be moved to before module execution
 
+    If a model is offloaded, assume that modules execute in the same order
+    that they are returned by `model.modules()`
+
+    If a model is not offloaded, assume that parameters are used in the same order
+    that they are returned by `model.parameters()`
+
     :param module: module to check, may be offloaded
     :return: onload device of module
     """
-    if has_offloaded_params(module):
-        return module._hf_hook.execution_device
+    for module in module.modules():
+        if has_offloaded_params(module):
+            return module._hf_hook.execution_device
 
     first_param = next(module.parameters(), None)
     if first_param is None:

--- a/tests/test_utils/test_offload.py
+++ b/tests/test_utils/test_offload.py
@@ -117,7 +117,7 @@ def test_get_execution_device_model():
     model = Model()
     assert get_execution_device(model) == torch.device("cpu")
 
-    attach_align_device_hook(model.a, torch.device("cuda:0"))
+    offloaded_dispatch(model.a, torch.device("cuda:0"))
     assert get_execution_device(model) == torch.device("cuda:0")
 
 

--- a/tests/test_utils/test_offload.py
+++ b/tests/test_utils/test_offload.py
@@ -102,9 +102,9 @@ def test_get_execution_device():
         assert get_execution_device(module) == torch.device("cuda:0")
 
 
+@requires_gpu
+@requires_accelerate()
 def test_get_execution_device_model():
-    from accelerate.hooks import attach_align_device_hook
-
     class Model(torch.nn.Module):
         def __init__(self):
             super().__init__()

--- a/tests/test_utils/test_offload.py
+++ b/tests/test_utils/test_offload.py
@@ -101,9 +101,23 @@ def test_get_execution_device():
     with init_empty_weights():
         assert get_execution_device(module) == torch.device("cuda:0")
 
-    # execution device of model
-    model = ExampleModel()
-    attach_align_device_hook(model, torch.device("cuda:0"))
+
+def test_get_execution_device_model():
+    from accelerate.hooks import attach_align_device_hook
+
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.a = torch.nn.Linear(1, 2)
+            self.b = torch.nn.Linear(2, 2, device="cuda:0")
+
+        def forward(self, x):
+            return self.b(self.a(x).to("cuda:0"))
+
+    model = Model()
+    assert get_execution_device(model) == torch.device("cpu")
+
+    attach_align_device_hook(model.a, torch.device("cuda:0"))
     assert get_execution_device(model) == torch.device("cuda:0")
 
 

--- a/tests/test_utils/test_offload.py
+++ b/tests/test_utils/test_offload.py
@@ -101,6 +101,11 @@ def test_get_execution_device():
     with init_empty_weights():
         assert get_execution_device(module) == torch.device("cuda:0")
 
+    # execution device of model
+    model = ExampleModel()
+    attach_align_device_hook(model, torch.device("cuda:0"))
+    assert get_execution_device(model) == torch.device("cuda:0")
+
 
 @requires_accelerate()
 def test_register_offload_parameter():


### PR DESCRIPTION
## Purpose ##
* Enable model device inference https://github.com/vllm-project/llm-compressor/pull/1572

## Changes ##
* When checking for offloading, check all submodules in the order that they're returned

## Testing ##
* Existing tests pass
* Added model tests pass
* Deepseek tests on LLM Compressor pass