### PR TITLE
bugfixes to `kylesayrs/transform_apply`

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -152,11 +152,7 @@ def apply_quantization_config(
     # list of submodules to ignore
     ignored_submodules = defaultdict(list)
     # mark appropriate layers for quantization by setting their quantization schemes
-    for name, submodule in iter_named_quantizable_modules(
-        model,
-        include_children=True,
-        include_attn=True,
-    ):  # child modules and attention modules
+    for name, submodule in model.named_modules():  # child modules and attention modules
         # potentially fix module name to remove FSDP wrapper prefix
         name = fix_fsdp_module_name(name)
         if matches := find_name_or_class_matches(name, submodule, config.ignore):

--- a/src/compressed_tensors/transform/factory/base.py
+++ b/src/compressed_tensors/transform/factory/base.py
@@ -99,10 +99,10 @@ class TransformFactory(RegistryMixin, ABC):
         # create transform as submodule
         transform_name = f"{self.name}_{args.location.value}"
         transform = self.create_transform(module, args)
-        register_offload_module(module, transform_name, transform)  # (1)
 
         # register input transformation hook
         if args.location == TransformLocation.INPUT:
+            register_offload_module(module, transform_name, transform)
 
             def input_hook(_, args):
                 input = args[0]
@@ -130,6 +130,7 @@ class TransformFactory(RegistryMixin, ABC):
 
         # register output transformation hook
         elif args.location == TransformLocation.OUTPUT:
+            register_offload_module(module, transform_name, transform)
 
             def output_hook(_, _input, output):
                 return transform(output)
@@ -139,9 +140,6 @@ class TransformFactory(RegistryMixin, ABC):
         # other locations such as q_attn and k_attn have not been implemented
         else:
             raise NotImplementedError()
-
-        # (1) even in the `weight` cases, this submodule attachment is needed in order
-        # to support saving in the frozen state
 
 
 class TransformBase(Module, ABC):


### PR DESCRIPTION
bugfixes to get this branch to work with [kylesayrs/transform-modifier](https://github.com/vllm-project/llm-compressor/tree/kylesayrs/transform-modifier).

Currently failing on load-up in vllm:

```
Loading safetensors checkpoint shards:   0% Completed | 0/14 [00:00<?, ?it/s]
ERROR 07-01 22:26:57 [core.py:515] EngineCore failed to start.
ERROR 07-01 22:26:57 [core.py:515] Traceback (most recent call last):
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 506, in run_engine_core
ERROR 07-01 22:26:57 [core.py:515]     engine_core = EngineCoreProc(*args, **kwargs)
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 390, in __init__
ERROR 07-01 22:26:57 [core.py:515]     super().__init__(vllm_config, executor_class, log_stats,
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/v1/engine/core.py", line 76, in __init__
ERROR 07-01 22:26:57 [core.py:515]     self.model_executor = executor_class(vllm_config)
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/executor/executor_base.py", line 53, in __init__
ERROR 07-01 22:26:57 [core.py:515]     self._init_executor()
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/executor/uniproc_executor.py", line 48, in _init_executor
ERROR 07-01 22:26:57 [core.py:515]     self.collective_rpc("load_model")
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/executor/uniproc_executor.py", line 57, in collective_rpc
ERROR 07-01 22:26:57 [core.py:515]     answer = run_method(self.driver_worker, method, args, kwargs)
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/utils.py", line 2671, in run_method
ERROR 07-01 22:26:57 [core.py:515]     return func(*args, **kwargs)
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/v1/worker/gpu_worker.py", line 180, in load_model
ERROR 07-01 22:26:57 [core.py:515]     self.model_runner.load_model()
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/v1/worker/gpu_model_runner.py", line 1601, in load_model
ERROR 07-01 22:26:57 [core.py:515]     self.model = model_loader.load_model(
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/model_executor/model_loader/base_loader.py", line 41, in load_model
ERROR 07-01 22:26:57 [core.py:515]     self.load_weights(model, model_config)
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/model_executor/model_loader/default_loader.py", line 269, in load_weights
ERROR 07-01 22:26:57 [core.py:515]     loaded_weights = model.load_weights(
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/model_executor/models/llama.py", line 601, in load_weights
ERROR 07-01 22:26:57 [core.py:515]     return loader.load_weights(
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/model_executor/models/utils.py", line 278, in load_weights
ERROR 07-01 22:26:57 [core.py:515]     autoloaded_weights = set(self._load_module("", self.module, weights))
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/model_executor/models/utils.py", line 236, in _load_module
ERROR 07-01 22:26:57 [core.py:515]     yield from self._load_module(prefix,
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/model_executor/models/utils.py", line 209, in _load_module
ERROR 07-01 22:26:57 [core.py:515]     loaded_params = module_load_weights(weights)
ERROR 07-01 22:26:57 [core.py:515]   File "/home/bdellabe/projects/.venv/lib/python3.10/site-packages/vllm/model_executor/models/llama.py", line 465, in load_weights
ERROR 07-01 22:26:57 [core.py:515]     param = params_dict[name]
ERROR 07-01 22:26:57 [core.py:515] KeyError: 'layers.14.mlp.down_proj.u_output.perm'
```