### PR TITLE
[cicd] Include Python version in artifact name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,7 +171,7 @@ jobs:
               uses: actions/upload-artifact@v4
               if: success() || failure()
               with:
-                  name: report-${{ inputs.test_label }}.xml
+                  name: report-${{ inputs.python }}-${{ inputs.test_label }}.xml
                   path: test-results/report.xml
                   retention-days: 5
 


### PR DESCRIPTION
## Summary

The `trigger-all` workflow runs the `test` workflow multiple times using different Python versions and hardware environment targets, but only one of those two differences is represented in the results that are uploaded to the run as an artifact. This caused a problem when two of the jobs were run in the same environment. By adding the Python version to the artifact name as well, this increases the entropy in the name and eliminates the current naming clashes.