### PR TITLE
[Quantization] Allow dynamic group activation quantization

### DIFF
--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -71,7 +71,8 @@ class QuantizationScheme(BaseModel):
                     and inputs.dynamic is True
                 ):
                     raise NotImplementedError(
-                        "Static and local group-wise quantization is not supported"
+                        "Static and local group-wise activation "
+                        "quantization is not supported"
                     )
 
                 raise NotImplementedError(


### PR DESCRIPTION
## Purpose ##
* Correct mistake [here](https://github.com/neuralmagic/compressed-tensors/pull/446) where dynamic grouop activation quantization is enabled for block quantization schemes