### PR TITLE
[Transform] [Utils] Canonical matching utilities

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -754,8 +754,8 @@ def map_module_to_scheme(model: Module) -> Dict[str, QuantizationScheme]:
         fix_fsdp_module_name(name): module.quantization_scheme
         for name, module in model.named_modules()
         if (
-            hasattr(module, "quantization_scheme") and
-            module.quantization_scheme.weights is not None
+            hasattr(module, "quantization_scheme")
+            and module.quantization_scheme.weights is not None
         )
     }
 

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -189,7 +189,12 @@ def _initialize_scale_zero_point(
     else:
         # TODO: consider erroring out in the future as if the dtype if not one of these,
         # there is likely bug
-        if scale_dtype not in [torch.float16, torch.bfloat16, torch.float32, torch.float64]:
+        if scale_dtype not in [
+            torch.float16,
+            torch.bfloat16,
+            torch.float32,
+            torch.float64,
+        ]:
             scale_dtype = torch.float16
         zp_dtype = quantization_args.pytorch_dtype()
 

--- a/src/compressed_tensors/transform/factory/base.py
+++ b/src/compressed_tensors/transform/factory/base.py
@@ -18,7 +18,6 @@ from typing import Optional
 import torch
 import torch.nn.utils.parametrize as P
 from compressed_tensors import InternalModule
-from compressed_tensors.quantization.lifecycle import is_target  # TODO: move to utils
 from compressed_tensors.registry.registry import RegistryMixin, T
 from compressed_tensors.transform import (
     TransformArgs,
@@ -29,6 +28,7 @@ from compressed_tensors.utils import (
     align_module_device,
     delete_offload_module,
     has_offloaded_params,
+    match_named_modules,
     patch_attr,
     register_offload_module,
     update_offload_parameter,
@@ -87,9 +87,8 @@ class TransformFactory(RegistryMixin, ABC):
         :param model: module to apply transforms to
         """
         for arg in self.scheme.apply:
-            for name, module in list(model.named_modules()):
-                if is_target(name, module, arg.targets, arg.ignore):
-                    self._apply_to_module(module, arg)
+            for _, module in match_named_modules(model, arg.targets, arg.ignore):
+                self._apply_to_module(module, arg)
 
     def _apply_to_module(self, module: Module, args: TransformArgs):
         """

--- a/src/compressed_tensors/utils/__init__.py
+++ b/src/compressed_tensors/utils/__init__.py
@@ -15,6 +15,7 @@
 
 from .helpers import *
 from .internal import *
+from .match import *
 from .offload import *
 from .permutations_24 import *
 from .permute import *

--- a/src/compressed_tensors/utils/match.py
+++ b/src/compressed_tensors/utils/match.py
@@ -23,7 +23,13 @@ import torch
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
 
-__all__ = ["match_named_modules", "is_match", "match_name", "match_class"]
+__all__ = [
+    "match_named_modules",
+    "match_named_parameters",
+    "is_match",
+    "match_name",
+    "match_class",
+]
 
 
 def match_named_modules(
@@ -40,15 +46,50 @@ def match_named_modules(
     :param targets: target strings, potentially containing "re:" prefixes
     :param ignore: targets to ignore, potentially containing "re:" prefixes
     :param warn_on_fail: if True, warns if any targets do not match any modules in model
+    :return: generator of module names and modules
     """
     unmatched_targets = set(targets)
     for name, module in model.named_modules():
         for target in targets:
             if is_match(name, module, target):
-                unmatched_targets.remove(target)
+                unmatched_targets -= target
 
                 if not any(is_match(name, module, ign) for ign in ignore):
                     yield name, module
+
+    if warn_on_fail:
+        for target in unmatched_targets:
+            _LOGGER.warning(
+                f"Could not match `{target}` in instance of {model.__class__.__name__}"
+            )
+
+
+def match_named_parameters(
+    model: torch.nn.Module,
+    targets: Iterable[str],
+    ignore: Iterable[str],
+    warn_on_fail: bool = False,
+) -> Generator[Tuple[str, torch.nn.Module, torch.nn.Parameter]]:
+    """
+    Yields parameters which match `targets` but do not match `ignore`.
+    Values are returned in order of `model.named_modules()`
+
+    :param model: model containing params to match against
+    :param targets: target strings, potentially containing "re:" prefixes
+    :param ignore: targets to ignore, potentially containing "re:" prefixes
+    :param warn_on_fail: if True, warns if any targets do not match any params in model
+    :return: generator of fully-qualified param names, parent modules, and params
+    """
+    unmatched_targets = set(targets)
+    for module_name, module in model.named_modules():
+        for param_name, param in module.named_parameters(recurse=False):
+            param_fqn = f"{module_name}.{param_name}"
+            for target in targets:
+                if match_name(param_fqn, target):
+                    unmatched_targets -= target
+
+                    if not any(match_name(param_fqn, ign) for ign in ignore):
+                        yield param_fqn, module, param
 
     if warn_on_fail:
         for target in unmatched_targets:

--- a/src/compressed_tensors/utils/match.py
+++ b/src/compressed_tensors/utils/match.py
@@ -14,7 +14,6 @@
 
 import logging
 import re
-from collections import OrderedDict
 from collections.abc import Generator
 from typing import Iterable, Tuple
 
@@ -153,7 +152,7 @@ def match_modules_set(
                 matches[target] = module
 
         # once we have a full set, yield and reset
-        if all(matches[target] is not None for target in targets):
+        if targets and all((matches[target] is not None for target in targets)):
             yield [matches[target] for target in targets]  # ensure correct ordering
             matches = dict.fromkeys(targets, None)
 
@@ -176,7 +175,7 @@ def match_name(name: str, target: str) -> bool:
     regex matches or if target string exactly matches name
     """
     if target.startswith("re:"):
-        return re.match(target.removeprefix("re:"), name)
+        return re.match(target.removeprefix("re:"), name) is not None
     else:
         return target == name
 

--- a/src/compressed_tensors/utils/match.py
+++ b/src/compressed_tensors/utils/match.py
@@ -52,7 +52,7 @@ def match_named_modules(
     for name, module in model.named_modules():
         for target in targets:
             if is_match(name, module, target):
-                unmatched_targets -= target
+                unmatched_targets -= {target}
 
                 if not any(is_match(name, module, ign) for ign in ignore):
                     yield name, module
@@ -86,7 +86,7 @@ def match_named_parameters(
             param_fqn = f"{module_name}.{param_name}"
             for target in targets:
                 if match_name(param_fqn, target):
-                    unmatched_targets -= target
+                    unmatched_targets -= {target}
 
                     if not any(match_name(param_fqn, ign) for ign in ignore):
                         yield param_fqn, module, param

--- a/src/compressed_tensors/utils/match.py
+++ b/src/compressed_tensors/utils/match.py
@@ -36,7 +36,7 @@ __all__ = [
 
 def match_named_modules(
     model: torch.nn.Module,
-    targets: Iterable[str] = tuple(),
+    targets: Iterable[str],
     ignore: Iterable[str] = tuple(),
     warn_on_fail: bool = False,
 ) -> Generator[Tuple[str, torch.nn.Module]]:
@@ -69,7 +69,7 @@ def match_named_modules(
 def match_named_parameters(
     model: torch.nn.Module,
     targets: Iterable[str],
-    ignore: Iterable[str],
+    ignore: Iterable[str] = tuple(),
     warn_on_fail: bool = False,
 ) -> Generator[Tuple[str, torch.nn.Module, torch.nn.Parameter]]:
     """
@@ -103,7 +103,7 @@ def match_named_parameters(
 def match_modules_set(
     model: torch.nn.Module,
     targets: Iterable[str],
-    ignore: Iterable[str],
+    ignore: Iterable[str] = tuple(),
 ) -> Generator[Iterable[torch.nn.Module]]:
     """
     Yields modules grouped with the same order and size as `targets`.

--- a/src/compressed_tensors/utils/match.py
+++ b/src/compressed_tensors/utils/match.py
@@ -158,7 +158,7 @@ def match_modules_set(
             matches = dict.fromkeys(targets, None)
 
     # check that none are left over
-    unmatched_keys = [match for match, value in matches.items() if value is None]
+    unmatched_keys = [match for match, value in matches.items() if value is not None]
     if len(unmatched_keys):
         raise ValueError(f"Unable to match targets into set: {unmatched_keys}")
 

--- a/src/compressed_tensors/utils/match.py
+++ b/src/compressed_tensors/utils/match.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import re
+from collections.abc import Generator
+from typing import Iterable, Tuple
+
+import torch
+
+
+_LOGGER: logging.Logger = logging.getLogger(__name__)
+
+
+__all__ = ["match_named_modules", "is_match", "match_name", "match_class"]
+
+
+def match_named_modules(
+    model: torch.nn.Module,
+    targets: Iterable[str] = tuple(),
+    ignore: Iterable[str] = tuple(),
+    warn_on_fail: bool = False,
+) -> Generator[Tuple[str, torch.nn.Module], None, None]:
+    """
+    Yields names and modules which match `targets` but do not match `ignore`.
+    Values are returned in order of `model.named_modules()`
+
+    :param model: model containing submodules to match against
+    :param targets: target strings, potentially containing "re:" prefixes
+    :param ignore: targets to ignore, potentially containing "re:" prefixes
+    :param warn_on_fail: if True, warns if any targets do not match any modules in model
+    """
+    unmatched_targets = set(targets)
+    for name, module in model.named_modules():
+        for target in targets:
+            if is_match(name, module, target):
+                unmatched_targets.remove(target)
+
+                if not any(is_match(name, module, ign) for ign in ignore):
+                    yield name, module
+
+    if warn_on_fail:
+        for target in unmatched_targets:
+            _LOGGER.warning(
+                f"Could not match `{target}` in instance of {model.__class__.__name__}"
+            )
+
+
+def is_match(name: str, module: torch.nn.Module, target: str) -> bool:
+    """
+    Returns true if either module name or module parent classes match against target
+    """
+    return match_name(name, target) or match_class(module, target)
+
+
+def match_name(name: str, target: str) -> bool:
+    """
+    Returns true if target string begins with "re:" and
+    regex matches or if target string exactly matches name
+    """
+    if target.startswith("re:"):
+        return re.match(target.removeprefix("re:"), name)
+    else:
+        return target == name
+
+
+def match_class(module: torch.nn.Module, target: str) -> bool:
+    """
+    Returns true if any torch parent class names match the target string exactly
+    """
+    # will never match against a regex pattern since `:` is not allowed in class names
+    return any(
+        issubclass(cls, torch.nn.Module) and cls.__name__ == target
+        for cls in module.__class__.__mro__
+    )

--- a/tests/test_utils/test_match.py
+++ b/tests/test_utils/test_match.py
@@ -1,0 +1,426 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+import torch.nn as nn
+from accelerate import init_empty_weights
+
+# Assuming the module is named "module_matching" - adjust import as needed
+from compressed_tensors.utils.match import (
+    is_match,
+    match_class,
+    match_modules_set,
+    match_name,
+    match_named_modules,
+    match_named_parameters,
+)
+
+
+class DummyModel(nn.Module):
+    """Test model for unit tests. Weights are initialized on meta device"""
+
+    def __init__(self):
+        super().__init__()
+        with init_empty_weights():
+            self.layer1 = nn.Linear(10, 20)
+            self.layer2 = nn.Linear(20, 30)
+            self.norm = nn.LayerNorm(30)
+            self.attention = nn.MultiheadAttention(30, 2)
+
+            # Create nested structure
+            self.transformer = nn.ModuleDict(
+                {
+                    "layers": nn.ModuleList(
+                        [
+                            nn.ModuleDict(
+                                {
+                                    "self_attn": nn.ModuleDict(
+                                        {
+                                            "q_proj": nn.Linear(30, 30),
+                                            "k_proj": nn.Linear(30, 30),
+                                            "v_proj": nn.Linear(30, 30),
+                                        }
+                                    ),
+                                    "norm": nn.LayerNorm(30),
+                                    "mlp": nn.Linear(30, 30),
+                                }
+                            )
+                            for _ in range(3)
+                        ]
+                    )
+                }
+            )
+
+
+class TestMatchName:
+    """Test cases for match_name function"""
+
+    def test_exact_match(self):
+        """Test exact string matching"""
+        assert match_name("layer1", "layer1") == True
+        assert match_name("layer1", "layer2") == False
+        assert (
+            match_name(
+                "transformer.layers.0.self_attn.q_proj",
+                "transformer.layers.0.self_attn.q_proj",
+            )
+            == True
+        )
+
+    def test_regex_match(self):
+        """Test regex matching with "re:" prefix"""
+        assert match_name("layer1", "re:layer.*") == True
+        assert match_name("layer1", "re:^layer1$") == True
+        assert match_name("layer1", "re:layer2") == False
+        assert (
+            match_name("transformer.layers.0.self_attn.q_proj", "re:.*q_proj") == True
+        )
+        assert (
+            match_name(
+                "transformer.layers.0.self_attn.q_proj",
+                "re:transformer\\.layers\\.\\d+\\.self_attn\\..*_proj$",
+            )
+            == True
+        )
+
+    def test_empty_strings(self):
+        """Test edge cases with empty strings"""
+        assert match_name("", "") == True
+        assert match_name("layer1", "") == False
+        assert match_name("", "layer1") == False
+
+    def test_regex_special_characters(self):
+        """Test regex with special characters"""
+        assert match_name("layer.1", "re:layer\\.1") == True
+        assert match_name("layer.1", "re:layer.1") == True  # . matches any char
+        assert match_name("layer_1", "re:layer_1") == True
+
+
+class TestMatchClass:
+    """Test cases for match_class function"""
+
+    def test_direct_class_match(self):
+        """Test matching direct class names"""
+        linear = nn.Linear(10, 20)
+        assert match_class(linear, "Linear") == True
+        assert match_class(linear, "Conv2d") == False
+
+        norm = nn.LayerNorm(10)
+        assert match_class(norm, "LayerNorm") == True
+        assert match_class(norm, "BatchNorm1d") == False
+
+    def test_parent_class_match(self):
+        """Test matching parent class names"""
+        linear = nn.Linear(10, 20)
+        assert match_class(linear, "Module") == True
+
+        conv = nn.Conv2d(3, 16, 3)
+        assert match_class(conv, "Module") == True
+        assert match_class(conv, "_ConvNd") == True
+
+    def test_non_torch_module(self):
+        """Test with non-torch modules"""
+        regular_object = object()
+        assert match_class(regular_object, "object") == False  # not a torch.nn.Module
+
+    def test_custom_module(self):
+        """Test with custom module classes"""
+        model = DummyModel()
+        assert match_class(model, "DummyModel") == True
+        assert match_class(model, "Module") == True
+
+
+class TestIsMatch:
+    """Test cases for is_match function"""
+
+    def test_name_match(self):
+        """Test matching by name"""
+        linear = nn.Linear(10, 20)
+        assert is_match("layer1", linear, "layer1") == True
+        assert is_match("layer1", linear, "layer2") == False
+
+    def test_class_match(self):
+        """Test matching by class"""
+        linear = nn.Linear(10, 20)
+        assert is_match("layer1", linear, "Linear") == True
+        assert is_match("layer1", linear, "Conv2d") == False
+
+    def test_combined_match(self):
+        """Test that either name or class match works"""
+        linear = nn.Linear(10, 20)
+        assert is_match("layer1", linear, "layer1") == True  # name match
+        assert is_match("layer1", linear, "Linear") == True  # class match
+        assert is_match("layer1", linear, "layer2") == False  # no match
+
+    def test_regex_in_name_match(self):
+        """Test regex matching in name"""
+        linear = nn.Linear(10, 20)
+        assert is_match("layer1", linear, "re:layer.*") == True
+        assert is_match("layer1", linear, "re:conv.*") == False
+
+
+class TestMatchNamedModules:
+    """Test cases for match_named_modules function"""
+
+    def test_exact_module_match(self):
+        """Test matching modules by exact name"""
+        model = DummyModel()
+        matches = list(match_named_modules(model, ["layer1", "layer2"]))
+
+        assert len(matches) == 2
+        names = [name for name, _ in matches]
+        assert "layer1" in names
+        assert "layer2" in names
+
+    def test_class_module_match(self):
+        """Test matching modules by class name"""
+        model = DummyModel()
+        matches = list(match_named_modules(model, ["Linear"]))
+
+        # Should find all Linear layers
+        linear_modules = [
+            module for _, module in matches if isinstance(module, nn.Linear)
+        ]
+        assert len(linear_modules) > 0
+
+    def test_regex_module_match(self):
+        """Test matching modules with regex patterns"""
+        model = DummyModel()
+        matches = list(match_named_modules(model, ["re:.*linear.*"]))
+
+        # Should find layers with "linear" in name (case insensitive depends on model)
+        assert len(matches) >= 0  # May be 0 if no "linear" in names
+
+    def test_ignore_parameter(self):
+        """Test ignoring specific modules"""
+        model = DummyModel()
+        matches_without_ignore = list(match_named_modules(model, ["Linear"]))
+        matches_with_ignore = list(
+            match_named_modules(model, ["Linear"], ignore=["layer1"])
+        )
+
+        # Should have fewer matches when ignoring layer1
+        assert len(matches_with_ignore) <= len(matches_without_ignore)
+
+        # layer1 should not be in ignored results
+        ignored_names = [name for name, _ in matches_with_ignore]
+        assert "layer1" not in ignored_names
+
+    def test_empty_targets(self):
+        """Test with empty targets list"""
+        model = DummyModel()
+        matches = list(match_named_modules(model, []))
+        assert len(matches) == 0
+
+    @patch("compressed_tensors.utils.match._LOGGER")
+    def test_warn_on_fail(self, mock_logger):
+        """Test warning when targets don"t match"""
+        model = DummyModel()
+        list(match_named_modules(model, ["nonexistent_module"], warn_on_fail=True))
+
+        mock_logger.warning.assert_called_once()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        assert "Could not match" in warning_msg
+        assert "nonexistent_module" in warning_msg
+
+
+class TestMatchNamedParameters:
+    """Test cases for match_named_parameters function"""
+
+    def test_parameter_match(self):
+        """Test matching parameters by name"""
+        model = DummyModel()
+        matches = list(match_named_parameters(model, ["layer1.weight", "layer1.bias"]))
+
+        assert len(matches) == 2
+        param_names = [name for name, _, _ in matches]
+        assert "layer1.weight" in param_names
+        assert "layer1.bias" in param_names
+
+    def test_regex_parameter_match(self):
+        """Test matching parameters with regex"""
+        model = DummyModel()
+        matches = list(match_named_parameters(model, ["re:.*weight$"]))
+
+        # Should find all weight parameters
+        weight_params = [name for name, _, _ in matches if name.endswith(".weight")]
+        assert len(weight_params) > 0
+
+    def test_ignore_parameters(self):
+        """Test ignoring specific parameters"""
+        model = DummyModel()
+        matches_without_ignore = list(match_named_parameters(model, ["re:.*weight$"]))
+        matches_with_ignore = list(
+            match_named_parameters(model, ["re:.*weight$"], ignore=["layer1.weight"])
+        )
+
+        # Should have fewer matches when ignoring
+        assert len(matches_with_ignore) < len(matches_without_ignore)
+
+        # layer1.weight should not be in ignored results
+        ignored_names = [name for name, _, _ in matches_with_ignore]
+        assert "layer1.weight" not in ignored_names
+
+    def test_parameter_return_values(self):
+        """Test that function returns correct tuple values"""
+        model = DummyModel()
+        matches = list(match_named_parameters(model, ["layer1.weight"]))
+
+        assert len(matches) == 1
+        param_name, parent_module, param = matches[0]
+
+        assert param_name == "layer1.weight"
+        assert parent_module is model.layer1
+        assert isinstance(param, nn.Parameter)
+        assert param is model.layer1.weight
+
+    @patch("compressed_tensors.utils.match._LOGGER")
+    def test_warn_on_fail_parameters(self, mock_logger):
+        """Test warning when parameter targets don"t match"""
+        model = DummyModel()
+        list(match_named_parameters(model, ["nonexistent.param"], warn_on_fail=True))
+
+        mock_logger.warning.assert_called_once()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        assert "Could not match" in warning_msg
+        assert "nonexistent.param" in warning_msg
+
+
+class TestMatchModulesSet:
+    """Test cases for match_modules_set function"""
+
+    def test_simple_module_set(self):
+        """Test matching simple module sets"""
+        model = DummyModel()
+        targets = [
+            "re:.*self_attn.q_proj$",
+            "re:.*self_attn.k_proj$",
+            "re:.*self_attn.v_proj$",
+        ]
+
+        matches = list(match_modules_set(model, targets))
+
+        # Should have 3 sets (one for each layer)
+        assert len(matches) == 3
+
+        # Each set should have 3 modules
+        for module_set in matches:
+            assert len(module_set) == 3
+            assert all(isinstance(m, nn.Linear) for m in module_set)
+
+    def test_module_set_ordering(self):
+        """Test that module sets maintain target ordering"""
+        model = DummyModel()
+        targets = [
+            "re:.*v_proj$",  # v first
+            "re:.*self_attn.q_proj$",  # q second
+            "re:.*self_attn.k_proj$",
+        ]  # k third
+
+        matches = list(match_modules_set(model, targets))
+
+        for module_set in matches:
+            # Check that modules are returned in target order (v, q, k)
+            v_proj, q_proj, k_proj = module_set
+            # We can"t easily check the exact modules, but we can check they"re all Linear
+            assert all(isinstance(m, nn.Linear) for m in [v_proj, q_proj, k_proj])
+
+    def test_incomplete_set_error(self):
+        """Test error when unable to complete a set"""
+        model = DummyModel()
+        targets = ["layer1", "nonexistent_module"]
+
+        with pytest.raises(ValueError, match="Unable to match targets into set"):
+            list(match_modules_set(model, targets))
+
+    def test_duplicate_match_error(self):
+        """Test error when same target matches multiple times before set completion"""
+        model = DummyModel()
+        # This should cause the same target to match multiple times
+        # before we can complete a set
+        targets = ["Linear", "Linear"]  # Two identical targets
+
+        with pytest.raises(
+            ValueError, match="Matched a .* twice before completing set"
+        ):
+            list(match_modules_set(model, targets))
+
+    def test_empty_targets_set(self):
+        """Test with empty targets"""
+        model = DummyModel()
+        matches = list(match_modules_set(model, []))
+        # Should yield one empty set for each module traversed?
+        # Actually, with empty targets, we expect no matches
+        assert len(matches) == 0
+
+    def test_module_set_with_ignore(self):
+        """Test module set matching with ignore parameter"""
+        model = DummyModel()
+        targets = ["re:.*self_attn.q_proj$", "re:.*self_attn.k_proj$"]
+        ignore = ["re:transformer.layers.0.*"]  # Ignore first layer
+
+        matches = list(match_modules_set(model, targets, ignore=ignore))
+
+        # Should have 2 sets (layers 1 and 2, but not 0)
+        assert len(matches) == 2
+
+
+class TestIntegration:
+    """Integration tests combining multiple functions"""
+
+    def test_complex_model_matching(self):
+        """Test matching on a more complex model structure"""
+        model = DummyModel()
+
+        # Test that we can find attention projection layers
+        q_matches = list(match_named_modules(model, ["re:.*q_proj$"]))
+        k_matches = list(match_named_modules(model, ["re:.*k_proj$"]))
+        v_matches = list(match_named_modules(model, ["re:.*v_proj$"]))
+
+        assert len(q_matches) == 3  # 3 layers
+        assert len(k_matches) == 3
+        assert len(v_matches) == 3
+
+    def test_parameter_and_module_consistency(self):
+        """Test that parameter and module matching are consistent"""
+        model = DummyModel()
+
+        # Get modules
+        module_matches = list(match_named_modules(model, ["layer1"]))
+        assert len(module_matches) == 1
+        module_name, module = module_matches[0]
+
+        # Get parameters from that module
+        param_matches = list(match_named_parameters(model, [f"{module_name}.weight"]))
+        assert len(param_matches) == 1
+        param_name, parent_module, param = param_matches[0]
+
+        # Check consistency
+        assert parent_module is module
+        assert param is module.weight
+
+    def test_all_functions_with_regex(self):
+        """Test all functions work with regex patterns"""
+        model = DummyModel()
+        regex_target = "re:.*Linear.*"
+
+        # Should not crash and should handle regex consistently
+        modules = list(match_named_modules(model, [regex_target]))
+        params = list(match_named_parameters(model, [regex_target]))
+
+        # Basic sanity checks
+        assert isinstance(modules, list)
+        assert isinstance(params, list)


### PR DESCRIPTION
## Purpose ##
* There currently exist 23 different functions for matching modules/parameters. These utils consolidate them to just 6.
* Used by transforms for module matching and layer norm matching

Function | Used for/by | Maps to
-- | -- | --
get_layer_by_name | awq | attrgetter(layer_name)(module)
get_layers_params | pruning modifiers | match_named_parameters
get_param | None | Delete
get_params | get_layers_params , get_param | Delete
set_layer | Distillation modifier | Module.set_submodule
get_layer | None | Delete
get_layers | Lots | match_named_modules
match_layers_params | get_layers | Delete
get_default_params | match_layers_params | Delete
match_targets | Many | match_named_modules
get_quantizable_layers | match_layers_params | Delete, use explicit targets
get_prunable_layers | match_layers_params | Delete, use explicit targets
get_terminal_layers | match_layers_params | Delete, use explicit targets
get_matching_layer | Smoothquant | match_modules_set
AWQ.set_resolved_mappings | AWQ | match_modules_set
expand_target_names | Compressor | match_named_parameters
is_target | Quantization | is_match
find_name_or_class_matches | Quantization | match_name or match_class
_find_matches | Quantization | Delete
get_nested_weight_mappings | Compressor | match_named_parameters
match_param_name | get_nested_weight_mappings | Delete,match_name
match_modules | sequential pipeline | match_named_modules
get_linear_layers | infer_sparsity_structure_from_model | match_named_modules
<!-- notionvc: d9accfd5-24a2-4d6a-ac6c-cfd743e587e1 -->


get_linear_layers

## Changes ##
* Implement 3 commonly-used functions
  * `match_named_modules` returns modules
  * `match_named_parameters` returns parameters (and their parent modules)
  * `match_modules_set` returns modules in predefined groups
* Implements 3 helper functions which are publicly exposed
  * `match_name` returns True if target regex matches the name
  * `match_class` returns True if target matches any parent classes
  * `is_match` returns True if either `match_name` or `match_class` is True

## Integration Plan ##
* This PR utilizes these matching utilities for transforms. Future PRs will replace existing functions with these function as described in the table

## Testing ##
* Added comprehensive tests generated by Claude, which I have manually reviewed and fixed any issues with 