### PR TITLE
[licensing refactor] remove `frozendict` dependency, use `types.MappingProxyType` instead

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ def _setup_packages() -> List:
     )
 
 def _setup_install_requires() -> List:
-    return ["torch>=1.7.0", "transformers", "pydantic>=2.0", "frozendict", "loguru"]
+    return ["torch>=1.7.0", "transformers", "pydantic>=2.0", "loguru"]
 
 def _setup_extras() -> Dict:
     return {

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -15,8 +15,8 @@
 import contextlib
 import warnings
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, TypeVar
 from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, TypeVar
 
 import numpy
 import torch
@@ -379,7 +379,7 @@ class ParameterizedDefaultDict(dict):
 
     def __init__(self, default_factory: Callable[[Any], Any]):
         self.default_factory = default_factory
-        self._factory_kwargs = MappingProxyType()
+        self._factory_kwargs = MappingProxyType({})
 
     def __missing__(self, key: Any) -> Any:
         if isinstance(key, tuple):
@@ -389,7 +389,7 @@ class ParameterizedDefaultDict(dict):
         self[key] = value
         return value
 
-    def get(self, *args, factory_kwargs: Mapping = MappingProxyType()) -> Any:
+    def get(self, *args, factory_kwargs: Mapping = MappingProxyType({})) -> Any:
         """
         Similar to `__getitem__`, but allows passing kwargs to factory function
 

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -16,10 +16,10 @@ import contextlib
 import warnings
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, TypeVar
+from types import MappingProxyType
 
 import numpy
 import torch
-from frozendict import frozendict
 from transformers import AutoConfig
 
 
@@ -379,7 +379,7 @@ class ParameterizedDefaultDict(dict):
 
     def __init__(self, default_factory: Callable[[Any], Any]):
         self.default_factory = default_factory
-        self._factory_kwargs = frozendict()
+        self._factory_kwargs = MappingProxyType()
 
     def __missing__(self, key: Any) -> Any:
         if isinstance(key, tuple):
@@ -389,7 +389,7 @@ class ParameterizedDefaultDict(dict):
         self[key] = value
         return value
 
-    def get(self, *args, factory_kwargs: Mapping = frozendict()) -> Any:
+    def get(self, *args, factory_kwargs: Mapping = MappingProxyType()) -> Any:
         """
         Similar to `__getitem__`, but allows passing kwargs to factory function
 


### PR DESCRIPTION
Resolves #468 

As described in
* #468 

`frozendict` has a license that breaks downstream allowlists, preventing some users from upgrading to current version of `compressed-tensors`. This removes that dependency, instead using `types.MappingProxyType`, a read-only view to a dictionary that is part of stdlib. `frozendict` was only used in a single file, so this ended up being a minimal change.