### PR TITLE
Update format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ def _setup_packages() -> List:
     )
 
 def _setup_install_requires() -> List:
-    return ["torch>=1.7.0", "transformers", "pydantic>=2.0", "frozendict"]
+    return ["torch>=1.7.0", "transformers", "pydantic>=2.0", "frozendict", "loguru"]
 
 def _setup_extras() -> Dict:
     return {

--- a/src/compressed_tensors/config/__init__.py
+++ b/src/compressed_tensors/config/__init__.py
@@ -15,6 +15,6 @@
 # flake8: noqa
 from .base import *
 from .dense import *
+from .format import *
 from .sparse_24_bitmask import *
 from .sparse_bitmask import *
-from .format import *

--- a/src/compressed_tensors/config/__init__.py
+++ b/src/compressed_tensors/config/__init__.py
@@ -17,3 +17,4 @@ from .base import *
 from .dense import *
 from .sparse_24_bitmask import *
 from .sparse_bitmask import *
+from .format import *

--- a/src/compressed_tensors/config/format.py
+++ b/src/compressed_tensors/config/format.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import torch
 from compressed_tensors.config import CompressionFormat, SparsityStructure
@@ -116,7 +116,7 @@ def set_per_module_format(
 def infer_and_set_per_module_quantization_format(
     model: torch.nn.Module,
     sparsity_structure: Optional[str] = None,
-) -> Optional[List[str]]:
+) -> Union[str, List[str]]:
     """
     Infers the quantization format for a model based on its state and provided
     compression arguments. Updates thhe quantization_scheme.format value
@@ -138,4 +138,4 @@ def infer_and_set_per_module_quantization_format(
 
     if len(unique_formats) > 0:
         return unique_formats
-    return None
+    return CompressionFormat.dense.value

--- a/src/compressed_tensors/config/format.py
+++ b/src/compressed_tensors/config/format.py
@@ -1,7 +1,20 @@
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import List, Optional
 
-from compressed_tensors import CompressionFormat
-from compressed_tensors.config import SparsityStructure
+from compressed_tensors.config import CompressionFormat, SparsityStructure
 from compressed_tensors.quantization import (
     QuantizationArgs,
     QuantizationStrategy,
@@ -9,6 +22,7 @@ from compressed_tensors.quantization import (
 )
 from compressed_tensors.quantization.utils import is_module_quantized
 from loguru import logger
+
 
 __all__ = ["infer_and_set_per_module_quantization_format"]
 

--- a/src/compressed_tensors/config/format.py
+++ b/src/compressed_tensors/config/format.py
@@ -32,10 +32,10 @@ def _get_quant_compression_format(
     input_args: QuantizationArgs,
     weight_args: QuantizationArgs,
     sparsity_structure: Optional[str] = None,
-) -> CompressionFormat: 
+) -> CompressionFormat:
     """
     Using the weight and input quantization args as well as an optional
-    sparsity structure, determine the compression format that should be 
+    sparsity structure, determine the compression format that should be
     applied to a given module
 
     :param input_args: input quantization parameters

--- a/src/compressed_tensors/config/format.py
+++ b/src/compressed_tensors/config/format.py
@@ -1,0 +1,114 @@
+from typing import List, Optional
+
+from compressed_tensors import CompressionFormat
+from compressed_tensors.config import SparsityStructure
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationStrategy,
+    QuantizationType,
+)
+from compressed_tensors.quantization.utils import is_module_quantized
+from loguru import logger
+
+__all__ = ["infer_and_set_per_module_quantization_format"]
+
+
+def _get_quant_compression_format(
+    input_args: QuantizationArgs,
+    weight_args: QuantizationArgs,
+    sparsity_structure: Optional[str] = None,
+):
+    is_24_structure = (
+        SparsityStructure(sparsity_structure) == SparsityStructure.TWO_FOUR
+    )
+    is_weight_only = weight_args is not None and input_args is None
+
+    if weight_args.num_bits == 4 and weight_args.type == QuantizationType.FLOAT.value:
+        return CompressionFormat.nvfp4_pack_quantized
+
+    if is_weight_only:  # w4a16 and w8a16
+        is_valid_pack = (
+            weight_args.num_bits in [4, 8]
+            and weight_args.type == QuantizationType.INT.value
+        )
+        if not is_valid_pack:  # packing only valid for int4 and int 8
+            return CompressionFormat.naive_quantized
+        if is_24_structure:
+            if (
+                weight_args.strategy is not QuantizationStrategy.CHANNEL.value
+                and weight_args.strategy is not QuantizationStrategy.GROUP.value
+            ):
+                # marlin24 kernel only applicable for channel/group quantization
+                return CompressionFormat.pack_quantized
+            return CompressionFormat.marlin_24
+        return CompressionFormat.pack_quantized
+
+    else:  # w8a8 float and int
+        if (
+            weight_args.type == QuantizationType.FLOAT.value
+            and weight_args.num_bits == 8
+        ):
+            return CompressionFormat.float_quantized
+        if weight_args.type == QuantizationType.INT.value:
+            return CompressionFormat.int_quantized
+
+        return CompressionFormat.naive_quantized
+
+
+def infer_and_set_per_module_quantization_format(
+    model,
+    quantization_format: Optional[str] = None,
+    save_compressed: bool = False,
+    sparsity_structure: Optional[str] = None,
+) -> Optional[List[str]]:
+    """
+    Infers the quantization format for a model based on its state and provided
+    compression arguments. Also updates thhe quantization_scheme.format value
+    based on the inferred format. Returns the unique list of formats in the model
+    or None if empty list
+
+    For a summary of the formats, see `docs/guides/compression_formats.md`.
+
+    :param model: model to check for quantization, if the model is not quantized no
+        quantization format is returned
+    :param quantization_format: user provided quantization format, supercedes any
+        inferred quantization format
+    :param save_compressed: used to infer a quantization format if None is provided
+    :return compression format appropriate for model
+    """
+
+    if not save_compressed:
+        return None
+
+    if quantization_format:
+        return [quantization_format]
+
+    unique_formats = []
+    for submodule in model.modules():
+        if is_module_quantized(submodule):
+            weight_scheme = submodule.quantization_scheme.weights
+            input_scheme = submodule.quantization_scheme.input_activations
+            if weight_scheme is None:
+                continue  # no weight quant - nothing to compress
+            compression_format = _get_quant_compression_format(
+                input_scheme, weight_scheme, sparsity_structure
+            )
+
+            # If set, we check if it matches our inferred one
+            if submodule.quantization_scheme.format is not None:
+                # If it does not, warn the user
+                if submodule.quantization_scheme.format != compression_format.value:
+                    logger.warning(
+                        "The provided format for the module does not match the "
+                        "inferred format. Compression may fail "
+                    )
+            else:
+                # If not set, we set ours
+                submodule.quantization_scheme.format = compression_format.value
+
+            if submodule.quantization_scheme.format not in unique_formats:
+                unique_formats.append(submodule.quantization_scheme.format)
+
+    if len(unique_formats) > 0:
+        return unique_formats
+    return None

