### PR TITLE
[Utils]

### DIFF
--- a/src/compressed_tensors/transform/factory/base.py
+++ b/src/compressed_tensors/transform/factory/base.py
@@ -14,7 +14,7 @@
 
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import List, Optional, Tuple, Set
+from typing import List, Optional, Set, Tuple
 
 import torch
 import torch.nn.utils.parametrize as P

--- a/tests/test_utils/test_match.py
+++ b/tests/test_utils/test_match.py
@@ -201,14 +201,20 @@ class TestIsMatch:
             "gate_up_proj": ["gate_proj", "up_proj"],
         }
 
-        assert is_match("dummy.qkv_proj", linear, "re:.*q_proj", mapping) == True
-        assert is_match("dummy.qkv_proj", linear, "re:.*k_proj", mapping) == True
-        assert is_match("dummy.qkv_proj", linear, "re:.*v_proj", mapping) == True
-        assert is_match("dummy.qkv_proj", linear, "Linear", mapping) == True
+        assert is_match("dummy.qkv_proj", linear, "re:.*q_proj", fused=mapping) == True
+        assert is_match("dummy.qkv_proj", linear, "re:.*k_proj", fused=mapping) == True
+        assert is_match("dummy.qkv_proj", linear, "re:.*v_proj", fused=mapping) == True
+        assert is_match("dummy.qkv_proj", linear, "Linear", fused=mapping) == True
 
-        assert is_match("dummy.gate_up_proj", linear, "re:.*gate_proj", mapping) == True
-        assert is_match("dummy.gate_up_proj", linear, "re:.*up_proj", mapping) == True
-        assert is_match("dummy.gate_up_proj", linear, "Linear", mapping) == True
+        assert (
+            is_match("dummy.gate_up_proj", linear, "re:.*gate_proj", fused=mapping)
+            == True
+        )
+        assert (
+            is_match("dummy.gate_up_proj", linear, "re:.*up_proj", fused=mapping)
+            == True
+        )
+        assert is_match("dummy.gate_up_proj", linear, "Linear", fused=mapping) == True
 
 
 class TestMatchNamedModules:


### PR DESCRIPTION
## Purpose ##
* Make module matching in vLLM a little cleaner

## Changes ##
* Change function signature of `is_match` to the following:
```python3
def is_match(
    name: str,
    module: torch.nn.Module,
    targets: str | Iterable[str],
    ignore: str | Iterable[str] = tuple(),
    fused: Optional[FusedMappping] = None,
)
```

## Testing ##
* Matching tests pass