### PR TITLE
revert forbid constraint on QuantizationConfig

### DIFF
--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -258,4 +258,5 @@ class QuantizationConfig(BaseModel):
 
         return False
 
-    model_config = ConfigDict(extra="forbid")
+    # TODO set `extra="forbid"` when upstream transformers is compatible
+    model_config = ConfigDict(extra="ignore")


### PR DESCRIPTION
#386 added constraints to pydantic base models to disallow extraneous inputs. This breaks upstream transformers, which passes in `**kwargs` to `QuantizationConfig.model_validate` [here](https://github.com/huggingface/transformers/blob/v4.55.0/src/transformers/utils/quantization_config.py#L1338-L1347).

This PR loosens the constraint to allow for extraneous inputs just on `QuantizationConfig`, to unblock failing ci/cd tests in llm-compressor until this can be changed in a follow-up PR to transformers