### PR TITLE
[Transform] Fix accelerate import to keep it as optional dependency

### DIFF
--- a/src/compressed_tensors/transform/apply.py
+++ b/src/compressed_tensors/transform/apply.py
@@ -15,9 +15,9 @@
 from typing import Dict
 
 import torch
-from accelerate.utils import has_offloaded_params
 from compressed_tensors import TRANSFORM_CONFIG_NAME
 from compressed_tensors.transform import TransformConfig, TransformFactory
+from compressed_tensors.utils.offload import has_offloaded_params
 
 
 __all__ = ["apply_transform_config"]


### PR DESCRIPTION
PR #445 introduced a direct import of `has_offloaded_params` from `accelerate.utils` at the module level in `transform/apply.py`. 

This could lead to upstream projects, like SGLang, failing to run with:
```python
  File ".../compressed_tensors/transform/apply.py", line 18, in <module>
    from accelerate.utils import has_offloaded_params
ModuleNotFoundError: No module named 'accelerate'
```

This PR just changes to has_offloaded_params from compressed_tensors.utils.offload instead of accelerate.utils directly. This ensures accelerate remains optional and the package can be imported without it installed.

The utils.offload module already has proper fallback handling with @check_accelerate decorator that returns False when accelerate is not available.

I have run basic tests checking that imports work, and also the `tests/test_transform/`. I'm new to this project, so please let me know if there's something else needed. 