### PR TITLE
update to allow READ only access

### DIFF
--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -99,8 +99,9 @@ def test_target_prioritization(mock_frozen):
     }
 
     model = AutoModelForCausalLM.from_pretrained(
-        "HuggingFaceM4/tiny-random-LlamaForCausalLM", torch_dtype="auto",
-        cache_dir="test-apply-model-cache"
+        "HuggingFaceM4/tiny-random-LlamaForCausalLM",
+        torch_dtype="auto",
+        cache_dir="test-apply-model-cache",
     )
     model.eval()
 


### PR DESCRIPTION
SUMMARY: 
* update `tests/test_quantization/lifecycle/test_apply.py` to use tmp "model-cache". this allows the "/model-cache" to be READ only.

TEST PLAN:
ran the test locally and verified that it does use the tmp "model-cache" and that the directory gets cleaned up.
