### PR TITLE
[KV Cache] support kv cache int8 per channel quant

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -224,7 +224,7 @@ def _initialize_attn_scales(module: Module, quantization_args: QuantizationArgs)
     """Initlaize k_scale, v_scale for  self_attn"""
 
     if quantization_args.strategy == QuantizationStrategy.CHANNEL:
-        expected_shape = module.k_proj.out_features
+        expected_shape = (module.k_proj.out_features, 1)
     elif quantization_args.strategy == QuantizationStrategy.TENSOR:
         expected_shape = 1
     else:

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -83,7 +83,7 @@ def initialize_module_for_quantization(
 
     if is_attention_module(module):
         # quantized actions based on calltime status
-        _initialize_attn_scales(module)
+        _initialize_attn_scales(module, scheme.output_activations)
 
     else:
 
@@ -220,10 +220,18 @@ def _initialize_scale_zero_point(
         register_offload_parameter(module, f"{base_name}_g_idx", init_g_idx)
 
 
-def _initialize_attn_scales(module: Module) -> None:
+def _initialize_attn_scales(module: Module, quantization_args: QuantizationArgs) -> None:
     """Initlaize k_scale, v_scale for  self_attn"""
 
-    expected_shape = 1  # per tensor
+    if quantization_args.strategy == QuantizationStrategy.CHANNEL:
+        expected_shape = module.k_proj.out_features
+    elif quantization_args.strategy == QuantizationStrategy.TENSOR:
+        expected_shape = 1
+    else:
+        raise ValueError(
+            f"One of {(QuantizationStrategy.TENSOR, QuantizationStrategy.CHANNEL)} must be specified "
+            f"for kv cache quantization."
+        )
 
     param = next(module.parameters())
     scale_dtype = param.dtype


### PR DESCRIPTION
kv cache quant int8 per channel is supported using this pr.
Besieds, llm-compressor needs to be updated as well: https://github.com/vllm-project/llm-compressor/pull/1663