### PR TITLE
drop python 3.9 and add 3.13 to testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
 
             - name: set python
               id: set_python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                   python-version: ${{ inputs.python }}
 

--- a/.github/workflows/trigger-all.yml
+++ b/.github/workflows/trigger-all.yml
@@ -49,6 +49,6 @@ jobs:
             push_to_pypi: ${{ (github.event.schedule == '30 0 * * *') || inputs.push_to_pypi || false }}
             test_configs: '[{"python":"3.11.4","label":"k8s-util","timeout":"40","code_coverage":true},
                             {"python":"3.10.12","label":"k8s-util","timeout":"40"},
-                            {"python":"3.13.8","label":"k8s-h100-solo","timeout":"40"},
+                            {"python":"3.13","label":"k8s-h100-solo","timeout":"40"},
                             {"python":"3.12.6","label":"k8s-a100-duo","timeout":"40"}]'
         secrets: inherit


### PR DESCRIPTION
Drop python 3.9 and add 3.13 into testing.

Added 3.13 had a successful run here: https://github.com/neuralmagic/compressed-tensors/actions/runs/18408783887