### PR TITLE
[Utils] Improve type hints for `deprecated`, only log once

### DIFF
--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import contextlib
-import warnings
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, TypeVar
 

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 import contextlib
+import warnings
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, TypeVar
 
 import numpy
 import torch
 from frozendict import frozendict
-from loguru import logger
 from transformers import AutoConfig
 
 
@@ -195,7 +195,7 @@ def deprecated(
 
         @wraps(func)
         def wrapped(*args, **kwargs):
-            logger.bind(log_once=True).warning(message)
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
             return func(*args, **kwargs)
 
         return wrapped


### PR DESCRIPTION
## Purpose ##
* Support logging deprecation warnings only once for functions which are called many times

## Changes ##
* Use generics type hinting
* Use `logger.bind(log_once=True).warning(message)` to log once

## Testing ##
* Confirmed that deprecation warnings are only called once