### PR TITLE
exclude transform_config from quantization_config parse

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -207,7 +207,7 @@ class ModelCompressor:
 
     @staticmethod
     def parse_sparsity_config(
-        compression_config: Union[Dict[str, Any], "CompressedTensorsConfig"]
+        compression_config: Union[Dict[str, Any], "CompressedTensorsConfig"],
     ) -> Union[Dict[str, Any], None]:
         """
         Parse sparsity config from quantization/compression config. Sparsity
@@ -227,7 +227,7 @@ class ModelCompressor:
 
     @staticmethod
     def parse_quantization_config(
-        compression_config: Union[Dict[str, Any], "CompressedTensorsConfig"]
+        compression_config: Union[Dict[str, Any], "CompressedTensorsConfig"],
     ) -> Union[Dict[str, Any], None]:
         """
         Parse quantization config from quantization/compression config. The
@@ -246,6 +246,7 @@ class ModelCompressor:
 
         quantization_config = deepcopy(compression_config)
         quantization_config.pop(SPARSITY_CONFIG_NAME, None)
+        quantization_config.pop(TRANSFORM_CONFIG_NAME, None)
 
         # some fields are required, even if a qconfig is not present
         # pop them off and if nothing remains, then there is no qconfig


### PR DESCRIPTION
`transform_config` was added to `compression_config`, but was not excluded when `compression_config` is parsed into `quantization_config`, causing downstream errors in `llm-compressors` transformers tests (example [here](https://github.com/vllm-project/llm-compressor/actions/runs/16912004476/job/47918117207?pr=1722#step:13:167)). This fix resolves that.