### PR TITLE
Support DeepSeekV3-style block FP8 quantization

### DIFF
--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -243,6 +243,29 @@ FP8_DYNAMIC = dict(
     ),
 )
 
+# Block‐wise FP8 (deepseekv3-style quantization):
+# static 128x128 per‐block weights and 
+# dynamic per‐token‐group activations
+FP8_BLOCK = dict(
+    weights=QuantizationArgs(
+        num_bits=8,
+        type=QuantizationType.FLOAT,
+        strategy=QuantizationStrategy.BLOCK,
+        symmetric=True,
+        dynamic=False,
+        block_structure=[128, 128],
+    ),
+    input_activations=QuantizationArgs(
+        num_bits=8,
+        type=QuantizationType.FLOAT,
+        strategy=QuantizationStrategy.GROUP,
+        symmetric=True,
+        dynamic=True,
+        observer=None,
+        group_size=128,
+    ),
+)
+
 PRESET_SCHEMES = {
     # Unquantized (no-op)
     "UNQUANTIZED": UNQUANTIZED,
@@ -257,6 +280,7 @@ PRESET_SCHEMES = {
     # Float weight and activation schemes
     "FP8": FP8,
     "FP8_DYNAMIC": FP8_DYNAMIC,
+    "FP8_BLOCK": FP8_BLOCK,
     "NVFP4A16": NVFP4A16,
     "NVFP4": NVFP4,
 }

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -171,7 +171,7 @@ def compute_dynamic_scales_and_zp(
         reduce_dims = tuple(idx for idx in range(value.ndim) if idx not in dim)
     elif args.strategy == QuantizationStrategy.TENSOR:
         reduce_dims = None
-    elif args.strategy == QuantizationStrategy.TENSOR_GROUP:
+    elif args.strategy in (QuantizationStrategy.TENSOR_GROUP, QuantizationStrategy.GROUP):
         if len(value.shape) > 2:
             value = value.squeeze(0)
 
@@ -189,7 +189,12 @@ def compute_dynamic_scales_and_zp(
     else:
         raise ValueError(
             "Dynamic quantization is only supported for ",
-            f"{QuantizationStrategy.TOKEN, QuantizationStrategy.TENSOR, QuantizationStrategy.TENSOR_GROUP}",
+            f"{(
+                QuantizationStrategy.TOKEN,
+                QuantizationStrategy.TENSOR,
+                QuantizationStrategy.TENSOR_GROUP,
+                QuantizationStrategy.GROUP,
+            )}",
         )
 
     if not reduce_dims:

--- a/tests/test_examples/test_bitmask_compression_ipynb.py
+++ b/tests/test_examples/test_bitmask_compression_ipynb.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import nbformat
 import pytest
+nbformat = pytest.importorskip("nbformat")
 from nbconvert.preprocessors import ExecutePreprocessor
 
 

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -30,6 +30,10 @@ from compressed_tensors.quantization.quant_args import (
 )
 from compressed_tensors.quantization.quant_config import QuantizationStatus
 from torch.nn import Linear
+import math
+
+from compressed_tensors.quantization.lifecycle.forward import _process_quantization
+from compressed_tensors.quantization.utils.helpers import calculate_range
 
 
 def make_dummy_g_idx(columns: int, group_size: int) -> torch.Tensor:
@@ -203,3 +207,49 @@ def test_dequantize(num_bits, type, strategy, group_size, scale, zero_point, g_i
         dtype=None,
         g_idx=g_idx,
     )
+
+
+def test_process_quantization_block_static():
+    """
+    Static block quantization (QuantizationStrategy.BLOCK) should split a 2D tensor
+    into blocks, quantize each block, and reassemble without changing shape.
+    """
+    rows, cols = 8, 8
+    bh, bw = 2, 4
+    x = torch.randn(rows, cols)
+    args = QuantizationArgs(
+        num_bits=8,
+        type="float",
+        strategy=QuantizationStrategy.BLOCK,
+        symmetric=True,
+        dynamic=False,
+        block_structure=[bh, bw],
+    )
+    num_rb = math.ceil(rows / bh)
+    num_cb = math.ceil(cols / bw)
+    scale = torch.rand(num_rb, num_cb) + 0.1
+    zp = torch.zeros_like(scale)
+    q_min, q_max = calculate_range(args, x.device)
+    out = _process_quantization(
+        x=x,
+        scale=scale,
+        zero_point=zp,
+        args=args,
+        do_quantize=True,
+        do_dequantize=False,
+        dtype=None,
+        global_scale=None,
+    )
+    assert out.shape == x.shape
+    # full fake-quantize roundtrip
+    out2 = _process_quantization(
+        x=x,
+        scale=scale,
+        zero_point=zp,
+        args=args,
+        do_quantize=True,
+        do_dequantize=True,
+        dtype=None,
+        global_scale=None,
+    )
+    assert out2.shape == x.shape

--- a/tests/test_quantization/test_quant_args.py
+++ b/tests/test_quantization/test_quant_args.py
@@ -59,7 +59,7 @@ def test_block():
 
     block = QuantizationArgs(**kwargs)
     assert block.strategy == QuantizationStrategy.BLOCK
-    assert block.block_structure == kwargs["block_structure"]
+    assert block.block_structure == [2, 4]
 
 
 def test_infer_strategy():

--- a/tests/test_quantization/test_utils/test_helpers.py
+++ b/tests/test_quantization/test_utils/test_helpers.py
@@ -20,7 +20,7 @@ from compressed_tensors.quantization import (
     QuantizationArgs,
     QuantizationStrategy,
 )
-from compressed_tensors.quantization.utils import calculate_qparams, generate_gparam
+from compressed_tensors.quantization.utils import calculate_qparams, compute_dynamic_scales_and_zp, generate_gparam
 
 
 @pytest.mark.parametrize(
@@ -73,3 +73,25 @@ def test_fused_global_scales():
     assert max_tensor_value.item() == pytest.approx(
         FP4_E2M1_DATA.max * FP8_E4M3_DATA.max / global_scale, abs=0.001
     )
+
+@pytest.mark.parametrize(
+    "shape,group_size,exp_shape",
+    [
+        # Only batch size =1 is supported for dynamic GROUP quantization
+        ((1, 4, 8), 4, torch.Size([4, 2])),
+    ],
+)
+def test_compute_dynamic_scales_and_zp_group(shape, group_size, exp_shape):
+    """
+    Dynamic group quantization should reduce activations in groups, producing
+    scales and zero points of shape [batch, num_groups].
+    """
+    value = torch.randn(*shape)
+    args = QuantizationArgs(
+        strategy=QuantizationStrategy.GROUP,
+        group_size=group_size,
+        dynamic=True,
+    )
+    scale, zp = compute_dynamic_scales_and_zp(value, args, module=torch.nn.Module())
+    assert scale.shape == exp_shape
+    assert zp.shape == exp_shape


### PR DESCRIPTION
Quite a few things packed into one here, but the goal is to support the 128x128 weight and 1x128 input quantization adopted by deepseekv3 and qwen3 models. See examples: https://huggingface.co/deepseek-ai/DeepSeek-V3 and https://huggingface.co/Qwen/Qwen3-0.6B-FP8

* Added BLOCK static quantization paths for weight quantization.
* Added GROUP dynamic quantization paths for per-token-group input quantization. I feel like this is more understandable than the "1x128" block input quantization deepseek uses.
* I’ve updated all of the places where `block_structure` was previously treated as an `“NxM”` string so that it now uses a Python list of two integers (e.g. `[128, 128]`). I added a pydantic validator that can convert this automatically for old checkpoints that use the string.