### PR TITLE
Enable code coverage report for nightly tests

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -69,11 +69,11 @@ runs:
           echo "::endgroup::"
 
           if [[ "${ENABLE_COVERAGE}" == "true" ]]; then
-            echo "::group::consolidating coverage reports"
-            mkdir -p coverage-results
-            mv .coverage coverage-results/ || echo ".coverage file not found"
-            mv coverage-html coverage-results/ || echo "coverage-html folder not found"
-            mv coverage.json coverage-results/ || echo "coverage.json file not found"
+            echo "::group::check coverage reports"
+            if [ ! -d coverage-html ]; then
+                echo "ERROR: coverage-html folder not found"
+                exit 1
+            fi
             echo "::endgroup::"
           fi
           

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -53,7 +53,7 @@ jobs:
             python: ${{ matrix.test_config.python }}
             timeout: ${{ matrix.test_config.timeout }}
             whl: ${{ needs.BUILD.outputs.whl }}
-            code_coverage: ${{ matrix.test_config.code_coverage || 'false' }}
+            code_coverage: ${{ matrix.test_config.code_coverage || false }}
         secrets: inherit
 
     UPLOAD:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -53,6 +53,7 @@ jobs:
             python: ${{ matrix.test_config.python }}
             timeout: ${{ matrix.test_config.timeout }}
             whl: ${{ needs.BUILD.outputs.whl }}
+            code_coverage: ${{ matrix.test_config.code_coverage || false }}
         secrets: inherit
 
     UPLOAD:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,7 +25,7 @@ on:
 
       # test related parameters
       test_configs:
-        description: "python, label, timeout"
+        description: "python, label, timeout, etc"
         type: string
         required: true
 
@@ -53,7 +53,7 @@ jobs:
             python: ${{ matrix.test_config.python }}
             timeout: ${{ matrix.test_config.timeout }}
             whl: ${{ needs.BUILD.outputs.whl }}
-            code_coverage: ${{ matrix.test_config.code_coverage || false }}
+            code_coverage: ${{ matrix.test_config.code_coverage || 'false' }}
         secrets: inherit
 
     UPLOAD:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
 
             - name: upload coverage report
               uses: actions/upload-artifact@v4
-              if: (success() || failure()) && inputs.code_coverage
+              if: (success() || failure()) && ${{ inputs.code_coverage == 'true' }}
               with:
                   name: coverage-results
                   path: coverage-results/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,8 +70,6 @@ jobs:
         permissions:
             contents: 'read'
             id-token: 'write'
-        environment:
-            coverage_url: ${{ steps.coverage.outputs.page_url }}
 
         steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,6 +138,11 @@ jobs:
                   suitename: test-${{ inputs.python }}-${{ inputs.test_label }}
                   code_coverage: ${{ inputs.code_coverage }}
 
+            - name: extra info for summary
+              if: ${{ inputs.code_coverage }}
+              run: |
+                  echo "EXTRA='Code Coverage: https://neuralmagic.github.io/compressed-tensors/'" >> $GITHUB_ENV
+
             - name: summary
               uses: neuralmagic/nm-actions/actions/summary-test@v1.13.0
               if: success() || failure()
@@ -147,6 +152,7 @@ jobs:
                   python: ${{ inputs.python }}
                   whl: ${{ inputs.whl }}
                   test_status: ${{ steps.test.outputs.status }}
+                  extra: ${{ env.EXTRA }}
 
             - name: copy results to GCP
               run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,7 @@ jobs:
         permissions:
             contents: 'read'
             id-token: 'write'
+            pages: 'write'
         environment:
             name: github-pages
             url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,9 +162,9 @@ jobs:
 
             - name: upload coverage report
               uses: actions/upload-pages-artifact@v3
-              if: (success() || failure()) && ${{ inputs.code_coverage }}
+              if: ${{ inputs.code_coverage }}
               with:
-                  path: coverage-results
+                  path: coverage-html
                   retention-days: 5
 
             - name: deploy to Github Pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,9 @@ jobs:
         permissions:
             contents: 'read'
             id-token: 'write'
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
 
         steps:
 
@@ -158,7 +161,7 @@ jobs:
 
             - name: upload coverage report
               uses: actions/upload-pages-artifact@v3
