### PR TITLE
Deprecate `iter_named_leaf_modules` and `iter_named_quantizable_modules`

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -42,10 +42,7 @@ from compressed_tensors.quantization import (
     load_pretrained_quantization_parameters,
 )
 from compressed_tensors.quantization.lifecycle import expand_target_names
-from compressed_tensors.quantization.utils import (
-    is_module_quantized,
-    iter_named_leaf_modules,
-)
+from compressed_tensors.quantization.utils import is_module_quantized
 from compressed_tensors.utils import (
     align_module_device,
     delete_offload_parameter,
@@ -747,7 +744,7 @@ def map_module_to_scheme(model: Module) -> Dict[str, QuantizationScheme]:
     """
     return {
         fix_fsdp_module_name(name): module.quantization_scheme
-        for name, module in iter_named_leaf_modules(model)
+        for name, module in model.named_modules()
         if is_module_quantized(module)
     }
 

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -322,9 +322,9 @@ def find_name_or_class_matches(
         2. matches on regex patterns
         3. matches on module names
     """
-    from compressed_tensors import UntargetableModule
+    from compressed_tensors import InternalModule
 
-    if isinstance(module, UntargetableModule):
+    if isinstance(module, InternalModule):
         return []
 
     targets = sorted(targets, key=lambda x: ("re:" in x, x))

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -21,6 +21,7 @@ from typing import OrderedDict as OrderedDictType
 from typing import Set, Union
 
 import torch
+from compressed_tensors import InternalModule
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization.lifecycle.compressed import (
     compress_quantized_weights,
@@ -322,6 +323,9 @@ def find_name_or_class_matches(
         2. matches on regex patterns
         3. matches on module names
     """
+    if isinstance(module, InternalModule):
+        return []
+
     targets = sorted(targets, key=lambda x: ("re:" in x, x))
     if isinstance(targets, Iterable):
         matches = _find_matches(name, targets) + _find_matches(

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -322,9 +322,9 @@ def find_name_or_class_matches(
         2. matches on regex patterns
         3. matches on module names
     """
-    from compressed_tensors import InternalModule
+    from compressed_tensors import UntargetableModule
 
-    if isinstance(module, InternalModule):
+    if isinstance(module, UntargetableModule):
         return []
 
     targets = sorted(targets, key=lambda x: ("re:" in x, x))

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -21,7 +21,6 @@ from typing import OrderedDict as OrderedDictType
 from typing import Set, Union
 
 import torch
-from compressed_tensors import InternalModule
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization.lifecycle.compressed import (
     compress_quantized_weights,
@@ -323,6 +322,8 @@ def find_name_or_class_matches(
         2. matches on regex patterns
         3. matches on module names
     """
+    from compressed_tensors import InternalModule
+
     if isinstance(module, InternalModule):
         return []
 

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -38,8 +38,6 @@ from compressed_tensors.quantization.utils import (
     KV_CACHE_TARGETS,
     infer_quantization_status,
     is_kv_cache_quant_scheme,
-    iter_named_leaf_modules,
-    iter_named_quantizable_modules,
 )
 from compressed_tensors.utils.helpers import fix_fsdp_module_name, replace_module
 from compressed_tensors.utils.offload import update_parameter_data
@@ -87,7 +85,7 @@ def load_pretrained_quantization_parameters(
     model_path = get_safetensors_folder(model_name_or_path)
     mapping = get_quantization_parameter_to_path_mapping(model_path)
 
-    for name, submodule in iter_named_leaf_modules(model):
+    for name, submodule in model.named_modules():
         if not is_module_quantized(submodule):
             continue
         if submodule.quantization_scheme.input_activations is not None:
@@ -152,11 +150,7 @@ def apply_quantization_config(
     # list of submodules to ignore
     ignored_submodules = defaultdict(list)
     # mark appropriate layers for quantization by setting their quantization schemes
-    for name, submodule in iter_named_quantizable_modules(
-        model,
-        include_children=True,
-        include_attn=True,
-    ):  # child modules and attention modules
+    for name, submodule in model.named_modules():
         # potentially fix module name to remove FSDP wrapper prefix
         name = fix_fsdp_module_name(name)
         if matches := find_name_or_class_matches(name, submodule, config.ignore):
@@ -287,7 +281,7 @@ def expand_target_names(
     """
     return {
         name
-        for name, module in iter_named_leaf_modules(model)
+        for name, module in model.named_modules()
         if is_target(name, module, targets, ignore)
     }
 

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -22,9 +22,7 @@ from compressed_tensors.quantization.quant_scheme import (
     preset_name_to_scheme,
 )
 from compressed_tensors.quantization.utils import (
-    calculate_compression_ratio,
     is_module_quantized,
-    iter_named_quantizable_modules,
     module_type,
     parse_out_kv_cache_args,
 )
@@ -177,9 +175,7 @@ class QuantizationConfig(BaseModel):
         quantization_status = None
         ignore = {}
         quantization_type_names = set()
-        for name, submodule in iter_named_quantizable_modules(
-            model, include_children=True, include_attn=True
-        ):
+        for name, submodule in model.named_modules():
             layer_type = module_type(submodule)
             if not is_module_quantized(submodule):
                 if layer_type not in ignore:

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -292,7 +292,7 @@ def module_type(module: Module) -> str:
 @deprecated(
     message="This function will be removed in a future release. "
     "Please use `model.named_modules()` and filter by "
-    "compressed_tensors.UntargetableModule if neceessary"
+    "compressed_tensors.InternalModule if neceessary"
 )
 def iter_named_leaf_modules(model: Module) -> Generator[Tuple[str, Module], None, None]:
     """
@@ -323,7 +323,7 @@ def iter_named_leaf_modules(model: Module) -> Generator[Tuple[str, Module], None
 @deprecated(
     message="This function will be removed in a future release. "
     "Please use `model.named_modules()` and filter by "
-    "compressed_tensors.UntargetableModule if neceessary"
+    "compressed_tensors.InternalModule if neceessary"
 )
 def iter_named_quantizable_modules(
     model: Module,

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -292,7 +292,7 @@ def module_type(module: Module) -> str:
 @deprecated(
     message="This function will be removed in a future release. "
     "Please use `model.named_modules()` and filter by "
-    "compressed_tensors.InternalModule if neceessary"
+    "compressed_tensors.UntargetableModule if neceessary"
 )
 def iter_named_leaf_modules(model: Module) -> Generator[Tuple[str, Module], None, None]:
     """
@@ -323,7 +323,7 @@ def iter_named_leaf_modules(model: Module) -> Generator[Tuple[str, Module], None
 @deprecated(
     message="This function will be removed in a future release. "
     "Please use `model.named_modules()` and filter by "
-    "compressed_tensors.InternalModule if neceessary"
+    "compressed_tensors.UntargetableModule if neceessary"
 )
 def iter_named_quantizable_modules(
     model: Module,

--- a/src/compressed_tensors/transform/factory/base.py
+++ b/src/compressed_tensors/transform/factory/base.py
@@ -17,7 +17,7 @@ from typing import Optional
 
 import torch
 import torch.nn.utils.parametrize as P
-from compressed_tensors import InternalModule
+from compressed_tensors import UntargetableModule
 from compressed_tensors.quantization.lifecycle import is_target  # TODO: move to utils
 from compressed_tensors.registry.registry import RegistryMixin, T
 from compressed_tensors.transform import (
@@ -145,7 +145,7 @@ class TransformFactory(RegistryMixin, ABC):
         # to support saving in the frozen state
 
 
-class TransformBase(InternalModule, ABC):
+class TransformBase(UntargetableModule, ABC):
     """
     Represents the application of a transform accord to TransformArgs
     """

--- a/src/compressed_tensors/transform/factory/base.py
+++ b/src/compressed_tensors/transform/factory/base.py
@@ -17,7 +17,7 @@ from typing import Optional
 
 import torch
 import torch.nn.utils.parametrize as P
-from compressed_tensors import UntargetableModule
+from compressed_tensors import InternalModule
 from compressed_tensors.quantization.lifecycle import is_target  # TODO: move to utils
 from compressed_tensors.registry.registry import RegistryMixin, T
 from compressed_tensors.transform import (
@@ -145,7 +145,7 @@ class TransformFactory(RegistryMixin, ABC):
         # to support saving in the frozen state
 
 
-class TransformBase(UntargetableModule, ABC):
+class TransformBase(InternalModule, ABC):
     """
     Represents the application of a transform accord to TransformArgs
     """

--- a/src/compressed_tensors/transform/factory/base.py
+++ b/src/compressed_tensors/transform/factory/base.py
@@ -17,6 +17,7 @@ from typing import Optional
 
 import torch
 import torch.nn.utils.parametrize as P
+from compressed_tensors import InternalModule
 from compressed_tensors.quantization.lifecycle import is_target  # TODO: move to utils
 from compressed_tensors.registry.registry import RegistryMixin, T
 from compressed_tensors.transform import (
@@ -144,7 +145,7 @@ class TransformFactory(RegistryMixin, ABC):
         # to support saving in the frozen state
 
 
-class TransformBase(Module, ABC):
+class TransformBase(InternalModule, ABC):
     """
     Represents the application of a transform accord to TransformArgs
     """

--- a/src/compressed_tensors/utils/__init__.py
+++ b/src/compressed_tensors/utils/__init__.py
@@ -14,9 +14,9 @@
 # flake8: noqa
 
 from .helpers import *
-from .internal import *
 from .offload import *
 from .permutations_24 import *
 from .permute import *
 from .safetensors_load import *
 from .semi_structured_conversions import *
+from .untargetable import *

--- a/src/compressed_tensors/utils/__init__.py
+++ b/src/compressed_tensors/utils/__init__.py
@@ -14,9 +14,9 @@
 # flake8: noqa
 
 from .helpers import *
+from .internal import *
 from .offload import *
 from .permutations_24 import *
 from .permute import *
 from .safetensors_load import *
 from .semi_structured_conversions import *
-from .untargetable import *

--- a/src/compressed_tensors/utils/internal.py
+++ b/src/compressed_tensors/utils/internal.py
@@ -22,5 +22,8 @@ class InternalModule(torch.nn.Module):
     """
     Abstract base class for modules which are not a part of the the model definition.
     `torch.nn.Module`s which inherit from this class will not be targeted by configs
+
+    This is typically used to skip apply configs to `Observers` and `Transforms`
     """
+
     pass

--- a/src/compressed_tensors/utils/internal.py
+++ b/src/compressed_tensors/utils/internal.py
@@ -15,10 +15,10 @@
 import torch
 
 
-__all__ = ["UntargetableModule"]
+__all__ = ["InternalModule"]
 
 
-class UntargetableModule(torch.nn.Module):
+class InternalModule(torch.nn.Module):
     """
     Abstract base class for modules which are not a part of the the model definition.
     `torch.nn.Module`s which inherit from this class will not be targeted by configs

--- a/src/compressed_tensors/utils/internal.py
+++ b/src/compressed_tensors/utils/internal.py
@@ -11,12 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# flake8: noqa
 
-from .helpers import *
-from .internal import *
-from .offload import *
-from .permutations_24 import *
-from .permute import *
-from .safetensors_load import *
-from .semi_structured_conversions import *
+import torch
+
+
+__all__ = ["InternalModule"]
+
+
+class InternalModule(torch.nn.Module):
+    """
+    Abstract base class for modules which are not a part of the the model definition.
+    `torch.nn.Module`s which inherit from this class will not be targeted by configs
+    """
+    pass

--- a/src/compressed_tensors/utils/untargetable.py
+++ b/src/compressed_tensors/utils/untargetable.py
@@ -15,10 +15,10 @@
 import torch
 
 
-__all__ = ["InternalModule"]
+__all__ = ["UntargetableModule"]
 
 
-class InternalModule(torch.nn.Module):
+class UntargetableModule(torch.nn.Module):
     """
     Abstract base class for modules which are not a part of the the model definition.
     `torch.nn.Module`s which inherit from this class will not be targeted by configs

--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -31,7 +31,6 @@ from compressed_tensors.quantization.lifecycle import (
     expand_target_names,
     is_target,
 )
-from compressed_tensors.quantization.utils import iter_named_leaf_modules
 from tests.testing_utils import requires_accelerate
 from transformers import AutoModelForCausalLM
 
@@ -98,7 +97,7 @@ def test_target_prioritization(mock_frozen):
     apply_quantization_config(model, config)
     mock_frozen(model)
 
-    for name, module in iter_named_leaf_modules(model):
+    for name, module in model.named_modules():
         if name == "model.layers.0.mlp.down_proj":
             assert module.quantization_scheme.weights.num_bits == 2
         elif re.match(".*down_proj", name):


### PR DESCRIPTION
## Purpose ##
* Refactor module targeting to be cleaner and easier to maintain
* Support skipping `TransformBase` modules

## Prerequisites ##
* https://github.com/vllm-project/llm-compressor/pull/1628

## Changes ##
* Deprecated `iter_named_leaf_modules` and `iter_named_quantizable_modules`
  * These functions are near copies of each other
  * These functions don't actually have any runtime savings over simple `model.modules()`. Infact, they're likely significantly slower
  * These functions hard code against "observer" module names and are difficult to extend to other modules like Transforms
* Add `UntargetableModule` class
```python3
class UntargetableModule(torch.nn.Module):
    """
    Abstract base class for modules which are not a part of the the model definition.
    `torch.nn.Module`s which inherit from this class will not be targeted by configs
    This is typically used to skip apply configs to `Observers` and `Transforms`
    """

    pass
```
  * `Observer` and `TransformBase` inherit from this class

## TODO ##
* Add skip in transforms apply

## Testing ##
* https://github.com/neuralmagic/llm-compressor-testing/actions/runs/16123598340 ✅