### PR TITLE
Speed up nvfp4 pack/unpack w/ torch.compile

### DIFF
--- a/src/compressed_tensors/compressors/quantized_compressors/nvfp4_quantized.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/nvfp4_quantized.py
@@ -105,6 +105,7 @@ class NVFP4PackedCompressor(BaseQuantizationCompressor):
         return decompressed_weight
 
 
+@torch.compile(fullgraph=True)
 def pack_fp4_to_uint8(x: torch.Tensor) -> torch.Tensor:
     """
     Packs a tensor with values in the fp4 range into uint8.
@@ -127,12 +128,11 @@ def pack_fp4_to_uint8(x: torch.Tensor) -> torch.Tensor:
 
     # Find closest valid FP4 value index for each element
     abs_x = torch.abs(x)
-    abs_indices = torch.zeros_like(abs_x, dtype=torch.long)
-    for i, val in enumerate(kE2M1):
-        abs_indices = torch.where(torch.isclose(abs_x, val), i, abs_indices)
+    abs_diff_x = torch.abs(abs_x.unsqueeze(-1) - kE2M1)  # [m, n, 8]
+    abs_indices = torch.argmin(abs_diff_x, dim=-1)  # [m, n]
 
     # Apply sign bit (bit 3) to get final 4-bit representation
-    indices = abs_indices + (torch.signbit(x) << 3).to(torch.long)
+    indices = abs_indices + (torch.signbit(x).to(torch.long) << 3)
 
     # Reshape to prepare for packing pairs of values
     indices = indices.reshape(-1)
@@ -155,6 +155,7 @@ kE2M1ToFloat = torch.tensor(
 )
 
 # reference: : https://github.com/vllm-project/vllm/pull/16362
+@torch.compile(fullgraph=True)
 def unpack_fp4_from_uint8(
     a: torch.Tensor, m: int, n: int, dtype: Optional[torch.dtype] = torch.bfloat16
 ) -> torch.Tensor:

--- a/src/compressed_tensors/compressors/quantized_compressors/nvfp4_quantized.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/nvfp4_quantized.py
@@ -71,7 +71,6 @@ class NVFP4PackedCompressor(BaseQuantizationCompressor):
         zero_point: Optional[torch.Tensor] = None,
         g_idx: Optional[torch.Tensor] = None,
     ) -> Dict[str, torch.Tensor]:
-
         quantized_weight = quantize(
             x=weight,
             scale=scale,
@@ -91,7 +90,6 @@ class NVFP4PackedCompressor(BaseQuantizationCompressor):
         compressed_data: Dict[str, Tensor],
         quantization_args: Optional[QuantizationArgs] = None,
     ) -> torch.Tensor:
-
         weight = compressed_data["weight_packed"]
         scale = compressed_data["weight_scale"]
         global_scale = compressed_data["weight_global_scale"]
@@ -105,7 +103,7 @@ class NVFP4PackedCompressor(BaseQuantizationCompressor):
         return decompressed_weight
 
 
-@torch.compile(fullgraph=True)
+@torch.compile(fullgraph=True, dynamic=True)
 def pack_fp4_to_uint8(x: torch.Tensor) -> torch.Tensor:
     """
     Packs a tensor with values in the fp4 range into uint8.
