### PR TITLE
fix format type

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -169,7 +169,7 @@ class ModelCompressor:
         cls,
         model: Module,
         sparsity_config: Union[SparsityCompressionConfig, str, None] = None,
-        quantization_format: Optional[Union[str, List[str]]] = None,
+        quantization_format: Optional[Union[str, CompressionFormat, List[str], List[CompressionFormat]]] = None,
     ) -> Optional["ModelCompressor"]:
         """
         Given a pytorch model and optional sparsity and/or quantization configs,
@@ -203,7 +203,7 @@ class ModelCompressor:
             quantization_config=quantization_config,
             transform_config=transform_config,
             compression_formats=[quantization_format]
-            if isinstance(quantization_format, str)
+            if not isinstance(quantization_format, list)
             else quantization_format,
         )
 
@@ -315,10 +315,11 @@ class ModelCompressor:
 
             self.quantization_compressor = {}
             for format in self.compression_formats:
+                name = format.value if isinstance(format, CompressionFormat) else format
                 self.quantization_compressor[
                     format
                 ] = BaseCompressor.load_from_registry(
-                    format, config=quantization_config
+                    name, config=quantization_config
                 )
 
     # ----- used by hf quantizer ----- #


### PR DESCRIPTION
The commit #415 breaks the llm-compressor save_pretrain
To reproduce it, run the [llm-compressor example](https://github.com/jiqing-feng/llm-compressor/blob/main/examples/quantization_w4a16/llama3_example.py)
`python llama3_example.py`
error:
```
Traceback (most recent call last):
  File "/home/sdp/jiqing/llm-compressor/examples/awq/llama_example.py", line 74, in <module>
    model.save_pretrained(SAVE_DIR, save_compressed=True)
  File "/home/sdp/jiqing/llm-compressor/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py", line 87, in save_pretrained_wrapper
    compressor = get_model_compressor(
                 ^^^^^^^^^^^^^^^^^^^^^
  File "/home/sdp/jiqing/llm-compressor/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py", line 240, in get_model_compressor
    return ModelCompressor.from_pretrained_model(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/compressed_tensors/compressors/model_compressors/model_compressor.py", line 201, in from_pretrained_model
    return cls(
           ^^^^
  File "/opt/venv/lib/python3.12/site-packages/compressed_tensors/compressors/model_compressors/model_compressor.py", line 317, in __init__
    for format in self.compression_formats:
TypeError: 'CompressionFormat' object is not iterable
```

The reason is that the llm-compressor pass `quantization_format` as a `CompressionFormat` instead of `str` [here](https://github.com/vllm-project/llm-compressor/blob/main/src/llmcompressor/transformers/sparsification/compressed_tensors_utils.py#L231).

The [BaseCompressor.load_from_registry](https://github.com/neuralmagic/compressed-tensors/blob/main/src/compressed_tensors/compressors/model_compressors/model_compressor.py#L320-L321) can only accept `str` type, so we need to convert it.

After this PR, the save issue can be fixed.