### PR TITLE
Remove skip marker for GPU test

### DIFF
--- a/tests/test_transform/factory/test_serialization.py
+++ b/tests/test_transform/factory/test_serialization.py
@@ -65,7 +65,6 @@ def test_serialization(type, randomize, model_apply, tmp_path, offload):
             assert torch.equal(param, saved_param)
 
 
-@pytest.mark.skip("Requires transformers#40673")
 @requires_gpu
 @pytest.mark.parametrize(
     "model_stub,exp_perplexity",


### PR DESCRIPTION
Remove skip marker for a test that requires a specific transformers issue to be resolved.