-              if: (success() || failure()) && ${{ inputs.code_coverage == 'true' }}
+              if: (success() || failure()) && ${{ inputs.code_coverage }}
               with:
                   path: coverage-results
                   retention-days: 5
@@ -166,4 +169,4 @@ jobs:
             - name: deploy to Github Pages
               id: coverage
               uses: actions/deploy-pages@v4
-              if: ${{ inputs.code_coverage == 'true' }}
+              if: ${{ inputs.code_coverage }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
             pages: 'write'
         environment:
             name: github-pages
-            url: ${{ steps.deployment.outputs.page_url }}
+            url: ${{ steps.coverage.outputs.page_url }}
 
         steps:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,8 @@ jobs:
         permissions:
             contents: 'read'
             id-token: 'write'
+        environment:
+            coverage_url: ${{ steps.coverage.outputs.page_url }}
 
         steps:
 
@@ -157,9 +159,13 @@ jobs:
                   retention-days: 5
 
             - name: upload coverage report
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-pages-artifact@v3
               if: (success() || failure()) && ${{ inputs.code_coverage == 'true' }}
               with:
-                  name: coverage-results
-                  path: coverage-results/*
+                  path: coverage-results
                   retention-days: 5
+
+            - name: deploy to Github Pages
+              id: coverage
+              uses: actions/deploy-pages@v4
+              if: ${{ inputs.code_coverage == 'true' }}

--- a/.github/workflows/trigger-all.yml
+++ b/.github/workflows/trigger-all.yml
@@ -35,6 +35,6 @@ jobs:
             test_configs: '[{"python":"3.11.4","label":"ubuntu-24.04","timeout":"40"},
                             {"python":"3.10.12","label":"ubuntu-22.04","timeout":"40"},
                             {"python":"3.9.17","label":"k8s-h100-solo","timeout":"40"},
-                            {"python":"3.12.6","label":"k8s-a100-duo","timeout":"40","code_coverage":"true"}]'
+                            {"python":"3.12.6","label":"k8s-a100-duo","timeout":"40","code_coverage":true}]'
 
         secrets: inherit

--- a/.github/workflows/trigger-all.yml
+++ b/.github/workflows/trigger-all.yml
@@ -35,6 +35,6 @@ jobs:
             test_configs: '[{"python":"3.11.4","label":"ubuntu-24.04","timeout":"40"},
                             {"python":"3.10.12","label":"ubuntu-22.04","timeout":"40"},
                             {"python":"3.9.17","label":"k8s-h100-solo","timeout":"40"},
-                            {"python":"3.12.6","label":"k8s-a100-duo","timeout":"40"}]'
+                            {"python":"3.12.6","label":"k8s-a100-duo","timeout":"40","code_coverage":"true"}]'
 
         secrets: inherit

--- a/.github/workflows/trigger-all.yml
+++ b/.github/workflows/trigger-all.yml
@@ -32,9 +32,9 @@ jobs:
             wf_category: ${{ inputs.wf_category || 'NIGHTLY' }}
             gitref: ${{ inputs.gitref || 'main' }}
             push_to_pypi: ${{ (github.event.schedule == '30 0 * * *') || inputs.push_to_pypi || false }}
-            test_configs: '[{"python":"3.11.4","label":"ubuntu-24.04","timeout":"40"},
+            test_configs: '[{"python":"3.11.4","label":"ubuntu-24.04","timeout":"40","code_coverage":true},
                             {"python":"3.10.12","label":"ubuntu-22.04","timeout":"40"},
                             {"python":"3.9.17","label":"k8s-h100-solo","timeout":"40"},
-                            {"python":"3.12.6","label":"k8s-a100-duo","timeout":"40","code_coverage":true}]'
+                            {"python":"3.12.6","label":"k8s-a100-duo","timeout":"40"}]'
 
         secrets: inherit


### PR DESCRIPTION
Code coverage is enabled for one of the nightly test jobs. Reporting will be available at the repo's GH pages here: https://neuralmagic.github.io/compressed-tensors/

A successful run from this PR is here: https://github.com/neuralmagic/compressed-tensors/actions/runs/16198607586

and the coverage results have been uploaded to the GH pages.

The GH pages is configured to only allow reports uploaded from the main branch GHA run going forward.