### PR TITLE
Install compilers etc to fix nightly test failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,10 @@ jobs:
               with:
                   python-version: ${{ inputs.python }}
 
+            - name: install system dependencies
+              run: sudo apt update && sudo apt install -y g++ gcc git-all
+              shell: bash
+
             - name: checkout code
               id: checkout
               uses: actions/checkout@v4


### PR DESCRIPTION
Add a step in the test workflow to install g++ compiler etc to solve a nightly test failure that's due to introduction of torch.compile in the code.