### PR TITLE
Fix a minor bug on GH hosted runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,13 @@ jobs:
                   python-version: ${{ inputs.python }}
 
             - name: install system dependencies
-              run: sudo apt update && sudo apt install -y g++ gcc git-all
+              run: |
+                if command -v g++ >/dev/null 2>&1; then
+                  echo "found g++ compiler"
+                else
+                   echo "installing g++ etc compilers..."
+                   sudo apt update && sudo apt install -y g++ gcc
+                fi
               shell: bash
 
             - name: checkout code


### PR DESCRIPTION
Fix failure on GH hosted runners and only install the g++ compiler etc when the compiler is not found.

A run is here: https://github.com/neuralmagic/compressed-tensors/actions/runs/17300320423/job/49109425527