### PR TITLE
Modernize python310 type hints in config/linear/logger/modeling

### DIFF
--- a/src/compressed_tensors/compressors/format.py
+++ b/src/compressed_tensors/compressors/format.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import List, Optional
-
 import torch
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization import QuantizationScheme
@@ -15,7 +13,7 @@ __all__ = ["infer_model_format", "infer_module_format"]
 
 # Priority order for compression format matching
 # More specific formats should come before more general ones
-COMPRESSION_FORMAT_PRIORITY: List[CompressionFormat] = [
+COMPRESSION_FORMAT_PRIORITY: list[CompressionFormat] = [
     CompressionFormat.mxfp4_pack_quantized,
     CompressionFormat.nvfp4_pack_quantized,
     CompressionFormat.pack_quantized,
@@ -28,7 +26,7 @@ COMPRESSION_FORMAT_PRIORITY: List[CompressionFormat] = [
 
 def infer_model_format(
     model: torch.nn.Module,
-    force_compression_format: Optional[str] = None,
+    force_compression_format: str | None = None,
 ) -> CompressionFormat:
     """
     Infers the quantization format for a model based on its modules

--- a/src/compressed_tensors/config/base.py
+++ b/src/compressed_tensors/config/base.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from enum import Enum, unique
-from typing import List, Optional
 
 from compressed_tensors.registry import RegistryMixin
 from pydantic import BaseModel
@@ -88,16 +87,16 @@ class SparsityCompressionConfig(RegistryMixin, BaseModel):
     Base data class for storing sparsity compression parameters
 
     :param format: name of compression format
-    :param targets: List of layer names or layer types that aren't sparse and should
+    :param targets: list of layer names or layer types that aren't sparse and should
         be ignored during compression. By default, assume all layers are targeted
-    :param ignore: List of layer names (unique) to ignore from targets. Defaults to None
+    :param ignore: list of layer names (unique) to ignore from targets. Defaults to None
     :param global_sparsity: average sparsity of the entire model
     :param sparsity_structure: structure of the sparsity, such as
     "unstructured", "2:4", "8:16" etc
     """
 
     format: str
-    targets: Optional[List[str]] = None
-    ignore: Optional[List[str]] = None
-    global_sparsity: Optional[float] = 0.0
-    sparsity_structure: Optional[str] = "unstructured"
+    targets: list[str] | None = None
+    ignore: list[str] | None = None
+    global_sparsity: float | None = 0.0
+    sparsity_structure: str | None = "unstructured"

--- a/src/compressed_tensors/config/dense.py
+++ b/src/compressed_tensors/config/dense.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import Optional
-
 from compressed_tensors.config import CompressionFormat, SparsityCompressionConfig
 
 
@@ -21,5 +19,5 @@ class DenseSparsityConfig(SparsityCompressionConfig):
     """
 
     format: str = CompressionFormat.dense.value
-    global_sparsity: Optional[float] = 0.0
-    sparsity_structure: Optional[str] = "unstructured"
+    global_sparsity: float | None = 0.0
+    sparsity_structure: str | None = "unstructured"

--- a/src/compressed_tensors/config/sparse_24_bitmask.py
+++ b/src/compressed_tensors/config/sparse_24_bitmask.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import Optional
-
 from compressed_tensors.config import (
     CompressionFormat,
     SparsityCompressionConfig,
@@ -25,5 +23,5 @@ class Sparse24BitMaskConfig(SparsityCompressionConfig):
     """
 
     format: str = CompressionFormat.sparse_24_bitmask.value
-    global_sparsity: Optional[float] = 0.0
-    sparsity_structure: Optional[str] = SparsityStructure.TWO_FOUR.value
+    global_sparsity: float | None = 0.0
+    sparsity_structure: str | None = SparsityStructure.TWO_FOUR.value

--- a/src/compressed_tensors/config/sparse_bitmask.py
+++ b/src/compressed_tensors/config/sparse_bitmask.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import Optional
-
 from compressed_tensors.config import CompressionFormat, SparsityCompressionConfig
 
 
@@ -21,5 +19,5 @@ class BitmaskConfig(SparsityCompressionConfig):
     """
 
     format: str = CompressionFormat.sparse_bitmask.value
-    global_sparsity: Optional[float] = 0.0
-    sparsity_structure: Optional[str] = "unstructured"
+    global_sparsity: float | None = 0.0
+    sparsity_structure: str | None = "unstructured"

--- a/src/compressed_tensors/logger.py
+++ b/src/compressed_tensors/logger.py
@@ -8,7 +8,7 @@ Logger configuration for Compressed Tensors.
 import os
 import sys
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any
 
 from loguru import logger
 
@@ -24,12 +24,12 @@ _logged_once = set()
 class LoggerConfig:
     disabled: bool = False
     clear_loggers: bool = True
-    console_log_level: Optional[str] = "INFO"
-    log_file: Optional[str] = None
-    log_file_level: Optional[str] = None
+    console_log_level: str | None = "INFO"
+    log_file: str | None = None
+    log_file_level: str | None = None
 
 
-def configure_logger(config: Optional[LoggerConfig] = None):
+def configure_logger(config: LoggerConfig | None = None):
     """
     Configure the logger for Compressed Tensors.
     This function sets up the console and file logging
@@ -84,7 +84,7 @@ def configure_logger(config: Optional[LoggerConfig] = None):
         )
 
 
-def support_log_once(record: Dict[str, Any]) -> bool:
+def support_log_once(record: dict[str, Any]) -> bool:
     """
     Support logging only once using `.bind(log_once=True)`
 

--- a/src/compressed_tensors/modeling/attention.py
+++ b/src/compressed_tensors/modeling/attention.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import inspect
-from typing import Callable, Optional
+from collections.abc import Callable
 
 from compressed_tensors.modeling.kvcache import initialize_hooked_kv_cache
 from compressed_tensors.quantization.lifecycle.forward import forward_quantize
@@ -114,7 +114,7 @@ def initialize_hooked_attention(model: PreTrainedModel, module: Module):
 
 
 def register_query_hook(
-    module: Module, hook: Callable[[Module, Tensor], Optional[Tensor]]
+    module: Module, hook: Callable[[Module, Tensor], Tensor | None]
 ) -> RemovableHandle:
     """
     Register a hook which takes post-rope query states as an argument and

--- a/src/compressed_tensors/modeling/kvcache.py
+++ b/src/compressed_tensors/modeling/kvcache.py
@@ -2,7 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import inspect
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from collections.abc import Callable
+from typing import Any
 from weakref import ReferenceType, ref
 
 from compressed_tensors.quantization.lifecycle.forward import forward_quantize
@@ -44,9 +45,9 @@ class QuantizedKVCache(InternalModule):
         super().__init__()
         self.config = config
         self.attn_module = ref(attn_module)  # avoid circular reference
-        self.past_key_values: Optional[ReferenceType[Cache]] = None
+        self.past_key_values: ReferenceType[Cache] | None = None
 
-    def update(self, *args, **kwargs) -> Tuple[Tensor, Tensor]:
+    def update(self, *args, **kwargs) -> tuple[Tensor, Tensor]:
         return self(*args, **kwargs)
 
     def forward(
@@ -55,7 +56,7 @@ class QuantizedKVCache(InternalModule):
         value_states: Tensor,
         *args,
         **kwargs,
-    ) -> Tuple[Tensor, Tensor]:
+    ) -> tuple[Tensor, Tensor]:
         # quantization
         module = self.attn_module()
         quant_args_attr = "quantization_scheme.input_activations"
@@ -76,7 +77,7 @@ class QuantizedKVCache(InternalModule):
 
         return ret
 
-    def add_past_key_values(self, past_key_values: Optional[Cache]):
+    def add_past_key_values(self, past_key_values: Cache | None):
         if past_key_values is not None:
             self.past_key_values = ref(past_key_values)
         else:
@@ -87,8 +88,8 @@ class QuantizedKVCache(InternalModule):
 
 
 def _kv_cache_attention_hook(
-    module: Module, args: List[Any], kwargs: Dict[str, Any]
-) -> Tuple[List[Any], Dict[str, Any]]:
+    module: Module, args: list[Any], kwargs: dict[str, Any]
+) -> tuple[list[Any], dict[str, Any]]:
     """
     Hook which should be called before each quantized attention forward pass.
     This hook dynamically replaces the `past_key_values` kwarg to the attention
@@ -102,7 +103,7 @@ def _kv_cache_attention_hook(
         if "past_key_values" in inspect.signature(module.forward).parameters
         else "past_key_value"
     )
-    past_key_values: Optional[Cache] = kwargs.get(_past_kv_name, None)
+    past_key_values: Cache | None = kwargs.get(_past_kv_name, None)
 
     cache: QuantizedKVCache = getattr(module, KV_CACHE_ATTR)
     cache.add_past_key_values(past_key_values)
@@ -127,7 +128,7 @@ def initialize_hooked_kv_cache(model: PreTrainedModel, module: Module):
 
 
 def register_key_hook(
-    module: Module, hook: Callable[[Module, Tensor], Optional[Tensor]]
+    module: Module, hook: Callable[[Module, Tensor], Tensor | None]
 ) -> RemovableHandle:
     """
     Register a hook which takes post-rope key states as an argument and
@@ -150,7 +151,7 @@ def register_key_hook(
 
 
 def register_value_hook(
-    module: Module, hook: Callable[[Module, Tensor], Optional[Tensor]]
+    module: Module, hook: Callable[[Module, Tensor], Tensor | None]
 ) -> RemovableHandle:
     """
     Register a hook which takes value states as an argument and


### PR DESCRIPTION
## Summary
- Modernize type hints in config, linear, logger, and modeling to Python 3.10 syntax (|, built-in generics).
- Replace typing collections with built-in/collections.abc where appropriate.
- No functional changes.

## Testing
- make quality
- pytest tests/test_configs/ -v
- pytest tests/test_linear/ -v
- pytest tests/test_modeling/ -v

Part of #492