### PR TITLE
Replace dict() constructor with {} literal syntax across the repo

### DIFF
--- a/src/compressed_tensors/offload/cache/base.py
+++ b/src/compressed_tensors/offload/cache/base.py
@@ -40,7 +40,7 @@ class OffloadCache(MutableMapping, ABC):
     offloaded_values: dict[str, torch.Tensor]
 
     # offloaded tensors -> onloaded tensors (only when offloading is disabled)
-    keep_onloaded_values: ClassVar[dict[torch.Tensor, torch.Tensor]] = dict()
+    keep_onloaded_values: ClassVar[dict[torch.Tensor, torch.Tensor]] = {}
 
     @classmethod
     def cls_from_device(
@@ -108,7 +108,7 @@ class OffloadCache(MutableMapping, ABC):
     def __init__(self, onload_device: torch.device | str):
         super().__init__()
         self.onload_device = onload_device
-        self.offloaded_values = dict()
+        self.offloaded_values = {}
 
     @abstractmethod
     def onload(self, offloaded: torch.Tensor | None) -> torch.Tensor | None:

--- a/src/compressed_tensors/offload/cache/disk.py
+++ b/src/compressed_tensors/offload/cache/disk.py
@@ -30,7 +30,7 @@ class DiskCache(OffloadCache):
     offload_device = "disk"
 
     # offloaded tensors -> weight info
-    index: dict[torch.Tensor, dict[str, str]] = dict()
+    index: dict[torch.Tensor, dict[str, str]] = {}
 
     # directory where new tensors are written to
     offload_dir: str

--- a/src/compressed_tensors/offload/dispatch.py
+++ b/src/compressed_tensors/offload/dispatch.py
@@ -232,7 +232,7 @@ def get_device_memory() -> dict[torch.device, int]:
     :return: mapping from torch device to total memory
     """
     if not torch.cuda.is_available():
-        return dict()
+        return {}
 
     if dist.is_available() and dist.is_initialized():
         logger.info("Detected distributed context. Dispatching to local rank gpu")

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -111,7 +111,7 @@ def apply_quantization_config(
 
     config = deepcopy(config)
     if config is None:  # see PR #180
-        return dict()
+        return {}
 
     # force zero points during initialization
     force_zero_point = config.quantization_status != QuantizationStatus.COMPRESSED

--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -140,24 +140,10 @@ def is_preset_scheme(name: str) -> bool:
     return name.upper() in PRESET_SCHEMES
 
 
-UNQUANTIZED = dict()
+UNQUANTIZED = {}
 
-NVFP4A16 = dict(
-    weights=QuantizationArgs(
-        num_bits=4,
-        type=QuantizationType.FLOAT,
-        strategy=QuantizationStrategy.TENSOR_GROUP,
-        symmetric=True,
-        dynamic=False,
-        group_size=16,
-        scale_dtype=FP8_E4M3_DATA.dtype,
-        zp_dtype=FP8_E4M3_DATA.dtype,
-    )
-)
-
-
-NVFP4 = dict(
-    weights=QuantizationArgs(
+NVFP4A16 = {
+    "weights": QuantizationArgs(
         num_bits=4,
         type=QuantizationType.FLOAT,
         strategy=QuantizationStrategy.TENSOR_GROUP,
@@ -167,7 +153,21 @@ NVFP4 = dict(
         scale_dtype=FP8_E4M3_DATA.dtype,
         zp_dtype=FP8_E4M3_DATA.dtype,
     ),
-    input_activations=QuantizationArgs(
+}
+
+
+NVFP4 = {
+    "weights": QuantizationArgs(
+        num_bits=4,
+        type=QuantizationType.FLOAT,
+        strategy=QuantizationStrategy.TENSOR_GROUP,
+        symmetric=True,
+        dynamic=False,
+        group_size=16,
+        scale_dtype=FP8_E4M3_DATA.dtype,
+        zp_dtype=FP8_E4M3_DATA.dtype,
+    ),
+    "input_activations": QuantizationArgs(
         num_bits=4,
         type=QuantizationType.FLOAT,
         strategy=QuantizationStrategy.TENSOR_GROUP,
@@ -178,23 +178,10 @@ NVFP4 = dict(
         scale_dtype=FP8_E4M3_DATA.dtype,
         zp_dtype=FP8_E4M3_DATA.dtype,
     ),
-)
+}
 
-MXFP4A16 = dict(
-    weights=QuantizationArgs(
-        num_bits=4,
-        type=QuantizationType.FLOAT,
-        strategy=QuantizationStrategy.GROUP,
-        symmetric=True,
-        dynamic=False,
-        group_size=32,
-        scale_dtype=torch.uint8,
-        zp_dtype=torch.uint8,
-    )
-)
-
-MXFP4 = dict(
-    weights=QuantizationArgs(
+MXFP4A16 = {
+    "weights": QuantizationArgs(
         num_bits=4,
         type=QuantizationType.FLOAT,
         strategy=QuantizationStrategy.GROUP,
@@ -204,7 +191,20 @@ MXFP4 = dict(
         scale_dtype=torch.uint8,
         zp_dtype=torch.uint8,
     ),
-    input_activations=QuantizationArgs(
+}
+
+MXFP4 = {
+    "weights": QuantizationArgs(
+        num_bits=4,
+        type=QuantizationType.FLOAT,
+        strategy=QuantizationStrategy.GROUP,
+        symmetric=True,
+        dynamic=False,
+        group_size=32,
+        scale_dtype=torch.uint8,
+        zp_dtype=torch.uint8,
+    ),
+    "input_activations": QuantizationArgs(
         num_bits=4,
         type=QuantizationType.FLOAT,
         strategy=QuantizationStrategy.GROUP,
@@ -214,41 +214,41 @@ MXFP4 = dict(
         scale_dtype=torch.uint8,
         zp_dtype=torch.uint8,
     ),
-)
+}
 
 
 # 8 bit integer weights and 8 bit activations quantization
-INT8_W8A8 = dict(
-    weights=QuantizationArgs(
+INT8_W8A8 = {
+    "weights": QuantizationArgs(
         num_bits=8,
         type=QuantizationType.INT,
         strategy=QuantizationStrategy.CHANNEL,
         symmetric=True,
         dynamic=False,
     ),
-    input_activations=QuantizationArgs(
+    "input_activations": QuantizationArgs(
         num_bits=8,
         type=QuantizationType.INT,
         strategy=QuantizationStrategy.TOKEN,
         symmetric=True,
         dynamic=True,
     ),
-)
+}
 
 # 8 bit integer weights only quantization
-W8A16 = dict(
-    weights=QuantizationArgs(
+W8A16 = {
+    "weights": QuantizationArgs(
         num_bits=8,
         type=QuantizationType.INT,
         strategy=QuantizationStrategy.CHANNEL,
         symmetric=True,
         dynamic=False,
     ),
-)
+}
 
 # 4 bit integer weights only quantization
-W4A16 = dict(
-    weights=QuantizationArgs(
+W4A16 = {
+    "weights": QuantizationArgs(
         num_bits=4,
         type=QuantizationType.INT,
         strategy=QuantizationStrategy.GROUP,
@@ -256,11 +256,11 @@ W4A16 = dict(
         symmetric=True,
         dynamic=False,
     ),
-)
+}
 
 # 4 bit integer weights only asymmetric quantization
-W4A16_ASYM = dict(
-    weights=QuantizationArgs(
+W4A16_ASYM = {
+    "weights": QuantizationArgs(
         num_bits=4,
         type=QuantizationType.INT,
         strategy=QuantizationStrategy.GROUP,
@@ -268,11 +268,11 @@ W4A16_ASYM = dict(
         symmetric=False,
         dynamic=False,
     ),
-)
+}
 
 # 4 bit integer weights and 8 bit activations quantization
-INT8_W4A8 = dict(
-    weights=QuantizationArgs(
+INT8_W4A8 = {
+    "weights": QuantizationArgs(
         num_bits=4,
         type=QuantizationType.INT,
         group_size=128,
@@ -280,18 +280,18 @@ INT8_W4A8 = dict(
         symmetric=True,
         dynamic=False,
     ),
-    input_activations=QuantizationArgs(
+    "input_activations": QuantizationArgs(
         num_bits=8,
         type=QuantizationType.INT,
         strategy=QuantizationStrategy.TOKEN,
         symmetric=True,
         dynamic=True,
     ),
-)
+}
 
 # 4 bit integer weights and 8 bit FP activations quantization
-W4AFP8 = dict(
-    weights=QuantizationArgs(
+W4AFP8 = {
+    "weights": QuantizationArgs(
         num_bits=4,
         type=QuantizationType.INT,
         strategy=QuantizationStrategy.GROUP,
@@ -299,7 +299,7 @@ W4AFP8 = dict(
         symmetric=True,
         dynamic=False,
     ),
-    input_activations=QuantizationArgs(
+    "input_activations": QuantizationArgs(
         num_bits=8,
         type=QuantizationType.FLOAT,
         strategy=QuantizationStrategy.TOKEN,
@@ -307,49 +307,49 @@ W4AFP8 = dict(
         dynamic=True,
         observer=None,
     ),
-)
+}
 
 # FP8 weights and FP8 activations quantization
-FP8 = dict(
-    weights=QuantizationArgs(
+FP8 = {
+    "weights": QuantizationArgs(
         num_bits=8,
         type=QuantizationType.FLOAT,
         strategy=QuantizationStrategy.TENSOR,
         symmetric=True,
         dynamic=False,
     ),
-    input_activations=QuantizationArgs(
+    "input_activations": QuantizationArgs(
         num_bits=8,
         type=QuantizationType.FLOAT,
         strategy=QuantizationStrategy.TENSOR,
         symmetric=True,
         dynamic=False,
     ),
-)
+}
 
 # FP8 weights and FP8 dynamic activations quantization
-FP8_DYNAMIC = dict(
-    weights=QuantizationArgs(
+FP8_DYNAMIC = {
+    "weights": QuantizationArgs(
         num_bits=8,
         type=QuantizationType.FLOAT,
         strategy=QuantizationStrategy.CHANNEL,
         symmetric=True,
         dynamic=False,
     ),
-    input_activations=QuantizationArgs(
+    "input_activations": QuantizationArgs(
         num_bits=8,
         type=QuantizationType.FLOAT,
         strategy=QuantizationStrategy.TOKEN,
         symmetric=True,
         dynamic=True,
     ),
-)
+}
 
 # Block‐wise FP8 (deepseekv3-style quantization):
 # static 128x128 per‐block weights and
 # dynamic per‐token‐group activations
-FP8_BLOCK = dict(
-    weights=QuantizationArgs(
+FP8_BLOCK = {
+    "weights": QuantizationArgs(
         num_bits=8,
         type=QuantizationType.FLOAT,
         strategy=QuantizationStrategy.BLOCK,
@@ -357,7 +357,7 @@ FP8_BLOCK = dict(
         dynamic=False,
         block_structure=[128, 128],
     ),
-    input_activations=QuantizationArgs(
+    "input_activations": QuantizationArgs(
         num_bits=8,
         type=QuantizationType.FLOAT,
         strategy=QuantizationStrategy.GROUP,
@@ -365,7 +365,7 @@ FP8_BLOCK = dict(
         dynamic=True,
         group_size=128,
     ),
-)
+}
 
 PRESET_SCHEMES = {
     # Unquantized (no-op)

--- a/tests/test_quantization/lifecycle/test_enabled.py
+++ b/tests/test_quantization/lifecycle/test_enabled.py
@@ -20,7 +20,7 @@ def test_quantization_enabled_disabled():
     apply_quantization_config(
         model=quantized_model,
         config=QuantizationConfig(
-            config_groups=dict(W8A8=["Linear"]),
+            config_groups={"W8A8": ["Linear"]},
             quantization_status="calibration",
         ),
     )


### PR DESCRIPTION
This PR unifies dictionary initialization style by replacing all dict() constructor calls with {} literal syntax throughout the codebase.

The {} syntax was already the established convention in parts of the repo.
For example, PRESET_SCHEMES in quant_scheme.py was already defined using {} literals with quoted string keys. However, the same file also used dict() with keyword arguments for all 14 preset scheme definitions (W4A16, FP8, FP8_DYNAMIC, etc.), creating an inconsistent mix of both styles.

Similarly, files like offload/cache/base.py, offload/cache/disk.py, offload/dispatch.py, and quantization/lifecycle/apply.py used dict() for empty dict initialization where {} is more idiomatic.