### PR TITLE
Clean up disk space and restore ubuntu 22.04 runner

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -33,7 +33,9 @@ runs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf /usr/local/share/boost
-          sudo apt-get clean
+          if [ $(cat /etc/issue) =~ Ubuntu ]; then
+              sudo apt-get clean
+          fi
           df -h
       shell: bash
 

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -26,7 +26,7 @@ runs:
       run: |
           echo "cleaning up disk space..."
           find . -type f -name '*.whl' -exec rm -rf {} \;
-          rm -rf ~/.cache/pip
+          python -m pip cache purge
           sudo rm -rf /usr/local/.ghcup
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo rm -rf /usr/local/lib/android/sdk/ndk

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -26,6 +26,7 @@ runs:
       run: |
           echo "cleaning up wheel files..."
           find . -type f -name '*.whl' -exec rm -rf {} \;
+          rm -rf ~/.cache/pip
           sudo rm -rf /usr/local/.ghcup
           sudo rm -rf /opt/hostedtoolcache/CodeQL
           sudo rm -rf /usr/local/lib/android/sdk/ndk

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -26,6 +26,13 @@ runs:
       run: |
           echo "cleaning up wheel files..."
           find . -type f -name '*.whl' -exec rm -rf {} \;
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/lib/android/sdk/ndk
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo apt-get clean
           df -h
       shell: bash
 

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -33,7 +33,7 @@ runs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf /usr/local/share/boost
-          if [ $(cat /etc/issue) =~ Ubuntu ]; then
+          if [[ "$(cat /etc/issue)" =~ Ubuntu ]]; then
               sudo apt-get clean
           fi
           df -h

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -24,7 +24,7 @@ runs:
 
     - name: clean up
       run: |
-          echo "cleaning up wheel files..."
+          echo "cleaning up disk space..."
           find . -type f -name '*.whl' -exec rm -rf {} \;
           rm -rf ~/.cache/pip
           sudo rm -rf /usr/local/.ghcup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,6 @@ jobs:
                   whl: ${{ inputs.whl }}
                   test_status: ${{ steps.test.outputs.status }}
 
-
             - name: copy results to GCP
               run: |
                   gcloud storage cp test-results/report.xml ${{ secrets.GCP_BUILD_ML_ASSETS2 }}/${{ github.run_id }}/test-results/report-${{ inputs.test_label }}.xml

--- a/.github/workflows/trigger-all.yml
+++ b/.github/workflows/trigger-all.yml
@@ -33,7 +33,7 @@ jobs:
             gitref: ${{ inputs.gitref || 'main' }}
             push_to_pypi: ${{ (github.event.schedule == '30 0 * * *') || inputs.push_to_pypi || false }}
             test_configs: '[{"python":"3.11.4","label":"ubuntu-24.04","timeout":"40"},
-                            {"python":"3.10.12","label":"ubuntu-24.04","timeout":"40"},
+                            {"python":"3.10.12","label":"ubuntu-22.04","timeout":"40"},
                             {"python":"3.9.17","label":"k8s-h100-solo","timeout":"40"},
                             {"python":"3.12.6","label":"k8s-a100-duo","timeout":"40"}]'
 


### PR DESCRIPTION
The workaround to clean up disk space looks working and a successful run is here: https://github.com/neuralmagic/compressed-tensors/actions/runs/15982420861

The workaround is based on the proposal in this runner image repo issue: https://github.com/actions/runner-images/issues/10386.

These folders are relatively large size and unnecessary so it's safe to clean up.