### PR TITLE
remove references to `llmcompressor.transformers.oneshot` in examples

### DIFF
--- a/examples/llama_1.1b/ex_llmcompressor_quantization.py
+++ b/examples/llama_1.1b/ex_llmcompressor_quantization.py
@@ -24,7 +24,7 @@
 from pathlib import Path
 
 import torch
-from llmcompressor.transformers import oneshot
+from llmcompressor import oneshot
 
 
 recipe = str(Path(__file__).parent / "example_quant_recipe.yaml")


### PR DESCRIPTION
Remove references to deprecated `llmcompressor.transformers.oneshot`