@@ -154,8 +152,9 @@ kE2M1ToFloat = torch.tensor(
     [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32
 )
 
+
 # reference: : https://github.com/vllm-project/vllm/pull/16362
-@torch.compile(fullgraph=True)
+@torch.compile(fullgraph=True, dynamic=True)
 def unpack_fp4_from_uint8(
     a: torch.Tensor, m: int, n: int, dtype: Optional[torch.dtype] = torch.bfloat16
 ) -> torch.Tensor:


### PR DESCRIPTION
Applies `torch.compile` to nvfp compressor as suggested in https://github.com/vllm-project/llm-compressor/issues/1485

Speed ups anywhere from 3x to 25x depending on cpu/gpu.

# Benchmarks

<details>
<summary> Benchmark pack/unpack (new) </summary>

```
./benchmark_fp4_packing.sh 

Running benchmark on CPU...
Creating tensor of shape (8192, 8192) on cpu...
Benchmarking on tensor of shape torch.Size([8192, 8192]) (67,108,864 elements) on cpu
Iter 1/3 - Pack: 1.8949s
Iter 2/3 - Pack: 0.0454s
Iter 3/3 - Pack: 0.0464s
Iter 1/3 - Unpack: 0.0784s
Iter 2/3 - Unpack: 0.0374s
Iter 3/3 - Unpack: 0.0377s

Benchmark Results:
Device: cpu
Tensor shape: 8192x8192 (67,108,864 elements)
Average pack time: 0.6622s (101.34M elements/s)
Average unpack time: 0.0512s (1311.30M elements/s)
Compression ratio: 8.00x
--------------------------------
Running benchmark on GPU...
Creating tensor of shape (8192, 8192) on cuda...
Benchmarking on tensor of shape torch.Size([8192, 8192]) (67,108,864 elements) on cuda:0
Iter 1/3 - Pack: 0.4240s
Iter 2/3 - Pack: 0.0027s
Iter 3/3 - Pack: 0.0027s
Iter 1/3 - Unpack: 0.0459s
Iter 2/3 - Unpack: 0.0005s
Iter 3/3 - Unpack: 0.0005s

Benchmark Results:
Device: cuda:0
Tensor shape: 8192x8192 (67,108,864 elements)
Average pack time: 0.1431s (468.85M elements/s)
Average unpack time: 0.0156s (4299.47M elements/s)
Compression ratio: 8.00x
```
</details>

<details>
<summary> Benchmark pack/unpack (old) </summary>

```
./benchmark_fp4_packing.sh 

Running benchmark on CPU...
Creating tensor of shape (8192, 8192) on cpu...
Benchmarking on tensor of shape torch.Size([8192, 8192]) (67,108,864 elements) on cpu
Iter 1/3 - Pack: 1.1415s
Iter 2/3 - Pack: 1.0510s
Iter 3/3 - Pack: 0.9702s
Iter 1/3 - Unpack: 0.1212s
Iter 2/3 - Unpack: 0.0985s
Iter 3/3 - Unpack: 0.0991s

Benchmark Results:
Device: cpu
Tensor shape: 8192x8192 (67,108,864 elements)
Average pack time: 1.0542s (63.66M elements/s)
Average unpack time: 0.1062s (631.62M elements/s)
Compression ratio: 8.00x
--------------------------------
Running benchmark on GPU...
Creating tensor of shape (8192, 8192) on cuda...
Benchmarking on tensor of shape torch.Size([8192, 8192]) (67,108,864 elements) on cuda:0
Iter 1/3 - Pack: 0.1073s
Iter 2/3 - Pack: 0.0649s
Iter 3/3 - Pack: 0.0650s
Iter 1/3 - Unpack: 0.0081s
Iter 2/3 - Unpack: 0.0050s
Iter 3/3 - Unpack: 0.0050s

Benchmark Results:
Device: cuda:0
Tensor shape: 8192x8192 (67,108,864 elements)
Average pack time: 0.0791s (848.65M elements/s)
Average unpack time: 0.0060s (11118.17M elements/s)
Compression ratio: 8.00x
```
</details>

This also translates to real usage improvements:
```bash
time python examples/quantization_w4a16_fp4/llama3_example.py
```
New

```
...
( Model preperation and test generation output excluded )
...
Compressing model: 423it [00:20, 20.30it/s]

real    2m37.888s
user    10m28.019s
sys     1m19.335s
```

Old

```
...
( Model preperation and test generation output excluded )
...
Compressing model: 423it [01:27,  4.83it/s]

real    3m59.430s
user    22m39.828s
sys     6m37.413s
```
