### PR TITLE
enable code coverage collection and reporting INFERENG-1049

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -7,6 +7,10 @@ inputs:
   suitename:
     description: "test suite name"
     required: true
+  code_coverage:
+    description: whether to collect code coverage metrics during test run
+    type: boolean
+    default: false
 outputs:
   status:
     description: "final status from test"
@@ -44,9 +48,35 @@ runs:
       run: |
           source ${{ inputs.venv }}/bin/activate
           rm -rf src
+
+          if [[ "{$ENABLE_COVERAGE}" == "true" ]]; then
+            echo "::group::Installing code coverage requirements via pip"
+            uv pip install bashlex https://github.com/neuralmagic/pytest-nm-releng/archive/v0.4.0.tar.gz
+            uv pip install coverage pytest-cov
+
+            # Adding Code coverage to the tests
+            nmre-generate-coverage-flags --package "vllm" --output-file ".coverage_flags.sh"
+            source .coverage_flags.sh
+            echo "::endgroup::"
+          fi
+
+          echo "::group::running tests"
           SUCCESS=0
           pytest tests --junitxml=test-results/report.xml -o junit_suite_name="${{ inputs.suitename }}" || SUCCESS=$?
           echo "status=${SUCCESS}" >> "$GITHUB_OUTPUT"
+          echo "::endgroup::"
+
+          if [[ $ENABLE_COVERAGE ]]; then
+            echo "::group::consolidating coverage reports"
+            mkdir -p coverage-results
+            mv tests/.coverage coverage-results/ || echo ".coverage file not found"
+            mv tests/coverage-html coverage-results/ || echo "coverage-html folder not found"
+            mv tests/coverage.json coverage-results/ || echo "coverage.json file not found"
+            echo "::endgroup::"
+          fi
+          
           deactivate
           exit ${SUCCESS}
       shell: bash
+      env:
+        ENABLE_COVERAGE: ${{ inputs.code_coverage || false }}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -62,6 +62,8 @@ runs:
 
           echo "::group::running tests"
           echo "PYTEST_ADDOPTS set to: ${PYTEST_ADDOPTS}"
+          echo "pwd: $(pwd)"
+
           SUCCESS=0
           pytest tests --junitxml=test-results/report.xml -o junit_suite_name="${{ inputs.suitename }}" || SUCCESS=$?
           echo "status=${SUCCESS}" >> "$GITHUB_OUTPUT"
@@ -69,6 +71,7 @@ runs:
 
           if [[ "${ENABLE_COVERAGE}" == "true" ]]; then
             echo "::group::consolidating coverage reports"
+            echo "$(find . -name '*cover*'\;)"
             mkdir -p coverage-results
             mv tests/.coverage coverage-results/ || echo ".coverage file not found"
             mv tests/coverage-html coverage-results/ || echo "coverage-html folder not found"

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -71,7 +71,7 @@ runs:
 
           if [[ "${ENABLE_COVERAGE}" == "true" ]]; then
             echo "::group::consolidating coverage reports"
-            echo "$(find . -name '*cover*'\;)"
+            echo "cover files: $(find .. -iname 'cover*')"
             mkdir -p coverage-results
             mv tests/.coverage coverage-results/ || echo ".coverage file not found"
             mv tests/coverage-html coverage-results/ || echo "coverage-html folder not found"

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -55,7 +55,7 @@ runs:
             pip install coverage pytest-cov
 
             # Adding Code coverage to the tests
-            nmre-generate-coverage-flags --package "compressed-tensors" --output-file ".coverage_flags.sh"
+            nmre-generate-coverage-flags --package "compressed_tensors" --output-file ".coverage_flags.sh"
             source .coverage_flags.sh
             echo "::endgroup::"
           fi

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -62,7 +62,6 @@ runs:
 
           echo "::group::running tests"
           echo "PYTEST_ADDOPTS set to: ${PYTEST_ADDOPTS}"
-          echo "pwd: $(pwd)"
 
           SUCCESS=0
           pytest tests --junitxml=test-results/report.xml -o junit_suite_name="${{ inputs.suitename }}" || SUCCESS=$?
@@ -71,11 +70,10 @@ runs:
 
           if [[ "${ENABLE_COVERAGE}" == "true" ]]; then
             echo "::group::consolidating coverage reports"
-            echo "cover files: $(find .. -iname 'cover*')"
             mkdir -p coverage-results
-            mv tests/.coverage coverage-results/ || echo ".coverage file not found"
-            mv tests/coverage-html coverage-results/ || echo "coverage-html folder not found"
-            mv tests/coverage.json coverage-results/ || echo "coverage.json file not found"
+            mv .coverage coverage-results/ || echo ".coverage file not found"
+            mv coverage-html coverage-results/ || echo "coverage-html folder not found"
+            mv coverage.json coverage-results/ || echo "coverage.json file not found"
             echo "::endgroup::"
           fi
           

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -55,7 +55,7 @@ runs:
             pip install coverage pytest-cov
 
             # Adding Code coverage to the tests
