### PR TITLE
[Offload] Fully remove dispatch

### DIFF
--- a/src/compressed_tensors/utils/offload.py
+++ b/src/compressed_tensors/utils/offload.py
@@ -579,6 +579,7 @@ def remove_dispatch(module: torch.nn.Module) -> torch.nn.Module:
     remove_hook_from_module(module, recurse=True)
     if hasattr(module, "hf_device_map"):
         delattr(module, "hf_device_map")
+    module.to("cpu")
 
     return module
 


### PR DESCRIPTION
## Purpose ##
* Fix bug where `remove_dispatch` would not remove dispatches from models which do not use `_hf_device_hook`s
* Consistently removed dispatches from models, even if the model was dispatched to only one GPU

## Changes ##
* Explicitly move model to CPU when removing dispatch

## Testing ##
Able to remove explicit device movement from https://github.com/vllm-project/llm-compressor/pull/1744