### PR TITLE
Update NVFP4 default observer

### DIFF
--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -172,7 +172,7 @@ NVFP4 = dict(
         symmetric=True,
         dynamic=False,
         group_size=16,
-        observer="static_minmax"
+        observer="static_minmax",
     ),
     input_activations=QuantizationArgs(
         num_bits=4,
@@ -181,7 +181,7 @@ NVFP4 = dict(
         symmetric=True,
         dynamic=DynamicType.LOCAL,
         group_size=16,
-        observer="static_minmax"
+        observer="static_minmax",
     ),
 )
 


### PR DESCRIPTION
- As opposed to use the running minmax, use the static minmax.
- Seems to be better for Qwen3 VL MoE
- Need to rerun on Llama3 8b
- Will potentially update to MSE as per MLR's results once we validate 