### PR TITLE
[Utils] Add `return_unmatched` argument to `match_modules_set`

### DIFF
--- a/tests/test_utils/test_match.py
+++ b/tests/test_utils/test_match.py
@@ -457,7 +457,21 @@ class TestMatchModulesSet:
         targets = ["layer1", "nonexistent_module"]
 
         with pytest.raises(ValueError, match="Unable to match targets into set"):
-            list(match_modules_set(model, targets))
+            list(match_modules_set(model, targets, return_unmatched=False))
+
+    def test_incomplete_set_return(self):
+        """Test error when unable to complete a set"""
+        model = DummyModel()
+        targets = ["layer1", "nonexistent_module"]
+
+        try:
+            while True:
+                next(match_modules_set(model, targets, return_unmatched=True))
+        except StopIteration as exception:
+            assert exception.value == {
+                "layer1": model.layer1,
+                "nonexistent_module": None,
+            }
 
     def test_duplicate_match_error(self):
         """Test error when same target matches multiple times before set completion"""


### PR DESCRIPTION
## Purpose ##
* Add support for returning any unmatched sets when using `match_modules_set`
  * This is useful for more verbose/specific erroring in the case of checking for fused modules

## Changes ##
* Fix typo `FusedMappping` -> FusedMapping`
* Fix typo in `match_modules_set` docstring
* Add `return_unmatched` argument to `match_modules_set`
* More verbose error when double matching in `match_modules_set`

Returned values from generators can be accessed in the following way:
```python3
matched_modules = []
unmatched_module = None
try:
  while True:
      matched_modules.append(next(match_modules_set(model, targets, return_unmatched=True)))
except StopIteration as exception:
  unmatched_module = exception.value
```

## Testing ##
* Added `test_incomplete_set_return`