### PR TITLE
Hadamard - padding size to 2^N

### DIFF
--- a/src/compressed_tensors/transform/factory/hadamard.py
+++ b/src/compressed_tensors/transform/factory/hadamard.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from typing import List, Optional
 
 import torch
@@ -74,8 +73,11 @@ class HadamardFactory(TransformFactory):
         construct_device: device,
         precision: dtype,
     ) -> Parameter:
-        data = deterministic_hadamard_matrix(size, precision, construct_device)
-        data = data.to(device=device)
+        maybe_padded_size = 1 << (size - 1).bit_length()
+        data_full = deterministic_hadamard_matrix(maybe_padded_size, precision, construct_device)
+        data = data_full[:size, :size]
+        if construct_device != device:
+            data = data.to(device=device)
         return Parameter(data, requires_grad=self.scheme.requires_grad)
 
     def _create_permutation(self, weight: Parameter) -> Parameter:

--- a/src/compressed_tensors/transform/factory/hadamard.py
+++ b/src/compressed_tensors/transform/factory/hadamard.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from typing import List, Optional
 
 import torch


### PR DESCRIPTION
Applying SpinQuant to the Qwen model failed because the `out_features` size is `3584,` which is not a power of 2. Would it be possible to resolve this issue via a patch, or are there other considerations to take into account?

The error is as below and it will be fixed if the patch is applied.

```
File "/mnt/user/bob/.quant/lib/python3.12/site-packages/llmcompressor/modifiers/transform/spinquant/base.py", line 147, in on_start apply_transform_config(state.model, self.transform_config) 
File "/mnt/user/bob/.quant/lib/python3.12/site-packages/compressed_tensors/transform/apply.py", line 33, in apply_transform_config factory.apply_to_model(model) 
File "/mnt/user/bob/.quant/lib/python3.12/site-packages/compressed_tensors/transform/factory/base.py", line 95, in apply_to_model self._apply_to_module(module, arg) 
File "/mnt/user/bob/.quant/lib/python3.12/site-packages/compressed_tensors/transform/factory/base.py", line 115, in _apply_to_module transform = self.create_transform(module, args) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
File "/mnt/user/bob/.quant/lib/python3.12/site-packages/compressed_tensors/transform/factory/hadamard.py", line 61, in create_transform weight = self.weights.get(size, dtype, device, factory_kwargs=factory_kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
File "/mnt/user/bob/.quant/lib/python3.12/site-packages/compressed_tensors/utils/helpers.py", line 396, in get return self[args] ~~~~^^^^^^ File "/mnt/user/bob/.quant/lib/python3.12/site-packages/compressed_tensors/utils/helpers.py", line 381, in __missing__ value = self.default_factory(*key, **self._factory_kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
File "/mnt/user/bob/.quant/lib/python3.12/site-packages/compressed_tensors/transform/factory/hadamard.py", line 73, in _create_weight data = deterministic_hadamard_matrix(size, dtype, construct_device) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
File "/mnt/user/bob/.quant/lib/python3.12/site-packages/compressed_tensors/transform/utils/hadamard.py", line 54, in deterministic_hadamard_matrix raise ValueError("Cannot construct deterministic hadamard of size != 2^n") 
ValueError: Cannot construct deterministic hadamard of size != 2^n
```