### PR TITLE
[Bugfix]: Reduce memory usage when load device does not match dispatch device

### DIFF
--- a/src/compressed_tensors/offload/utils.py
+++ b/src/compressed_tensors/offload/utils.py
@@ -34,7 +34,8 @@ def send_tensors(value: T, *args, **kwargs) -> T:
     """
     match value:
         case torch.Tensor():
-            tensor = value.to(*args, **kwargs)
+            with torch.no_grad():
+                tensor = value.to(*args, **kwargs)
 
             # special case: avoid changing param pointer when possible
             if tensor.data_ptr() == value.data_ptr():


### PR DESCRIPTION
## Purpose ##
* Reduce memory usage when load device does not match dispatch device
  * Before, the gradient calculated during copy operations would keep a reference of the old tensor alive

## Changes ##
* Perform tensor copy operations in `torch.no_grad` context

## Testing ##
Below is the memory profile of loading a model on cpu, then dispatching to cuda

| Before Changes | After Changes |
| - | - |
| <img width="640" height="480" alt="before_with_grad" src="https://github.com/user-attachments/assets/803ffb97-d21b-455d-91ae-f357c3313e2e" /> | <img width="640" height="480" alt="after_with_grad" src="https://github.com/user-attachments/assets/456882cc-4011-4f68-b89d-03933f754670" /> |