### PR TITLE
[Compression] Fix compression device movement in cases of indexed devices

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -392,8 +392,8 @@ class ModelCompressor:
         for prefix, module in tqdm(model.named_modules(), desc="Compressing model"):
 
             if prefix in module_to_scheme or prefix in sparse_compression_targets:
-                module_device = get_execution_device(module).type
-                is_meta = (module_device == "meta")
+                module_device = get_execution_device(module)
+                is_meta = module_device.type == "meta"
 
                 exec_device = "meta" if is_meta else "cpu"
                 onloading_device = "meta" if is_meta else module_device

--- a/src/compressed_tensors/compressors/sparse_compressors/sparse_24_bitmask.py
+++ b/src/compressed_tensors/compressors/sparse_compressors/sparse_24_bitmask.py
@@ -178,9 +178,13 @@ def sparse24_bitmask_compress(
 
     if tensor.is_meta:
         num_rows, num_cols = tensor.shape
-        compressed_values = torch.empty((num_rows, num_cols // 2), dtype=tensor.dtype, device="meta")
+        compressed_values = torch.empty(
+            (num_rows, num_cols // 2), dtype=tensor.dtype, device="meta"
+        )
         packed_cols = (num_cols + 7) // 8
-        bitmasks_packed = torch.empty((num_rows, packed_cols), dtype=torch.uint8, device="meta")
+        bitmasks_packed = torch.empty(
+            (num_rows, packed_cols), dtype=torch.uint8, device="meta"
+        )
         return compressed_values, bitmasks_packed
 
     bytemasks = get_24_bytemasks(tensor=tensor)

--- a/tests/test_compressors/model_compressors/test_model_compressor.py
+++ b/tests/test_compressors/model_compressors/test_model_compressor.py
@@ -446,10 +446,7 @@ def test_compress_model_meta(model_stub, q_format, s_config):
         cpu_model, s_config, q_format
     )
     # Only stores dtype because meta model does not store values
-    expected = {
-        k: v.dtype
-        for k, v in reference_compressor.compress(cpu_model).items()
-    }
+    expected = {k: v.dtype for k, v in reference_compressor.compress(cpu_model).items()}
 
     # Load model on meta device
     meta_model = AutoModelForCausalLM.from_pretrained(


### PR DESCRIPTION
## Purpose ##
* Fix model device movement if the model is deployed to multiple GPUs

## Background ##
Getting the `type` attribute of a `torch.device` strips away the index of the device (for example, both `cuda:0` and `cuda:1` become `cuda`). This means that when the module parameters are placed back on their original `onloading_device`s, they'll all be move to `cuda:0`, even if they started on a different device. This could lead to memory issues for larger models