--- a/tests/test_configs/test_infer_quant.py
+++ b/tests/test_configs/test_infer_quant.py
@@ -60,6 +60,6 @@ def test_infer_quant_format(preset, sparsity_structure, expected_format):
         module.quantization_scheme = quant_scheme
 
     inferred_format = infer_and_set_per_module_quantization_format(
-        dummy_model, save_compressed=True, sparsity_structure=sparsity_structure
+        dummy_model, sparsity_structure=sparsity_structure
     )
     assert inferred_format[0] == expected_format

--- a/tests/test_configs/test_infer_quant.py
+++ b/tests/test_configs/test_infer_quant.py
@@ -1,10 +1,25 @@
-import pytest
-from compressed_tensors.quantization import preset_name_to_scheme
+# Copyright (c) 2021 - present / Neuralmagic, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-from compressed_tensors.config.formats import (
+from collections import OrderedDict
+
+import pytest
+import torch
+from compressed_tensors.config.format import (
     infer_and_set_per_module_quantization_format,
 )
-import torch
+from compressed_tensors.quantization import preset_name_to_scheme
 
 
 @pytest.mark.parametrize(
@@ -22,14 +37,14 @@ def test_infer_quant_format(preset, sparsity_structure, expected_format):
     quant_scheme = preset_name_to_scheme(preset, targets=["Linear"])
 
     dummy_model = torch.nn.Sequential(
-        torch.nn.OrderedDict(
+        OrderedDict(
             [
-                ("fc1", torch.nnLinear(8, 16, bias=True)),
+                ("fc1", torch.nn.Linear(8, 16, bias=True)),
                 ("fc2", torch.nn.Linear(16, 32, bias=True)),
                 (
                     "block1",
                     torch.nn.Sequential(
-                        torch.nn.OrderedDict(
+                        OrderedDict(
                             [
                                 ("fc1", torch.nn.Linear(32, 16, bias=True)),
                                 ("fc2", torch.nn.Linear(16, 8, bias=True)),

--- a/tests/test_configs/test_infer_quant.py
+++ b/tests/test_configs/test_infer_quant.py
@@ -1,0 +1,50 @@
+import pytest
+from compressed_tensors.quantization import preset_name_to_scheme
+
+from compressed_tensors.config.formats import (
+    infer_and_set_per_module_quantization_format,
+)
+import torch
+
+
+@pytest.mark.parametrize(
+    "preset,sparsity_structure,expected_format",
+    [
+        ["W8A8", "unstructured", "int-quantized"],
+        ["W8A16", "unstructured", "pack-quantized"],
+        ["W8A16", "2:4", "marlin-24"],
+        ["W4A16", "unstructured", "pack-quantized"],
+        ["W4A16", "2:4", "marlin-24"],
+        ["FP8", "unstructured", "float-quantized"],
+    ],
+)
+def test_infer_quant_format(preset, sparsity_structure, expected_format):
+    quant_scheme = preset_name_to_scheme(preset, targets=["Linear"])
+
+    dummy_model = torch.nn.Sequential(
+        torch.nn.OrderedDict(
+            [
+                ("fc1", torch.nnLinear(8, 16, bias=True)),
+                ("fc2", torch.nn.Linear(16, 32, bias=True)),
+                (
+                    "block1",
+                    torch.nn.Sequential(
+                        torch.nn.OrderedDict(
+                            [
+                                ("fc1", torch.nn.Linear(32, 16, bias=True)),
+                                ("fc2", torch.nn.Linear(16, 8, bias=True)),
+                            ]
+                        )
+                    ),
+                ),
+            ]
+        )
+    )
+
+    for _, module in dummy_model.named_modules():
+        module.quantization_scheme = quant_scheme
+
+    inferred_format = infer_and_set_per_module_quantization_format(
+        dummy_model, save_compressed=True, sparsity_structure=sparsity_structure
+    )
+    assert inferred_format[0] == expected_format


### PR DESCRIPTION
# Summary 

Move format infer functionality from llmcompressor to compressed-tensors - https://github.com/vllm-project/llm-compressor/pull/1786

- Simplifies functionality to set the format based on the quant_scheme and sparsity scheme, if a format is not already set by the user
- Use the per module format to determine the global format for the model
- Adds dosctrings
- Add loguru
- Return dense if no format inferred, not None

# Next Steps

We can set the per module format when the quantization scheme is initialized with some work on how we're handling the sparsity config / structure. Will work on simplifying this next to allow this. Otherwise, we currently do it during compression time at the end