### PR TITLE
[Bugfix] Fix Per-Token Dynamic Activation Quantization

### DIFF
--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -167,7 +167,7 @@ def compute_dynamic_scales_and_zp(
 
     keep_dims = True
     if args.strategy == QuantizationStrategy.TOKEN:
-        dim = {1, 2}
+        dim = {0, 1}
         reduce_dims = tuple(idx for idx in range(value.ndim) if idx not in dim)
     elif args.strategy == QuantizationStrategy.TENSOR:
         reduce_dims = None


### PR DESCRIPTION
### Summary
This PR fixes the activation quantization issue described in Issue #394, where the input scale shape was incorrect when using the Dynamic TOKEN strategy.

### Fix
- Corrected the reduction dimensions to ensure only the hidden dimension is reduced.
- This ensures the input scale shape is `(batch_size, seq_len, 1)` instead of `(1, seq_len, hidden_dim)`.