### PR TITLE
Modernize python310 type hints in transform/offload/registry

### DIFF
--- a/src/compressed_tensors/offload/__init__.py
+++ b/src/compressed_tensors/offload/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import contextlib
-from typing import Iterable, Optional
+from collections.abc import Iterable
 
 import torch
 from compressed_tensors.offload.cache import OffloadCache
@@ -146,7 +146,7 @@ def register_offload_module(base: torch.nn.Module, name: str, module: torch.nn.M
 @contextlib.contextmanager
 def align_modules(
     modules: torch.nn.Module | Iterable[torch.nn.Module],
-    execution_device: Optional[torch.device] = None,
+    execution_device: torch.device | None = None,
 ):
     """
     Context manager for onloading modules to a device, and disabling onload and offload
@@ -163,7 +163,7 @@ def align_modules(
 
 @contextlib.contextmanager
 def align_module_device(
-    module: torch.nn.Module, execution_device: Optional[torch.device] = None
+    module: torch.nn.Module, execution_device: torch.device | None = None
 ):
     """
     Context manager that moves a module's parameters to the specified execution device.

--- a/src/compressed_tensors/offload/cache/base.py
+++ b/src/compressed_tensors/offload/cache/base.py
@@ -15,7 +15,7 @@
 import contextlib
 from abc import ABC, abstractmethod
 from collections.abc import MutableMapping
-from typing import ClassVar, Literal, Optional
+from typing import ClassVar, Literal
 
 import torch
 import torch.distributed as dist
@@ -41,7 +41,7 @@ class OffloadCache(MutableMapping, ABC):
     """
 
     onload_device: torch.device | str
-    offload_device: Optional[torch.device | str]
+    offload_device: torch.device | str | None
 
     # global flags for disabling
     offloading_disabled: ClassVar[bool] = False
@@ -56,7 +56,7 @@ class OffloadCache(MutableMapping, ABC):
     @classmethod
     def cls_from_device(
         cls,
-        device: Optional[torch.device | str | Literal["disk"]] = None,
+        device: torch.device | str | Literal["disk"] | None = None,
     ) -> type["OffloadCache"]:
         """
         Get the subclass which implements offloading for the given `offload_device`.

--- a/src/compressed_tensors/offload/dispatch.py
+++ b/src/compressed_tensors/offload/dispatch.py
@@ -15,7 +15,7 @@
 from collections.abc import Container
 from copy import deepcopy
 from functools import partial
-from typing import Literal, Optional, TypeVar
+from typing import Literal, TypeVar
 
 import torch
 from compressed_tensors.offload.module import offload_module, remove_module_offload
@@ -62,9 +62,9 @@ def offload_model(
 
 def dispatch_model(
     model: ModelType,
-    device_memory: Optional[dict[torch.device, int]] = None,
-    extra_memory: Optional[int] = None,
-    no_split_modules: Optional[Container[str]] = None,
+    device_memory: dict[torch.device, int] | None = None,
+    extra_memory: int | None = None,
+    no_split_modules: Container[str] | None = None,
 ) -> ModelType:
     """
     Dispatch a model for autoregressive generation. This means that modules are

--- a/src/compressed_tensors/offload/utils.py
+++ b/src/compressed_tensors/offload/utils.py
@@ -15,7 +15,7 @@
 from collections.abc import Container
 from dataclasses import fields, is_dataclass
 from itertools import chain
-from typing import Optional, TypeVar
+from typing import TypeVar
 
 import torch
 from loguru import logger
@@ -67,7 +67,7 @@ def send_tensors(value: T, *args, **kwargs) -> T:
 
 
 def get_module_device(
-    module: torch.nn.Module, default: Optional[torch.device] = None
+    module: torch.nn.Module, default: torch.device | None = None
 ) -> torch.device:
     """
     Infer the device of a module using the first

--- a/src/compressed_tensors/registry/registry.py
+++ b/src/compressed_tensors/registry/registry.py
@@ -19,7 +19,7 @@ of neuralmagic utilities
 
 import importlib
 from collections import defaultdict
-from typing import Any, Dict, List, Optional, TypeVar, Union
+from typing import Any, TypeVar
 
 
 __all__ = [
@@ -32,8 +32,8 @@ __all__ = [
 ]
 
 
-_ALIAS_REGISTRY: Dict[type, Dict[str, str]] = defaultdict(dict)
-_REGISTRY: Dict[type, Dict[str, Any]] = defaultdict(dict)
+_ALIAS_REGISTRY: dict[type, dict[str, str]] = defaultdict(dict)
+_REGISTRY: dict[type, dict[str, Any]] = defaultdict(dict)
 T = TypeVar("", bound="RegistryMixin")
 
 
@@ -55,8 +55,8 @@ def standardize_lookup_name(name: str) -> str:
 
 
 def standardize_alias_name(
-    name: Union[None, str, List[str]],
-) -> Union[None, str, List[str]]:
+    name: str | list[str] | None,
+) -> str | list[str] | None:
     if name is None:
         return None
     elif isinstance(name, str):
@@ -119,9 +119,7 @@ class RegistryMixin:
     registry_requires_subclass: bool = False
 
     @classmethod
-    def register(
-        cls, name: Optional[str] = None, alias: Union[List[str], str, None] = None
-    ):
+    def register(cls, name: str | None = None, alias: list[str] | str | None = None):
         """
         Decorator for registering a value (ie class or function) wrapped by this
         decorator to the base class (class that .register is called from)
@@ -141,7 +139,7 @@ class RegistryMixin:
 
     @classmethod
     def register_value(
-        cls, value: Any, name: str, alias: Union[str, List[str], None] = None
+        cls, value: Any, name: str, alias: str | list[str] | None = None
     ):
         """
         Registers the given value to the class `.register_value` is called from
@@ -186,14 +184,14 @@ class RegistryMixin:
         )
 
     @classmethod
-    def registered_names(cls) -> List[str]:
+    def registered_names(cls) -> list[str]:
         """
         :return: list of all names registered to this class
         """
         return registered_names(cls)
 
     @classmethod
-    def registered_aliases(cls) -> List[str]:
+    def registered_aliases(cls) -> list[str]:
         """
         :return: list of all aliases registered to this class
         """
@@ -203,8 +201,8 @@ class RegistryMixin:
 def register(
     parent_class: type,
     value: Any,
-    name: Optional[str] = None,
-    alias: Union[List[str], str, None] = None,
+    name: str | None = None,
+    alias: list[str] | str | None = None,
     require_subclass: bool = False,
 ):
     """
@@ -277,7 +275,7 @@ def get_from_registry(
     return retrieved_value
 
 
-def registered_names(parent_class: type) -> List[str]:
+def registered_names(parent_class: type) -> list[str]:
     """
     :param parent_class: class to look up the registry of
     :return: all names registered to the given class
@@ -285,7 +283,7 @@ def registered_names(parent_class: type) -> List[str]:
     return list(_REGISTRY[parent_class].keys())
 
 
-def registered_aliases(parent_class: type) -> List[str]:
+def registered_aliases(parent_class: type) -> list[str]:
     """
     :param parent_class: class to look up the registry of
     :return: all aliases registered to the given class
@@ -297,9 +295,7 @@ def registered_aliases(parent_class: type) -> List[str]:
     return registered_aliases
 
 
-def register_alias(
-    name: str, parent_class: type, alias: Union[str, List[str], None] = None
-):
+def register_alias(name: str, parent_class: type, alias: str | list[str] | None = None):
     """
     Updates the mapping from the alias(es) to the given name.
     If the alias is None, the name is used as the alias.

--- a/src/compressed_tensors/transform/factory/base.py
+++ b/src/compressed_tensors/transform/factory/base.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import List, Optional
 
 import torch
 import torch.nn.utils.parametrize as P
@@ -58,9 +57,9 @@ class TransformFactory(RegistryMixin, ABC):
     :param seed: random seed used to transform weight randomization
     """
 
-    transforms: List["TransformBase"]
+    transforms: list["TransformBase"]
 
-    def __init__(self, name: str, scheme: TransformScheme, seed: Optional[int] = None):
+    def __init__(self, name: str, scheme: TransformScheme, seed: int | None = None):
         self.name = name
         self.scheme = scheme
         self.generator = torch.Generator()
@@ -191,7 +190,7 @@ class TransformBase(InternalModule, ABC):
 
     args: TransformArgs
     weight: Parameter
-    _dynamic_tied_weights_keys: List[str] = ["weight"]
+    _dynamic_tied_weights_keys: list[str] = ["weight"]
 
     @abstractmethod
     def forward(self, value: Tensor) -> Tensor:

--- a/src/compressed_tensors/transform/factory/hadamard.py
+++ b/src/compressed_tensors/transform/factory/hadamard.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
-
 import torch
 from compressed_tensors.transform import TransformArgs, TransformScheme
 from compressed_tensors.transform.factory.base import TransformBase, TransformFactory
@@ -38,7 +36,7 @@ class HadamardFactory(TransformFactory):
     :param seed: random seed used to transform weight randomization
     """
 
-    def __init__(self, name: str, scheme: TransformScheme, seed: Optional[int] = None):
+    def __init__(self, name: str, scheme: TransformScheme, seed: int | None = None):
         super().__init__(name, scheme, seed)
         self.weights = ParameterizedDefaultDict(self._create_weight)
         self.perms = ParameterizedDefaultDict(self._create_permutation)
@@ -83,12 +81,12 @@ class HadamardFactory(TransformFactory):
 
 
 class HadamardTransform(TransformBase):
-    _dynamic_tied_weights_keys: List[str] = ["weight", "perm"]
+    _dynamic_tied_weights_keys: list[str] = ["weight", "perm"]
 
     def __init__(
         self,
         weight: Parameter,
-        perm: Optional[Parameter],
+        perm: Parameter | None,
         scheme: TransformScheme,
         args: TransformArgs,
         module_type: type[torch.nn.Module],

--- a/src/compressed_tensors/transform/factory/matrix_multiply.py
+++ b/src/compressed_tensors/transform/factory/matrix_multiply.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
-
 import torch
 from compressed_tensors.transform import TransformArgs, TransformScheme
 from compressed_tensors.transform.factory.base import TransformBase, TransformFactory
@@ -37,7 +35,7 @@ class RandomMatrixFactory(TransformFactory):
     :param seed: random seed used to transform weight randomization
     """
 
-    def __init__(self, name: str, scheme: TransformScheme, seed: Optional[int] = None):
+    def __init__(self, name: str, scheme: TransformScheme, seed: int | None = None):
         super().__init__(name, scheme, seed)
         self.weights = ParameterizedDefaultDict(self._create_weight)
         self.inverses = ParameterizedDefaultDict(self._create_inverse)

--- a/src/compressed_tensors/transform/transform_args.py
+++ b/src/compressed_tensors/transform/transform_args.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import List
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -67,10 +66,10 @@ class TransformArgs(BaseModel, use_enum_values=True):
     :param ignore: any modules which should be ignored from the targets list
     """
 
-    targets: List[str]
+    targets: list[str]
     location: TransformLocation
     inverse: bool = Field(default=False)
-    ignore: List[str] = Field(default_factory=list)
+    ignore: list[str] = Field(default_factory=list)
 
     @field_validator("targets", "ignore", mode="before")
     @classmethod

--- a/src/compressed_tensors/transform/transform_config.py
+++ b/src/compressed_tensors/transform/transform_config.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict
-
 from compressed_tensors.transform import TransformScheme
 from pydantic import BaseModel, ConfigDict
 
@@ -30,6 +28,6 @@ class TransformConfig(BaseModel):
         to a particular model. The keys can be any arbitrary string
     """
 
-    config_groups: Dict[str, TransformScheme]
+    config_groups: dict[str, TransformScheme]
 
     model_config = ConfigDict(extra="forbid")

--- a/src/compressed_tensors/transform/transform_scheme.py
+++ b/src/compressed_tensors/transform/transform_scheme.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
-
 import torch
 from compressed_tensors.transform import TransformArgs
 from compressed_tensors.utils import TorchDtype
@@ -46,10 +44,10 @@ class TransformScheme(BaseModel):
     """
 
     type: str
-    apply: List[TransformArgs] = Field(default_factory=list)
+    apply: list[TransformArgs] = Field(default_factory=list)
     randomize: bool = Field(default=False)
     requires_grad: bool = Field(default=False)
-    head_dim: Optional[int] = Field(default=None)
+    head_dim: int | None = Field(default=None)
     precision: TorchDtype = Field(default=torch.float32)
 
     model_config = ConfigDict(extra="forbid")

--- a/src/compressed_tensors/transform/utils/hadamard.py
+++ b/src/compressed_tensors/transform/utils/hadamard.py
@@ -14,7 +14,6 @@
 
 import math
 from pathlib import Path
-from typing import Optional
 
 import torch
 from safetensors import safe_open
@@ -66,7 +65,7 @@ def random_hadamard_matrix(
     size: int,
     dtype: torch.dtype = torch.bfloat16,
     device: torch.device = torch.device("cpu"),
-    gen: Optional[torch.Generator] = None,
+    gen: torch.Generator | None = None,
 ) -> torch.Tensor:
     """
     Produces a randomly generated Hadamard matrix. Differs from
@@ -104,7 +103,7 @@ def _fetch_hadamard_divisor(
     dtype: torch.dtype,
     device: torch.device = torch.device("cpu"),
     file_path: str = REPO_PATH,
-) -> Optional[torch.Tensor]:
+) -> torch.Tensor | None:
     """
     Fetch a known hadamard matrix from the given file path. The returned matrix will
     be of of size `k` such that `n / k` is a power of two. Return None if no such

--- a/src/compressed_tensors/transform/utils/matrix.py
+++ b/src/compressed_tensors/transform/utils/matrix.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
-
 import torch
 from compressed_tensors.transform import TransformLocation
 
@@ -24,7 +22,7 @@ __all__ = ["get_transform_size", "apply_transform_weight"]
 def get_transform_size(
     module: torch.nn.Module,
     location: TransformLocation,
-    head_dim: Optional[int] = None,
+    head_dim: int | None = None,
 ) -> int:
     """
     Determine the size of a transform matrix given its location on the module


### PR DESCRIPTION
## Summary
- Modernize type hints in transform, offload, and registry to Python 3.10 syntax (|, built-in generics).
- Replace typing collections with built-in/collections.abc where appropriate.
- No functional changes.

## Testing
- make quality
- pytest tests/test_transform/ -v
- pytest tests/test_offload/ -v
- pytest tests/test_registry.py -v

Part of #492