### PR TITLE
[Quantization][Decompression] Fix QDQ for dynamic quant; Update NVFP4 Compression Params

### DIFF
--- a/src/compressed_tensors/compressors/quantized_compressors/nvfp4_quantized.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/nvfp4_quantized.py
@@ -60,6 +60,25 @@ class NVFP4PackedCompressor(BaseQuantizationCompressor):
             "weight_zero_point",
             "weight_global_scale",
         )
+    
+    def compression_param_info(
+        self,
+        weight_shape: torch.Size,
+        quantization_args: Optional[QuantizationArgs] = None,
+    ) -> Dict[str, Tuple[torch.Size, torch.dtype]]:
+        """
+        Creates a dictionary of expected shapes and dtypes for each compression
+            parameter used by the compressor
+
+        :param weight_shape: uncompressed weight shape
+        :param quantization_args: quantization parameters for the weight
+        :return: dictionary mapping compressed parameter names to shape and dtype
+        """
+        output = {
+            "weight_packed": (torch.Size((weight_shape[0], weight_shape[1] // 2)), torch.uint8),
+        }
+        return output
+
 
     def compress_weight(
         self,

--- a/src/compressed_tensors/compressors/quantized_compressors/nvfp4_quantized.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/nvfp4_quantized.py
@@ -60,7 +60,7 @@ class NVFP4PackedCompressor(BaseQuantizationCompressor):
             "weight_zero_point",
             "weight_global_scale",
         )
-    
+
     def compression_param_info(
         self,
         weight_shape: torch.Size,
@@ -75,10 +75,12 @@ class NVFP4PackedCompressor(BaseQuantizationCompressor):
         :return: dictionary mapping compressed parameter names to shape and dtype
         """
         output = {
-            "weight_packed": (torch.Size((weight_shape[0], weight_shape[1] // 2)), torch.uint8),
+            "weight_packed": (
+                torch.Size((weight_shape[0], weight_shape[1] // 2)),
+                torch.uint8,
+            ),
         }
         return output
-
 
     def compress_weight(
         self,

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -291,11 +291,11 @@ def _process_quantization(
             x = safe_permute(x, perm, dim=1)
 
         # Maintain all dimensions apart from the last dim, which is divided by the group_size
-        reshaped_dims = tuple(x.shape[:-1]) + (
+        reshaped_dims = (
             ceil(x.shape[-1] / group_size),
             group_size,
         )
-        x = torch.reshape(x, reshaped_dims)
+        x = x.unflatten(-1, reshaped_dims)
 
         if do_quantize:
             output = _quantize(
@@ -318,11 +318,7 @@ def _process_quantization(
                 global_scale=global_scale,
             )
 
-        original_shaped_dims = tuple(output.shape[:-2]) + (
-            output.shape[-1] * output.shape[-2],
-        )
-        output = torch.reshape(output, original_shaped_dims)
-
+        output = output.flatten(start_dim=-2)
         output = output.to(output_dtype)
 
         if not is_column_order:

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -257,13 +257,14 @@ def _process_quantization(
         QuantizationStrategy.GROUP,
         QuantizationStrategy.TENSOR_GROUP,
     ):
+        """
         n_dims = x.shape
         if len(n_dims) > 2:
             x = x.squeeze(0)
-
+        """
         output_dtype = dtype if dtype is not None else x.dtype
         output = torch.zeros_like(x).to(output_dtype)
-        columns = output.shape[1]
+        columns = output.shape[-1]
 
         # TODO: make validation step for inputs
 
@@ -293,14 +294,25 @@ def _process_quantization(
             perm = torch.argsort(g_idx)
             x = safe_permute(x, perm, dim=1)
 
-        x = torch.reshape(
-            x,
-            (
-                x.shape[0],
-                ceil(x.shape[1] / group_size),
-                group_size,
-            ),
-        )
+        if len(x.shape) > 2:
+            x = torch.reshape(
+                x,
+                (
+                    x.shape[0],
+                    x.shape[1],
+                    ceil(x.shape[-1] / group_size),
+                    group_size,
+                ),
+            )
+        else:
+              x = torch.reshape(
+                x,
+                (
+                    x.shape[0],
+                    ceil(x.shape[-1] / group_size),
+                    group_size,
+                ),
+            )
 
         if do_quantize:
             output = _quantize(
@@ -323,18 +335,24 @@ def _process_quantization(
                 global_scale=global_scale,
             )
 
-        output = torch.reshape(
-            output,
-            (output.shape[0], output.shape[1] * output.shape[2]),
-        )
+        if len(x.shape) > 3:
+            output = torch.reshape(
+                output,
+                (output.shape[0], output.shape[1], output.shape[-1] * output.shape[-2]),
+            )
+        else:
+            output = torch.reshape(
+                output,
+                (output.shape[0], output.shape[-1] * output.shape[-2]),
+            )
 
         output = output.to(output_dtype)
 
         if not is_column_order:
             output = safe_permute(output, torch.argsort(perm), dim=1)
 
-        if len(n_dims) > 2:
-            output = output.unsqueeze(0)
+        #if len(n_dims) > 2:
+        #    output = output.unsqueeze(0)
 
     else:  # covers channel, token and tensor strategies
         if do_quantize:

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -167,7 +167,7 @@ def compute_dynamic_scales_and_zp(
 
     keep_dims = True
     if args.strategy == QuantizationStrategy.TOKEN:
-        dim = {0, 1, 2}
+        dim = {1, 2}
         reduce_dims = tuple(idx for idx in range(value.ndim) if idx not in dim)
     elif args.strategy == QuantizationStrategy.TENSOR:
         reduce_dims = None
@@ -176,13 +176,8 @@ def compute_dynamic_scales_and_zp(
         QuantizationStrategy.GROUP,
     ):
 
-        if len(value.shape) > 2:
-            dim = {0, 1, 2}
-        else:
-            dim = {0, 1}
-
         reduce_dims = tuple(
-            idx for idx in range(len(value.shape) + 1) if idx not in dim
+            idx for idx in range(len(value.shape) + 1) if idx not in range(value.dim())
         )
         keep_dims = False
 

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -176,16 +176,14 @@ def compute_dynamic_scales_and_zp(
         QuantizationStrategy.GROUP,
     ):
 
-        reduce_dims = tuple(
-            idx for idx in range(len(value.shape) + 1) if idx not in range(value.dim())
-        )
+        reduce_dims = -1
         keep_dims = False
 
-        reshaped_dims = tuple(value.shape[:-1]) + (
+        reshaped_dims = (
             math.ceil(value.shape[-1] / args.group_size),
             args.group_size,
         )
-        value = torch.reshape(value, reshaped_dims)
+        value = value.unflatten(-1, reshaped_dims)
 
     else:
         supported_strategies = (

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -175,35 +175,23 @@ def compute_dynamic_scales_and_zp(
         QuantizationStrategy.TENSOR_GROUP,
         QuantizationStrategy.GROUP,
     ):
-        #if len(value.shape) > 2:
-        #    value = value.squeeze(0)
+
         if len(value.shape) > 2:
             dim = {0, 1, 2}
         else:
             dim = {0, 1}
 
-        reduce_dims = tuple(idx for idx in range(len(value.shape) + 1) if idx not in dim)
+        reduce_dims = tuple(
+            idx for idx in range(len(value.shape) + 1) if idx not in dim
+        )
         keep_dims = False
 
-        if len(value.shape) > 2:
-            value = torch.reshape(
-                value,
-                (
-                    value.shape[0],
-                    value.shape[1],
-                    math.ceil(value.shape[-1] / args.group_size),
-                    args.group_size,
-                ),
-            )
-        else:
-            value = torch.reshape(
-                value,
-                (
-                    value.shape[0],
-                    math.ceil(value.shape[-1] / args.group_size),
-                    args.group_size,
-                ),
-            )
+        reshaped_dims = tuple(value.shape[:-1]) + (
+            math.ceil(value.shape[-1] / args.group_size),
+            args.group_size,
+        )
+        value = torch.reshape(value, reshaped_dims)
+
     else:
         supported_strategies = (
             QuantizationStrategy.TOKEN,

--- a/tests/test_quantization/test_utils/test_helpers.py
+++ b/tests/test_quantization/test_utils/test_helpers.py
@@ -83,7 +83,7 @@ def test_fused_global_scales():
     "shape,group_size,exp_shape",
     [
         # Only batch size =1 is supported for dynamic GROUP quantization
-        ((1, 4, 8), 4, torch.Size([4, 2])),
+        ((1, 4, 8), 4, torch.Size([1, 4, 2])),
     ],
 )
 def test_compute_dynamic_scales_and_zp_group(shape, group_size, exp_shape):


### PR DESCRIPTION
- Add compression info for nvfp4 to support decompression with CompressedLinear
- Update to support batch_size > 1 when running QDQ for tensor_group / group dynamic activations - this is done by updatng the reshape command to be generic such that all dimensions are maintained apart from the last / group_dim which has to be reshaped for QDQ