-            nmre-generate-coverage-flags --package "vllm" --output-file ".coverage_flags.sh"
+            nmre-generate-coverage-flags --package "compressed-tensors" --output-file ".coverage_flags.sh"
             source .coverage_flags.sh
             echo "::endgroup::"
           fi

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -48,11 +48,11 @@ runs:
       run: |
           source ${{ inputs.venv }}/bin/activate
           rm -rf src
-          echo "ENABLE_COVERAGE: ${ENABLE_COVERAGE}"
+
           if [[ "${ENABLE_COVERAGE}" == "true" ]]; then
             echo "::group::Installing code coverage requirements via pip"
-            uv pip install bashlex https://github.com/neuralmagic/pytest-nm-releng/archive/v0.4.0.tar.gz
-            uv pip install coverage pytest-cov
+            pip install bashlex https://github.com/neuralmagic/pytest-nm-releng/archive/v0.4.0.tar.gz
+            pip install coverage pytest-cov
 
             # Adding Code coverage to the tests
             nmre-generate-coverage-flags --package "vllm" --output-file ".coverage_flags.sh"

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -48,8 +48,8 @@ runs:
       run: |
           source ${{ inputs.venv }}/bin/activate
           rm -rf src
-
-          if [[ "{$ENABLE_COVERAGE}" == "true" ]]; then
+          echo "ENABLE_COVERAGE: ${ENABLE_COVERAGE}"
+          if [[ "${ENABLE_COVERAGE}" == "true" ]]; then
             echo "::group::Installing code coverage requirements via pip"
             uv pip install bashlex https://github.com/neuralmagic/pytest-nm-releng/archive/v0.4.0.tar.gz
             uv pip install coverage pytest-cov
@@ -66,7 +66,7 @@ runs:
           echo "status=${SUCCESS}" >> "$GITHUB_OUTPUT"
           echo "::endgroup::"
 
-          if [[ $ENABLE_COVERAGE ]]; then
+          if [[ "${ENABLE_COVERAGE}" == "true" ]]; then
             echo "::group::consolidating coverage reports"
             mkdir -p coverage-results
             mv tests/.coverage coverage-results/ || echo ".coverage file not found"

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -61,6 +61,7 @@ runs:
           fi
 
           echo "::group::running tests"
+          echo "PYTEST_ADDOPTS set to: ${PYTEST_ADDOPTS}"
           SUCCESS=0
           pytest tests --junitxml=test-results/report.xml -o junit_suite_name="${{ inputs.suitename }}" || SUCCESS=$?
           echo "status=${SUCCESS}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,3 +155,11 @@ jobs:
                   name: report-${{ inputs.test_label }}.xml
                   path: test-results/report.xml
                   retention-days: 5
+
+            - name: upload coverage report
+              uses: actions/upload-artifact@v4
+              if: (success() || failure()) && inputs.code_coverage
+              with:
+                  name: coverage-results
+                  path: coverage-results/*
+                  retention-days: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,10 @@ on:
       run_id:
         description: run id of the BUILD job that generated the assets
         type: string
+      code_coverage:
+        description: whether to collect code coverage metrics during test run
+        type: boolean
+        default: false
 
   # makes workflow manually callable
   workflow_dispatch:
@@ -51,6 +55,10 @@ on:
       run_id:
         description: run id of the BUILD job that generated the assets
         type: string
+      code_coverage:
+        description: whether to collect code coverage metrics during test run
+        type: boolean
+        default: false
 
 jobs:
 
@@ -124,6 +132,7 @@ jobs:
               with:
                   venv: ${{ steps.create_venv.outputs.penv }}
                   suitename: test-${{ inputs.python }}-${{ inputs.test_label }}
+                  code_coverage: ${{ inputs.code_coverage }}
 
             - name: summary
               uses: neuralmagic/nm-actions/actions/summary-test@v1.13.0


### PR DESCRIPTION
These code changes allow the `test` action to toggle on collection of code coverage metrics while pytest is running.  This uses the `pytest-cov` package to collect and report the metrics.
metrics are consolidated in a compressed artifact attached to the `test` action.
metrics are reported as both a .json file and .html files.

Run of the `test` action w/ no code coverage requested, to demonstrate default behavior matches the existing behavior: https://github.com/neuralmagic/compressed-tensors/actions/runs/16126116474
Run of the `test` action w/ code coverage requested has the collected results available as an artifact at the bottom of the summary:
https://github.com/neuralmagic/compressed-tensors/actions/runs/16010001155


