### PR TITLE
[Bugfix] Only quant-compress modules with weight quantization

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -747,12 +747,16 @@ class ModelCompressor:
 
 def map_module_to_scheme(model: Module) -> Dict[str, QuantizationScheme]:
     """
-    Returns a dictionary which maps quantized module names to their quantization schemes
+    Returns a dictionary which maps quantized module names to their quantization
+    schemes. Only includes modules with weight quantization
     """
     return {
         fix_fsdp_module_name(name): module.quantization_scheme
         for name, module in model.named_modules()
-        if is_module_quantized(module)
+        if (
+            hasattr(module, "quantization_scheme") and
+            module.quantization_scheme.weights is not None
+        )
     }
 
 


### PR DESCRIPTION
## Purpose ##
* Skip compression for attention modules, which have a quantization config but do not have weights to quantize
  * Without these changes, attention modules will be compressed. This is not a problem in itself (since they have no weights, they are no opped), but https://github.com/neuralmagic/compressed-tensors/pull/347 fixes a bug which occurs when non-leaf modules are attempted to be compressed

## Changes ##
* `map_module_to_scheme` used to only quantize compress leaf modules. Now, this method only quantize compresses modules with weight quantization

## Testing ##
* KV cache tests pass with https://github.com/vllm-project/llm-compressor/pull/1635