### PR TITLE
Always save g_idx when initialized in quantization compressor

### DIFF
--- a/src/compressed_tensors/compressors/quantized_compressors/base.py
+++ b/src/compressed_tensors/compressors/quantized_compressors/base.py
@@ -129,14 +129,6 @@ class BaseQuantizationCompressor(BaseCompressor):
                 if name.endswith("zero_point") and self._skip_zp(name, names_to_scheme):
                     continue
 
-                # omit saving for g_idx if uninitialized
-                # TODO: does this case actually occur?
-                elif (
-                    name.endswith("g_idx")
-                    and value.device.type != "meta"
-                    and torch.any(value <= -1)
-                ):
-                    continue
                 compressed_dict[name] = value.to(compression_device)
 
         return compressed_dict


### PR DESCRIPTION
## Summary
- Remove conditional skip for `g_idx` saving in `BaseQuantizationCompressor`
- Always save `g_idx` when present since it's only initialized when needed
- Removes TODO comment about whether uninitialized case actually occurs

## Rationale
The `g_idx` parameter is only initialized when it's needed for the quantization scheme. Since the initialization logic already handles when it should be created, there's no need to conditionally skip saving it based on uninitialized values. This simplifies the compression logic and ensures all necessary quantization parameters are preserved.

## Changes
- Removed 8-line conditional block that skipped `g_idx` saving when values were <= -1
- Removed associated TODO comment

Signed-off-by: Rahul Tuli <rtuli@redhat.com>