### PR TITLE
[cicd] Add post-release run to push next nightly

### DIFF
--- a/.github/workflows/post-release-nightly-build.yml
+++ b/.github/workflows/post-release-nightly-build.yml
@@ -7,10 +7,7 @@ on:
 jobs:
   BUILD-TEST-NIGHTLY:
     name: Post-release nightly build & release
-    uses: ./.github/workflows/build-test.yml
+    uses: ./.github/workflows/trigger-all.yml
     with:
-      wf_category: NIGHTLY
-      gitref: main
       push_to_pypi: true
-      test_configs: '[{"python":"3.9","label":"k8s-h100-solo","timeout":"40"}]'
     secrets: inherit

--- a/.github/workflows/post-release-nightly-build.yml
+++ b/.github/workflows/post-release-nightly-build.yml
@@ -9,5 +9,7 @@ jobs:
     name: Post-release nightly build & release
     uses: ./.github/workflows/trigger-all.yml
     with:
+      wf_category: NIGHTLY
       push_to_pypi: true
+      gitref: main
     secrets: inherit

--- a/.github/workflows/post-release-nightly-build.yml
+++ b/.github/workflows/post-release-nightly-build.yml
@@ -1,0 +1,16 @@
+name: Post-release nightly build & release
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  BUILD-TEST-NIGHTLY:
+    name: Post-release nightly build & release
+    uses: ./.github/workflows/build-test.yml
+    with:
+      wf_category: NIGHTLY
+      gitref: main
+      push_to_pypi: true
+      test_configs: '[{"python":"3.9","label":"k8s-h100-solo","timeout":"40"}]'
+    secrets: inherit

--- a/.github/workflows/trigger-all.yml
+++ b/.github/workflows/trigger-all.yml
@@ -36,5 +36,4 @@ jobs:
                             {"python":"3.10.12","label":"k8s-util","timeout":"40"},
                             {"python":"3.9.17","label":"k8s-h100-solo","timeout":"40"},
                             {"python":"3.12.6","label":"k8s-a100-duo","timeout":"40"}]'
-
         secrets: inherit

--- a/.github/workflows/trigger-all.yml
+++ b/.github/workflows/trigger-all.yml
@@ -5,6 +5,13 @@ on:
       # * is a special character in YAML so you have to quote this string
       - cron: '30 0 * * *'  # nightly run
 
+    workflow_call:
+        inputs:
+            push_to_pypi:
+                description: "when set and tests pass, then '.whl' & '.tar.gz' will be pushed to public pypi"
+                type: boolean
+                default: false
+
     workflow_dispatch:
         inputs:
             wf_category:

--- a/.github/workflows/trigger-all.yml
+++ b/.github/workflows/trigger-all.yml
@@ -7,10 +7,18 @@ on:
 
     workflow_call:
         inputs:
+            wf_category:
+                description: "workflow category, must be 'NIGHTLY' or 'RELEASE' (default: NIGHTLY)"
+                type: string
+                default: NIGHTLY
             push_to_pypi:
                 description: "when set and tests pass, then '.whl' & '.tar.gz' will be pushed to public pypi"
                 type: boolean
                 default: false
+            gitref:
+                description: "git commit hash or tag name"
+                type: string
+                default: 'main'
 
     workflow_dispatch:
         inputs:


### PR DESCRIPTION
Adds a new workflow that is triggered by a release event† ­­which will run the `build-test` workflow with only a single test config in order to push out a new nightly.

† The workflow uses `types: [released]`, and the `released` type, per [the docs](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=released#release), means:

> A release was published, or a pre-release was changed to a release.