### PR TITLE
Fix block size inference logic

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -124,8 +124,13 @@ def dequantize(
                     strategy=QuantizationStrategy.GROUP, group_size=group_size
                 )
             else:
+                rows, cols = x_q.shape[-2], x_q.shape[-1]
+                block_height = rows // scale.shape[0]  # Rows per block
+                block_width = cols // scale.shape[1]   # Columns per block
+
                 args = QuantizationArgs(
-                    strategy=QuantizationStrategy.BLOCK, block_structure=scale.shape
+                    strategy=QuantizationStrategy.BLOCK,
+                    block_structure=[block_height, block_width],
                 )
         else:
             raise ValueError(

--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -126,7 +126,7 @@ def dequantize(
             else:
                 rows, cols = x_q.shape[-2], x_q.shape[-1]
                 block_height = rows // scale.shape[0]  # Rows per block
-                block_width = cols // scale.shape[1]   # Columns per block
+                block_width = cols // scale.shape[1]  # Columns per block
 
                 args = QuantizationArgs(
                     strategy=QuantizationStrategy.BLOCK,


### PR DESCRIPTION
## Fix Block Quantization Structure Inference

### Problem
The `dequantize` function incorrectly used `scale.shape` directly as `block_structure`.

### Solution
Calculate actual block dimensions from tensor and scale shapes:

### Impact
- Fixes garbage output in decompressed models using block quantization
- Ensures correct block structure interpretation during dequantization