### PR TITLE
[Transform] Revert deprecation of `TransformScheme.head_dim` for compatibility with vllm

### DIFF
--- a/src/compressed_tensors/transform/factory/hadamard.py
+++ b/src/compressed_tensors/transform/factory/hadamard.py
@@ -52,7 +52,7 @@ class HadamardFactory(TransformFactory):
         :param args: defines how the transform will be applied to the module
         """
         assert hasattr(module, "weight")
-        size = get_transform_size(module, args.location, self.scheme.block_size)
+        size = get_transform_size(module, args.location, self.scheme.head_dim)
         exec_device = get_execution_device(module)
         device = get_offloaded_device(module)
         precision = self.scheme.precision if args.is_online() else torch.float64

--- a/src/compressed_tensors/transform/factory/matrix_multiply.py
+++ b/src/compressed_tensors/transform/factory/matrix_multiply.py
@@ -51,7 +51,7 @@ class RandomMatrixFactory(TransformFactory):
         :param args: defines how the transform will be applied to the module
         """
         assert hasattr(module, "weight")
-        size = get_transform_size(module, args.location, self.scheme.block_size)
+        size = get_transform_size(module, args.location, self.scheme.head_dim)
         device = get_offloaded_device(module)
         precision = self.scheme.precision if args.is_online() else torch.float64
 

--- a/src/compressed_tensors/transform/transform_scheme.py
+++ b/src/compressed_tensors/transform/transform_scheme.py
@@ -47,10 +47,12 @@ class TransformScheme(BaseModel):
     randomize: bool = Field(default=False)
     requires_grad: bool = Field(default=False)
     block_size: Optional[int] = Field(default=None)
-    # NOTE: head_dim is deprecated, but cannot be tagged as such because it will
-    # raise a warnings.warn that torch dynamo cannot trace when used in vllm
+    # NOTE: head_dim is deprecated in favor of the more appropriate block_size,
+    # but cannot be tagged as such because it will a warnings.warn that
+    # torch dynamo cannot trace when used in vllm
     head_dim: Optional[int] = Field(
         default=None,
+        exclude=True,
         # TODO: Deprecate once references to head_dim are removed in vllm
         # deprecated="head_dim is deprecated, use block_size instead"
     )
@@ -61,7 +63,7 @@ class TransformScheme(BaseModel):
         """
         Default to block_size if it set, otherwise use deprecated head_dim
         if it is set and block_size is not.
-        Set both values because block_sizse is preferred but vllm currently
+        Set both values because block_size is preferred but vllm currently
         uses head_dim.
         """
         if model.block_size is not None:

--- a/src/compressed_tensors/transform/transform_scheme.py
+++ b/src/compressed_tensors/transform/transform_scheme.py
@@ -36,10 +36,11 @@ class TransformScheme(BaseModel):
     :param randomize: True if uniquely randomized transform weights should be used,
         otherwise use identical transform weights where applicable
     :param requires_grad: True if weights include gradients for training
-    :param head_dim: If set, the transform matrix will be block diagonal, with each
-        block being a square matrix of this size. The name head_dim was used because
-        some rotations need to be block-diagonal with block_size equal to the head_dim,
-        but research has shown value in applying some rotations with smaller block_size
+    :param head_dim: If set, the transform matrix will be block diagonal with each
+        block being a square matrix of this size. The name head_dim was chosen because
+        some rotations need to be block-diagonal with block size equal to the head_dim,
+        but research has shown value in applying some rotations with smaller block size,
+        irrespective of head_dim.
     :param precision: Precision at which this transform should be applied during online
         rotations. Fused (offline) rotations are always performed in float64
     """

--- a/tests/test_transform/factory/test_correctness.py
+++ b/tests/test_transform/factory/test_correctness.py
@@ -33,7 +33,7 @@ from tests.testing_utils import requires_accelerate, requires_gpu
 def test_correctness_linear(type, randomize, head_dim, input_batch_size):
     size = (4, 8)
     module = torch.nn.Linear(*size, bias=False)
-    scheme = TransformScheme(type=type, randomize=randomize, block_size=head_dim)
+    scheme = TransformScheme(type=type, randomize=randomize, head_dim=head_dim)
     factory = TransformFactory.from_scheme(scheme, name="")
 
     input_tfm = factory.create_transform(
@@ -150,7 +150,7 @@ def test_correctness_attention_heads(type, randomize, head_dim, input_batch_size
             "": TransformScheme(
                 type=type,
                 randomize=randomize,
-                block_size=head_dim,
+                head_dim=head_dim,
                 apply=[
                     TransformArgs(targets="v_proj", location="weight_output"),
                     TransformArgs(

--- a/tests/test_transform/test_transform_scheme.py
+++ b/tests/test_transform/test_transform_scheme.py
@@ -72,28 +72,3 @@ def test_multiple_groups():
     assert not scheme.randomize
     assert scheme.type == "hadamard"
     assert len(scheme.apply) == 20
-
-
-def test_transform_scheme_block_size():
-    """
-    Ensure json with (deprecated) `head_dim` or `block_size`
-    both load up correctly and save with `block_size` field
-    """
-
-    old_scheme = TransformScheme.model_validate_json(
-        '{"type": "hadamard", "head_dim": 128}'
-    )
-    assert old_scheme.block_size == 128
-    assert old_scheme.model_dump()["block_size"] == 128
-    old_scheme = TransformScheme(type="hadamard", head_dim=64)
-    assert old_scheme.block_size == 64
-    assert old_scheme.model_dump()["block_size"] == 64
-
-    new_scheme = TransformScheme.model_validate_json(
-        '{"type": "hadamard", "block_size": 128}'
-    )
-    assert new_scheme.block_size == 128
-    assert new_scheme.model_dump()["block_size"] == 128
-    new_scheme = TransformScheme(type="hadamard", block_size=64)
-    assert new_scheme.block_size == 64
-    assert new_scheme.model_dump()["block_size"] == 64


### PR DESCRIPTION
We deprecated `TransformScheme.head_dim` in favor of `block_size` in #466 , but vllm still references `head_dim` [here](https://github.com/vllm-project/vllm/blob/3468f17ebe4daf19ff120d95eebde48f59d7cac2/vllm/model_executor/layers/quantization/compressed_tensors/transform/module.py#L90). 

This PR reverts the deprecation because it is not worth the pain of resolving a name change in vllm, which would require several steps:
1. Fix CT so that head_dim can still be used, release a CT v0.12 
2. Upgrade vllm's CT dependency to v0.12
3. Then change all references of `head_dim` to `block_size` in vllm src.
4. Then we can remove the CT changes introduced in this PR

Merge in conjunction with:
* https://github.com/vllm-project/llm-compressor/pull/1870