### PR TITLE
Fix lint error on main

### DIFF
--- a/tests/test_compressors/quantized_compressors/test_nvfp4_quant.py
+++ b/tests/test_compressors/quantized_compressors/test_nvfp4_quant.py
@@ -54,4 +54,4 @@ def test_pack_unpack_odd_dims():
     )
 
     with pytest.raises((ValueError, torch._dynamo.exc.Unsupported)):
-        _packed = pack_fp4_to_uint8(x)
+        _ = pack_fp4_to_uint8(x)


### PR DESCRIPTION
A lint error made it through CI (likely because it passed tests before the quality checks were added to CI). 