### PR TITLE
Fixing bug in matrix_multiply.py

### DIFF
--- a/src/compressed_tensors/transform/factory/matrix_multiply.py
+++ b/src/compressed_tensors/transform/factory/matrix_multiply.py
@@ -68,7 +68,7 @@ class RandomMatrixFactory(TransformFactory):
             (size, size),
             generator=self.generator,
             dtype=precision,
-            device=self.generator.device
+            device=self.generator.device,
         ).to(device)
         return Parameter(data, requires_grad=self.scheme.requires_grad)
 

--- a/tests/test_transform/factory/test_correctness.py
+++ b/tests/test_transform/factory/test_correctness.py
@@ -171,7 +171,7 @@ def test_correctness_attention_heads(type, randomize, head_dim, input_batch_size
 def test_random_matrix_device_handling(cuda_default):
     """
     Test that random-matrix transforms can be created
-    on CUDA. 
+    on CUDA.
     """
     seed = 0
     size = (4, 8)
@@ -195,5 +195,3 @@ def test_random_matrix_device_handling(cuda_default):
     # Verify that transforms were created on CUDA
     assert input_tfm.weight.device.type == "cuda"
     torch.set_default_device(cur_default)
-
-


### PR DESCRIPTION
generator is created on cpu by default so trying to create a tensor on cuda with a cpu generator would cause an error, we can just move it over instead. Note: we cannot just create a cuda generator if we want to maintain reproducability because cpu and cuda generators aren't deterministically equivalent so generate on cpu and move to device is our best option if we want to keep that determinism

added a test to demonstrate that this works and was broken before. added random-matrix to the other correctness tests

(test was generated with claude-code and verified by me)