### PR TITLE
Add back get unexpected keys to support transformers lower bound

### DIFF
--- a/tests/test_compressors/model_compressors/test_model_compressor.py
+++ b/tests/test_compressors/model_compressors/test_model_compressor.py
@@ -451,6 +451,41 @@ def test_multiple_quant_compressors():
 
 
 @pytest.mark.parametrize(
+    "model, sparsity_config, quantization_config, expected",
+    [
+        (
+            TwoLayerModel(),
+            get_bitmask_sparsity_config(targets=["re:.*layer1$"]),
+            create_quantization_config(bits=8, type="int", strategy="channel"),
+            {
+                f"{layer}.{suffix}"
+                for layer, suffixes in {
+                    "layer1": [
+                        "shape",
+                        "row_offsets",
+                        "weight_zero_point",
+                        "weight_g_idx",
+                        "bitmask",
+                        "weight_scale",
+                        "compressed",
+                    ],
+                    "layer2": ["weight_scale", "weight_zero_point", "weight_g_idx"],
+                }.items()
+                for suffix in suffixes
+            },
+        )
+    ],
+)
+def test_get_unexpected_keys(model, sparsity_config, quantization_config, expected):
+    model_compressor = ModelCompressor(
+        sparsity_config=sparsity_config, quantization_config=quantization_config
+    )
+
+    actual = model_compressor.get_unexpected_file_keys(model)
+    assert len(actual) == len(expected) and all(key in actual for key in expected)
+
+
+@pytest.mark.parametrize(
     "model_stub,comp_stub",
     [
         (


### PR DESCRIPTION
- Previously removed as no longer required for latest transformers but required for lower bound support