### PR TITLE
fix block quantization initialization

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -180,6 +180,22 @@ def _initialize_scale_zero_point(
         ):
             num_groups = math.ceil(weight_shape[1] / quantization_args.group_size)
             expected_shape = (weight_shape[0], max(num_groups, 1))
+        elif quantization_args.strategy == QuantizationStrategy.BLOCK:
+            # For block quantization, scale shape should match number of blocks
+            if quantization_args.block_structure is None:
+                raise ValueError("Block quantization requires block_structure to be specified")
+            block_height, block_width = quantization_args.block_structure
+            rows, cols = weight_shape[-2], weight_shape[-1]
+            num_rows_blocks = math.ceil(rows / block_height)
+            num_cols_blocks = math.ceil(cols / block_width)
+            expected_shape = (num_rows_blocks, num_cols_blocks)
+    elif quantization_args.strategy == QuantizationStrategy.BLOCK:.
+        import warnings
+        warnings.warn(
+            f"BLOCK quantization not supported for {base_name} activations. "
+            f"Falling back to tensor-level quantization.",
+        )
+        expected_shape = 1
 
     # 3. Identify quantization scale and zp dtype
     scale_dtype = scale_dtype if scale_dtype is not None else module.weight.dtype

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -189,7 +189,7 @@ def _initialize_scale_zero_point(
             num_rows_blocks = math.ceil(rows / block_height)
             num_cols_blocks = math.ceil(cols / block_width)
             expected_shape = (num_rows_blocks, num_cols_blocks)
-    elif quantization_args.strategy == QuantizationStrategy.BLOCK:.
+    elif quantization_args.strategy == QuantizationStrategy.BLOCK:
         import warnings
         warnings.warn(
             f"BLOCK quantization not supported for {base_name} activations. "

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -15,6 +15,7 @@
 
 import logging
 import math
+import warnings
 from enum import Enum
 from typing import List, Optional
 
@@ -170,8 +171,8 @@ def _initialize_scale_zero_point(
     else:
         expected_shape = 1
 
-    if weight_shape is not None:
-        if quantization_args.strategy == QuantizationStrategy.CHANNEL and base_name == "weight":
+    if base_name == "weight" and weight_shape is not None:
+        if quantization_args.strategy == QuantizationStrategy.CHANNEL:
             # (output_channels, 1) - only for weights
             expected_shape = (weight_shape[0], 1)
         elif quantization_args.strategy in (
@@ -181,7 +182,7 @@ def _initialize_scale_zero_point(
             # GROUP/TENSOR_GROUP for both weights and activations
             num_groups = math.ceil(weight_shape[1] / quantization_args.group_size)
             expected_shape = (weight_shape[0], max(num_groups, 1))
-        elif quantization_args.strategy == QuantizationStrategy.BLOCK and base_name == "weight":
+        elif quantization_args.strategy == QuantizationStrategy.BLOCK:
             # For block quantization, scale shape should match number of blocks - only for weights
             if quantization_args.block_structure is None:
                 raise ValueError("Block quantization requires block_structure to be specified")
@@ -189,9 +190,18 @@ def _initialize_scale_zero_point(
             rows, cols = weight_shape[-2], weight_shape[-1]
             num_rows_blocks = math.ceil(rows / block_height)
             num_cols_blocks = math.ceil(cols / block_width)
+            
+            # Warn if dimensions don't divide evenly
+            if rows % block_height != 0 or cols % block_width != 0:
+                warnings.warn(
+                    f"Block quantization: tensor shape {weight_shape} does not divide evenly "
+                    f"by block structure {quantization_args.block_structure}. "
+                    f"Some blocks will be incomplete which may affect quantization quality.",
+                    UserWarning
+                )
+            
             expected_shape = (num_rows_blocks, num_cols_blocks)
     elif quantization_args.strategy == QuantizationStrategy.BLOCK:
-        import warnings
         warnings.warn(
             f"BLOCK quantization not supported for {base_name} activations. "
             f"Falling back to tensor-level quantization.",

--- a/tests/test_quantization/lifecycle/test_initialize.py
+++ b/tests/test_quantization/lifecycle/test_initialize.py
@@ -175,7 +175,7 @@ def test_initialize_module_for_quantization_offloaded(
         ),
         (
             QuantizationArgs(strategy="block", block_structure=[2, 4]),
-            QuantizationArgs(strategy="group", group_size=2),
+            None,
         ),
         (
             QuantizationArgs(strategy="token"),

--- a/tests/test_quantization/lifecycle/test_initialize.py
+++ b/tests/test_quantization/lifecycle/test_initialize.py
@@ -174,8 +174,8 @@ def test_initialize_module_for_quantization_offloaded(
             ),
         ),
         (
-            QuantizationArgs(strategy="block"),
-            QuantizationArgs(strategy="block"),
+            QuantizationArgs(strategy="block", block_structure=[2, 4]),
+            QuantizationArgs(strategy="group", group_size=2),
         ),
         (
             QuantizationArgs(strategy="token"),
@@ -227,7 +227,17 @@ def test_initialize_quantization_parameters(weights, input_activations):
             expected_shape = (layer.weight.shape[0], max(num_groups, 1))
 
         elif args.strategy == QuantizationStrategy.BLOCK:
-            expected_shape = (1,)
+            # For block quantization, only weights get block-level scales
+            # Activations fall back to tensor-level since shape is unknown at init
+            if q_type == "weights" and args.block_structure is not None:
+                block_height, block_width = args.block_structure
+                rows, cols = layer.weight.shape[-2], layer.weight.shape[-1]
+                num_rows_blocks = math.ceil(rows / block_height)
+                num_cols_blocks = math.ceil(cols / block_width)
+                expected_shape = (num_rows_blocks, num_cols_blocks)
+            else:
+                # For activations or when block_structure is None
+                expected_shape = (1,)
 
         elif args.strategy == QuantizationStrategy.TOKEN:
             expected_shape = (1, 1)


### PR DESCRIPTION
## Purpose ##
- Fixed shape mismatch error in block quantization example

## Changes ##
- Add block quantization shape initialization and throw a warning when users attempt to apply block quantization on activations. 

## Tests ##
- Tested the example & `test_initialization.py` in compressed-tensors. Let me know if there's anything else I should test for. 