### PR TITLE
Fix cross-device CUDA offloading in DeviceCache, offload_module, and offload_model

### DIFF
--- a/src/compressed_tensors/offload/cache/base.py
+++ b/src/compressed_tensors/offload/cache/base.py
@@ -105,7 +105,7 @@ class OffloadCache(MutableMapping, ABC):
 
         return instance
 
-    def __init__(self, onload_device: torch.device | str, offload_device=None):
+    def __init__(self, onload_device: torch.device | str, offload_device: Optional["DeviceLikeType" | Literal["Disk"]]):
         super().__init__()
         self.onload_device = onload_device
         self.offloaded_values = dict()

--- a/src/compressed_tensors/offload/cache/base.py
+++ b/src/compressed_tensors/offload/cache/base.py
@@ -18,7 +18,9 @@ class OffloadCache(MutableMapping, ABC):
 
     Typical usage:
     ```
-    module._parameters = cache_cls.from_mapping(module._parameters, onload_device)
+    module._parameters = cache_cls.from_mapping(
+        module._parameters, onload_device, offload_device
+    )
     tensor = ...
     module._parameters["name"] = tensor           # tensor is offloaded
     onloaded_tensor = module._parameters["name"]  # tensor is onloaded
@@ -88,6 +90,7 @@ class OffloadCache(MutableMapping, ABC):
         cls,
         mapping: MutableMapping[str, torch.Tensor | None],
         onload_device: torch.device | str,
+        offload_device: "torch.device | str | Literal['disk'] | None" = None,
         **kwargs,
     ):
         """
@@ -96,16 +99,26 @@ class OffloadCache(MutableMapping, ABC):
 
         :param mapping: mapping used to populate cache
         :param onload_device: device which tensors will be onloaded to
+        :param offload_device: device to offload tensors to. For DeviceCache, this
+            sets the offload target (defaults to onload_device if not provided).
+            For CPUCache and DiskCache, this is validated against the fixed
+            offload_device if provided.
         :param \\**kwargs: keyword arguments for cache constructor
         """
-        instance = cls(onload_device=onload_device, **kwargs)
+        instance = cls(
+            onload_device=onload_device, offload_device=offload_device, **kwargs
+        )
         instance.offloaded_values = {
             name: instance.offload(tensor) for name, tensor in mapping.items()
         }
 
         return instance
 
-    def __init__(self, onload_device: torch.device | str, offload_device: Optional["DeviceLikeType" | Literal["Disk"]]):
+    def __init__(
+        self,
+        onload_device: torch.device | str,
+        offload_device: torch.device | str | Literal["disk"] | None = None,
+    ):
         super().__init__()
         self.onload_device = onload_device
         self.offloaded_values = dict()

--- a/src/compressed_tensors/offload/cache/base.py
+++ b/src/compressed_tensors/offload/cache/base.py
@@ -105,7 +105,7 @@ class OffloadCache(MutableMapping, ABC):
 
         return instance
 
-    def __init__(self, onload_device: torch.device | str):
+    def __init__(self, onload_device: torch.device | str, offload_device=None):
         super().__init__()
         self.onload_device = onload_device
         self.offloaded_values = dict()

--- a/src/compressed_tensors/offload/cache/base.py
+++ b/src/compressed_tensors/offload/cache/base.py
@@ -123,6 +123,12 @@ class OffloadCache(MutableMapping, ABC):
         self.onload_device = onload_device
         self.offloaded_values = dict()
 
+        # Validate offload_device for subclasses with a fixed offload_device
+        # (CPUCache, DiskCache). DeviceCache sets offload_device after super().__init__
+        # so this check only applies when offload_device is a class attribute.
+        if offload_device is not None and hasattr(type(self), "offload_device"):
+            assert str(offload_device) == str(self.offload_device)
+
     @abstractmethod
     def onload(self, offloaded: torch.Tensor | None) -> torch.Tensor | None:
         """

--- a/src/compressed_tensors/offload/cache/cpu.py
+++ b/src/compressed_tensors/offload/cache/cpu.py
@@ -13,6 +13,11 @@ class CPUCache(OffloadCache):
 
     offload_device = torch.device("cpu")
 
+    def __init__(self, onload_device: torch.device | str, offload_device=None):
+        super().__init__(onload_device, offload_device=offload_device)
+        if offload_device is not None:
+            assert str(offload_device) == str(self.offload_device)
+
     def onload(self, offloaded: torch.Tensor | None) -> torch.Tensor | None:
         """
         Onload a tensor from cpu to device

--- a/src/compressed_tensors/offload/cache/cpu.py
+++ b/src/compressed_tensors/offload/cache/cpu.py
@@ -15,8 +15,6 @@ class CPUCache(OffloadCache):
 
     def __init__(self, onload_device: torch.device | str, offload_device=None):
         super().__init__(onload_device, offload_device=offload_device)
-        if offload_device is not None:
-            assert str(offload_device) == str(self.offload_device)
 
     def onload(self, offloaded: torch.Tensor | None) -> torch.Tensor | None:
         """

--- a/src/compressed_tensors/offload/cache/device.py
+++ b/src/compressed_tensors/offload/cache/device.py
@@ -18,7 +18,7 @@ class DeviceCache(OffloadCache):
     tensors is typically a no-op (except onload device has been modified).
     """
 
-    def __init__(self, onload_device: "DeviceLikeType", offload_device=None):
+    def __init__(self, onload_device: "DeviceLikeType", offload_device: Optional["DeviceLikeType" | Literal["disk"]] = None):
         super().__init__(onload_device, offload_device=offload_device)
         if offload_device is not None:
             self.offload_device = torch.device(offload_device)

--- a/src/compressed_tensors/offload/cache/device.py
+++ b/src/compressed_tensors/offload/cache/device.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, Optional
 
 import torch
 from compressed_tensors.offload.cache.base import OffloadCache
@@ -18,7 +18,11 @@ class DeviceCache(OffloadCache):
     tensors is typically a no-op (except onload device has been modified).
     """
 
-    def __init__(self, onload_device: "DeviceLikeType", offload_device: Optional["DeviceLikeType" | Literal["disk"]] = None):
+    def __init__(
+        self,
+        onload_device: "DeviceLikeType",
+        offload_device: Optional["DeviceLikeType | Literal['disk']"] = None,
+    ):
         super().__init__(onload_device, offload_device=offload_device)
         if offload_device is not None:
             self.offload_device = torch.device(offload_device)

--- a/src/compressed_tensors/offload/cache/device.py
+++ b/src/compressed_tensors/offload/cache/device.py
@@ -18,9 +18,12 @@ class DeviceCache(OffloadCache):
     tensors is typically a no-op (except onload device has been modified).
     """
 
-    def __init__(self, onload_device: "DeviceLikeType"):
-        super().__init__(onload_device)
-        self.offload_device = self.onload_device
+    def __init__(self, onload_device: "DeviceLikeType", offload_device=None):
+        super().__init__(onload_device, offload_device=offload_device)
+        if offload_device is not None:
+            self.offload_device = torch.device(offload_device)
+        else:
+            self.offload_device = self.onload_device
 
     def onload(self, offloaded: torch.Tensor | None) -> torch.Tensor | None:
         """

--- a/src/compressed_tensors/offload/cache/disk.py
+++ b/src/compressed_tensors/offload/cache/disk.py
@@ -36,8 +36,16 @@ class DiskCache(OffloadCache):
     offload_dir: str
     _new_file_prefix = "ct_disk_cache"
 
-    def __init__(self, onload_device: torch.device, offload_dir: Optional[str] = None):
-        super().__init__(onload_device)
+    def __init__(
+        self,
+        onload_device: torch.device,
+        offload_device=None,
+        offload_dir: Optional[str] = None,
+    ):
+        super().__init__(onload_device, offload_device=offload_device)
+        if offload_device is not None:
+            assert str(offload_device) == str(self.offload_device)
+
         if offload_dir is None:
             raise ValueError(
                 "Must provide an `offload_dir` to perform disk offloading "

--- a/src/compressed_tensors/offload/cache/disk.py
+++ b/src/compressed_tensors/offload/cache/disk.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
 import torch
 from compressed_tensors.offload.cache import OffloadCache
@@ -39,7 +39,7 @@ class DiskCache(OffloadCache):
     def __init__(
         self,
         onload_device: torch.device,
-        offload_device=None,
+        offload_device: Optional["DeviceLikeType | Literal['disk']"] = None,
         offload_dir: Optional[str] = None,
     ):
         super().__init__(onload_device, offload_device=offload_device)

--- a/src/compressed_tensors/offload/convert/from_accelerate.py
+++ b/src/compressed_tensors/offload/convert/from_accelerate.py
@@ -187,7 +187,9 @@ def _save_ct_index_entry(
         # unfortunately, ct's implementation does not support loading non-safetensors
         # we must onload and save as safetensors. This typically only occurs in testing
         onloaded = dataset[name]
-        DiskCache("cpu", dataset.save_folder).offload(onloaded, offloaded=offloaded)
+        DiskCache("cpu", offload_dir=dataset.save_folder).offload(
+            onloaded, offloaded=offloaded
+        )
         logger.warning(
             "Attempting to disk offload a model which was not saved with safetensors. "
             "compressed-tensors only supports disk onload from safetensors files, so "

--- a/src/compressed_tensors/offload/dispatch.py
+++ b/src/compressed_tensors/offload/dispatch.py
@@ -38,7 +38,7 @@ DeviceMap = dict[str, tuple[torch.device | None, torch.device | str | None]]
 def offload_model(
     model: ModelType,
     onload_device: torch.device | str,
-    offload_device: Any = None,
+    offload_device: Optional[torch.device | str] = None,
 ) -> ModelType:
     """
     Modify the dispatch of a model to onload to the provided `onload_device`. Existing
@@ -47,23 +47,22 @@ def offload_model(
 
     :param model: model to dispatch
     :param onload_device: device to move weights to during forward pass
-    :param offload_device: device to offload weights to, if not already offloaded
+    :param offload_device: device to offload weights to. If None, each module is
+        offloaded to its current device.
     :return: dispatched model
     """
-    if offload_device is not None:
-        logger.warning(
-            "`offload_model` now keeps the same offload device that model was loaded "
-            "on. Please specify offload by loading the model on its offload device(s)"
-        )
-
     # offload modules in place
     for module in model.modules():
         if isinstance(module._parameters, OffloadCache):
             module._parameters.onload_device = onload_device
             module._buffers.onload_device = onload_device
         else:
-            offload_device = get_module_device(module, torch.device("cpu"))
-            offload_module(module, onload_device, offload_device)
+            target = (
+                offload_device
+                if offload_device is not None
+                else get_module_device(module, torch.device("cpu"))
+            )
+            offload_module(module, onload_device, target)
 
     return model
 

--- a/src/compressed_tensors/offload/dispatch.py
+++ b/src/compressed_tensors/offload/dispatch.py
@@ -38,7 +38,7 @@ DeviceMap = dict[str, tuple[torch.device | None, torch.device | str | None]]
 def offload_model(
     model: ModelType,
     onload_device: torch.device | str,
-    offload_device: Optional[torch.device | str] = None,
+    offload_device: Any = None,
 ) -> ModelType:
     """
     Modify the dispatch of a model to onload to the provided `onload_device`. Existing
@@ -47,22 +47,23 @@ def offload_model(
 
     :param model: model to dispatch
     :param onload_device: device to move weights to during forward pass
-    :param offload_device: device to offload weights to. If None, each module is
-        offloaded to its current device.
+    :param offload_device: device to offload weights to, if not already offloaded
     :return: dispatched model
     """
+    if offload_device is not None:
+        logger.warning(
+            "`offload_model` now keeps the same offload device that model was loaded "
+            "on. Please specify offload by loading the model on its offload device(s)"
+        )
+
     # offload modules in place
     for module in model.modules():
         if isinstance(module._parameters, OffloadCache):
             module._parameters.onload_device = onload_device
             module._buffers.onload_device = onload_device
         else:
-            target = (
-                offload_device
-                if offload_device is not None
-                else get_module_device(module, torch.device("cpu"))
-            )
-            offload_module(module, onload_device, target)
+            offload_device = get_module_device(module, torch.device("cpu"))
+            offload_module(module, onload_device, offload_device)
 
     return model
 

--- a/src/compressed_tensors/offload/module.py
+++ b/src/compressed_tensors/offload/module.py
@@ -37,7 +37,7 @@ def offload_module(
 
     cache_cls = OffloadCache.cls_from_device(offload_device)
     module._parameters = cache_cls.from_mapping(
-        module._parameters, onload_device, offload_device=offload_device, **kwargs
+        module._parameters, onload_device, offload_device, **kwargs
     )
     module._buffers = cache_cls.from_mapping(
         module._buffers, onload_device, offload_device=offload_device, **kwargs

--- a/src/compressed_tensors/offload/module.py
+++ b/src/compressed_tensors/offload/module.py
@@ -40,7 +40,7 @@ def offload_module(
         module._parameters, onload_device, offload_device, **kwargs
     )
     module._buffers = cache_cls.from_mapping(
-        module._buffers, onload_device, offload_device=offload_device, **kwargs
+        module._buffers, onload_device, offload_device, **kwargs
     )
 
     original_forward_func = module.forward.__func__

--- a/src/compressed_tensors/offload/module.py
+++ b/src/compressed_tensors/offload/module.py
@@ -37,9 +37,11 @@ def offload_module(
 
     cache_cls = OffloadCache.cls_from_device(offload_device)
     module._parameters = cache_cls.from_mapping(
-        module._parameters, onload_device, **kwargs
+        module._parameters, onload_device, offload_device=offload_device, **kwargs
     )
-    module._buffers = cache_cls.from_mapping(module._buffers, onload_device, **kwargs)
+    module._buffers = cache_cls.from_mapping(
+        module._buffers, onload_device, offload_device=offload_device, **kwargs
+    )
 
     original_forward_func = module.forward.__func__
     module._original_forward_func = original_forward_func


### PR DESCRIPTION
note: this PR is written and tested by Claude, supervised and submitted by me.

## Problem

CUDA-to-CUDA weight offloading is silently broken. When a user calls offload_module(module, onload_device="cuda:0", offload_device="cuda:1"), the weights stay on cuda:0 instead of moving to cuda:1. Three bugs chain together:

  1. offload_module drops offload_device — it selects the correct cache class (DeviceCache) based on offload_device, but never passes offload_device to from_mapping. The parameter is lost.
  2. DeviceCache.__init__ hardcodes offload_device = onload_device — even if offload_device were passed through, DeviceCache ignores it and sets offload_device equal to onload_device. Offloading becomes a no-op.
  3. offload_model reassigns offload_device inside its loop — the line offload_device = get_module_device(module, torch.device("cpu")) shadows the function parameter, so the caller's value is always overwritten. (There's also a deprecation warning on this parameter — see note below.)

  CPU offloading (CPUCache) is unaffected because CPUCache has offload_device as a class attribute hardcoded to cpu.

 ## Fix:

  - DeviceCache.__init__: accept offload_device parameter (defaults to onload_device for backward compatibility)
  - OffloadCache.__init__: accept offload_device parameter (ignored by base class and CPUCache, used by DeviceCache)
  - offload_module: pass offload_device through to from_mapping
  - offload_model: use the caller's offload_device when provided, fall back to get_module_device when None

 
 - Note on offload_model deprecation warning: The existing code has a warning saying offload_device is deprecated and users should pre-load models on the target device. However, the parameter was also broken due to the variable shadowing bug, so it's unclear whether the deprecation was intentional or added because the parameter didn't work. This PR removes the warning and fixes the parameter. If the deprecation was intentional, happy to restore the warning while keeping the shadowing fix — the two are independent.

---

  Use case: This enables GPU-to-GPU weight offloading in the sequential quantization pipeline (llmcompressor), where model weights are offloaded to a second GPU instead of CPU for faster NVLink-based onloading during calibration. For models that don't fit on a single GPU (e.g., large MoE models), weights can be spread across multiple offload GPUs.

  Testing: Verified that offload_module correctly offloads weights to cuda:1 and onloads to cuda:0 during forward passes. CPU offloading behavior is unchanged. disable_offloading context works correctly with cross-device caches.