### PR TITLE
[Bugfix] Fix Inf global_scale when activations are all-zero in NVFP4

### DIFF
--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -323,7 +323,7 @@ def generate_gparam(
     min_vals = torch.min(updated_min_val, torch.zeros_like(updated_min_val))
     max_vals = torch.max(updated_max_val, torch.zeros_like(updated_max_val))
     max_val_pos = torch.max(torch.abs(min_vals), torch.abs(max_vals))
-    max_val_pos = torch.clamp(max_val_pos, min=torch.finfo(torch.float32).tiny)
+    max_val_pos = torch.clamp(max_val_pos, min=torch.finfo(max_val_pos.dtype).tiny)
     global_scale = scale_data.max * quant_data.max / max_val_pos
     return global_scale.to(dtype).reshape([1])
 


### PR DESCRIPTION
## Summary

- When quantizing MoE models with NVFP4, some experts' `down_proj` layers receive all-zero activations during calibration (`SiLU(gate(x)) * up(x)` evaluates to zero for all calibration tokens). This causes `generate_gparam` to compute `scale_data.max * quant_data.max / 0 = Inf`.
- The Inf `global_scale` propagates through inference, producing NaN logits and crashing vLLM.
- In practice, this affects a small number of rarely-activated experts (e.g. 14 out of 92,400 `input_global_scale` tensors in Qwen3.5-397B-A17B), but even a single Inf is enough to crash inference.
- Fix: clamp `max_val_pos` to `torch.finfo(float32).tiny` before division.

## Test plan

- [x] Verified fix against Qwen3.5-397B-A17B NVFP4 quantization (512 experts per layer, 60 layers)
- [x] Previously had 14/92,400 Inf `input_global_scale` values across `down_proj` of rarely-activated experts — all resolved with this clamp
- [x] 92,400/92,400 `input_global_scale` tensors now valid (0 NaN, 0 Inf)


Signed-off-by: Sehyo Alex_Noble@hotmail.com