### PR TITLE
[Bugfix] Remove assert when dispatched to device

### DIFF
--- a/src/compressed_tensors/offload/cache/device.py
+++ b/src/compressed_tensors/offload/cache/device.py
@@ -35,8 +35,8 @@ class DeviceCache(OffloadCache):
         :param key: cpu tensor to onload
         :return: device tensor
         """
-        assert offloaded.device == self.onload_device
-        return offloaded
+        # move because onload_device might be modified after init
+        return send_tensors(offloaded, device=self.onload_device, copy=False)
 
     def offload(self, tensor: torch.Tensor | None) -> torch.Tensor:
         """


### PR DESCRIPTION
## Purpose ##
* Fix functions which may move tensors to a target device, such as model compression

## Changes ##
* Remove assert statement which assumes that modules offloaded to a device will be onloaded to the same device