### PR TITLE
[Transform] Fix config serialization

### DIFF
--- a/src/compressed_tensors/transform/factory/base.py
+++ b/src/compressed_tensors/transform/factory/base.py
@@ -99,7 +99,7 @@ class TransformFactory(RegistryMixin, ABC):
         :param args: defines how the transform will be applied to the target module
         """
         # create transform as submodule
-        transform_name = f"{self.name}_{args.location.value}"
+        transform_name = f"{self.name}_{args.location}"
         transform = self.create_transform(module, args)
         register_offload_module(module, transform_name, transform)
 

--- a/src/compressed_tensors/transform/transform_args.py
+++ b/src/compressed_tensors/transform/transform_args.py
@@ -46,7 +46,7 @@ class TransformLocation(str, Enum):
     Q_ATTN = "q_attn"
 
 
-class TransformArgs(BaseModel):
+class TransformArgs(BaseModel, use_enum_values=True):
     """
     Arguments which define *how* and where a transform should be applied to a model
 


### PR DESCRIPTION
## Purpose ##
* Allow transforms config to be serialized without encoding python objects
  * This is specifically useful for serializing recipes

<details><summary>previous.yaml</summary>

```yaml
default_stage:
  default_modifiers:
    SpinQuantModifier:
      rotations:
      - !!python/object/apply:llmcompressor.modifiers.transform.spinquant.base.SpinquantRotation [
        R1]
      - !!python/object/apply:llmcompressor.modifiers.transform.spinquant.base.SpinquantRotation [
        R2]
      transform_type: hadamard
      randomize: false
      learnable: false
      transform_config:
        config_groups:
          R1:
            type: hadamard
            apply:
            - targets: ['re:.*embed_tokens$', 're:.*o_proj$', 're:.*down_proj$']
              location: !!python/object/apply:compressed_tensors.transform.transform_args.TransformLocation [
                weight_output]
              inverse: false
              ignore: []
            - targets: ['re:.*q_proj$', 're:.*k_proj$', 're:.*v_proj$', 're:.*up_proj$', 're:.*gate_proj$',
                lm_head]
              location: !!python/object/apply:compressed_tensors.transform.transform_args.TransformLocation [
                weight_input]
              inverse: true
              ignore: []
            randomize: false
            requires_grad: false
            head_dim: null
          R2:
            type: hadamard
            apply:
            - targets: ['re:.*v_proj$']
              location: !!python/object/apply:compressed_tensors.transform.transform_args.TransformLocation [
                weight_output]
              inverse: false
              ignore: []
            - targets: ['re:.*o_proj$']
              location: !!python/object/apply:compressed_tensors.transform.transform_args.TransformLocation [
                weight_input]
              inverse: true
              ignore: []
            randomize: false
            requires_grad: false
            head_dim: 128
```
</details>

<details><summary>now.yaml</summary>

```yaml
default_stage:
  default_modifiers:
    SpinQuantModifier:
      rotations: [R1, R2]  # required changes on LC
      transform_type: hadamard
      randomize: false
      learnable: false
      transform_config:
        config_groups:
          R1:
            type: hadamard
            apply:
            - targets: ['re:.*embed_tokens$', 're:.*o_proj$', 're:.*down_proj$']
              location: weight_output
              inverse: false
              ignore: []
            - targets: ['re:.*q_proj$', 're:.*k_proj$', 're:.*v_proj$', 're:.*up_proj$', 're:.*gate_proj$',
                lm_head]
              location: weight_input
              inverse: true
              ignore: []
            randomize: false
            requires_grad: false
            head_dim: null
          R2:
            type: hadamard
            apply:
            - targets: ['re:.*v_proj$']
              location: weight_output
              inverse: false
              ignore: []
            - targets: ['re:.*o_proj$']
              location: weight_input
              inverse: true
              ignore: []
            randomize: false
            requires_grad: false
            head_dim: 128
```
</details>

## Changes ##
* Use enum values for `TransformArgs` in order to account for `TransformLocation`

## Testing ##
* Tests pass
* Recipe is serialized properly