### PR TITLE
added wrapper for execution device

### DIFF
--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -179,7 +179,14 @@ def get_execution_device(module: torch.nn.Module) -> torch.device:
     """
     for submodule in module.modules():
         if has_offloaded_params(submodule):
-            return submodule._hf_hook.execution_device
+            if isinstance(submodule._hf_hook.execution_device, int):
+                return torch.device(
+                    f"cuda:{submodule._hf_hook.execution_device}"
+                    if submodule._hf_hook.execution_device >= 0
+                    else "cpu"
+                )
+            else:
+                return submodule._hf_hook.execution_device
 
         param = next(submodule.parameters(recurse=False), None)
         if param is not None:

--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -86,6 +86,7 @@ __all__ = [
     "offloaded_dispatch",
     "disable_offloading",
     "remove_dispatch",
+    "cast_to_device",
 ]
 
 
@@ -169,6 +170,19 @@ def update_parameter_data(
 """ Candidates for Upstreaming """
 
 
+def cast_to_device(device_spec: Union[int, torch.device]) -> torch.device:
+    """
+    Convert an integer device index or torch.device into a torch.device object.
+
+    :param device_spec: Device index (int) or torch.device object.
+                        Negative integers map to CPU.
+    :return: torch.device corresponding to the given device specification.
+    """
+    if isinstance(device_spec, int):
+        return torch.device(f"cuda:{device_spec}" if device_spec >= 0 else "cpu")
+    return device_spec
+
+
 def get_execution_device(module: torch.nn.Module) -> torch.device:
     """
     Get the device which inputs should be moved to before module execution.
@@ -179,14 +193,7 @@ def get_execution_device(module: torch.nn.Module) -> torch.device:
     """
     for submodule in module.modules():
         if has_offloaded_params(submodule):
-            if isinstance(submodule._hf_hook.execution_device, int):
-                return torch.device(
-                    f"cuda:{submodule._hf_hook.execution_device}"
-                    if submodule._hf_hook.execution_device >= 0
-                    else "cpu"
-                )
-            else:
-                return submodule._hf_hook.execution_device
+            return cast_to_device(submodule._hf_hook.execution_device)
 
         param = next(submodule.parameters(recurse=False), None)
         if param is not None:


### PR DESCRIPTION
## Issue
Device type error encountered 
```
      is_meta = module_device.type == "meta"
  AttributeError: 'int' object has no attribute 'type'
```

## Changes
Added wrapper to make sure that `get_execution_device` always returns `torch.device`. 

## Test
Tested the failed test locally. 
```
pytest tests/examples/test_quantizing_moe.py::TestQuantizingMOE::test_deepseek_example_script[mixtral_example.py]
============================================================================================= test session starts =============================================================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/hzhao/llm-compressor
configfile: pyproject.toml
plugins: anyio-4.9.0, rerunfailures-15.0, mock-3.14.0
collected 1 item                                                                                                                                                                                              

tests/examples/test_quantizing_moe.py .                                                                                                                                                                 [100%]

======================================================================================= 1 passed in 1053.05s (0:17:33) ========================================================================================
```