### PR TITLE
[Quantization] Torch compile quantization functions

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/forward.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward.py
@@ -431,7 +431,7 @@ def forward_quantize(
     )
 
 
-@torch.compile(mode="max-autotune")
+@torch.compile(mode="default")
 @torch.no_grad()
 def _quantize(
     x: torch.Tensor,
@@ -465,7 +465,7 @@ def _quantize(
     return quantized_value
 
 
-@torch.compile(mode="max-autotune")
+@torch.compile(mode="default")
 @torch.no_grad()
 def _dequantize(
     x_q: torch.Tensor,


### PR DESCRIPTION
## Purpose ##
* Improve runtime of quantization and dequantization operations

1.43x improvement over base implementation



<details><summary>`measure_runtime`</summary>

```
"""
#!/usr/bin/env python3
"""
Benchmark: Metadata + send/recv vs broadcast_object_list for tensor transfer
when the receiver doesn't know the tensor shape/dtype ahead of time.

Run with: torchrun --nproc_per_node=2 benchmark_tensor_transfer.py
Or: python -m torch.distributed.run --nproc_per_node=2 benchmark_tensor_transfer.py
"""

import os
import time
import argparse
from dataclasses import dataclass
from typing import Optional

import torch
import torch.distributed as dist


# Dtype encoding for metadata approach
DTYPE_TO_INT = {
    torch.float32: 0,
    torch.float64: 1,
    torch.float16: 2,
    torch.bfloat16: 3,
    torch.int32: 4,
    torch.int64: 5,
    torch.int16: 6,
    torch.int8: 7,
    torch.uint8: 8,
}
INT_TO_DTYPE = {v: k for k, v in DTYPE_TO_INT.items()}


@dataclass
class BenchmarkResult:
    method: str
    tensor_shape: tuple
    dtype: torch.dtype
    device: str
    num_iterations: int
    total_time_ms: float
    avg_time_ms: float
    std_time_ms: float
    throughput_gbps: float


def get_tensor_size_bytes(tensor: torch.Tensor) -> int:
    return tensor.numel() * tensor.element_size()


def format_size(size_bytes: int) -> str:
    if size_bytes >= 1e9:
        return f"{size_bytes / 1e9:.2f} GB"
    elif size_bytes >= 1e6:
        return f"{size_bytes / 1e6:.2f} MB"
    elif size_bytes >= 1e3:
        return f"{size_bytes / 1e3:.2f} KB"
    return f"{size_bytes} B"


# =============================================================================
# Method 1: Metadata + send/recv
# =============================================================================

def send_tensor_with_metadata(tensor: torch.Tensor, dst: int, group=None):
    """Send tensor with metadata prefix so receiver can allocate."""
    # Metadata: [ndim, dtype_enum, shape...]
    meta = torch.tensor(
        [tensor.ndim, DTYPE_TO_INT[tensor.dtype], *tensor.shape],
        dtype=torch.long,
        device=tensor.device,
    )
    dist.send(meta, dst, group=group)
    dist.send(tensor.contiguous(), dst, group=group)


def recv_tensor_with_metadata(src: int, device: torch.device, group=None, max_ndim: int = 8) -> torch.Tensor:
    """Receive tensor, first getting metadata to know shape/dtype."""
    # Buffer for metadata: ndim + dtype + up to max_ndim shape dims
    meta = torch.empty(2 + max_ndim, dtype=torch.long, device=device)
    dist.recv(meta, src, group=group)

    ndim = meta[0].item()
    dtype = INT_TO_DTYPE[meta[1].item()]
    shape = tuple(meta[2 : 2 + ndim].tolist())

    tensor = torch.empty(shape, dtype=dtype, device=device)
    dist.recv(tensor, src, group=group)
    return tensor


# =============================================================================
# Method 2: broadcast_object_list
# =============================================================================

def send_tensor_broadcast_object(tensor: torch.Tensor, src: int, group=None):
    """Send tensor using broadcast_object_list (pickle-based)."""
    obj_list = [tensor]
    dist.broadcast_object_list(obj_list, src=src, group=group)


def recv_tensor_broadcast_object(src: int, device: torch.device, group=None) -> torch.Tensor:
    """Receive tensor using broadcast_object_list."""
    obj_list = [None]
    dist.broadcast_object_list(obj_list, src=src, group=group)
    tensor = obj_list[0]
    # Ensure tensor is on the correct device
    if tensor.device != device:
        tensor = tensor.to(device)
    return tensor


# =============================================================================
# Benchmarking
# =============================================================================

def benchmark_metadata_approach(
    rank: int,
    tensor_shape: tuple,
    dtype: torch.dtype,
    device: torch.device,
    num_warmup: int,
    num_iterations: int,
) -> Optional[BenchmarkResult]:
    """Benchmark the metadata + send/recv approach."""
    times = []

    for i in range(num_warmup + num_iterations):
        if device.type == "cuda":
            torch.cuda.synchronize()
        dist.barrier()

        start = time.perf_counter()

        if rank == 0:
            tensor = torch.randn(tensor_shape, dtype=dtype, device=device)
            send_tensor_with_metadata(tensor, dst=1)
        else:
            tensor = recv_tensor_with_metadata(src=0, device=device)

        if device.type == "cuda":
            torch.cuda.synchronize()

        elapsed = time.perf_counter() - start

        if i >= num_warmup:
            times.append(elapsed * 1000)  # Convert to ms

    if rank == 0:
        times_tensor = torch.tensor(times)
        tensor_bytes = torch.empty(tensor_shape, dtype=dtype).numel() * torch.empty(1, dtype=dtype).element_size()
        avg_time = times_tensor.mean().item()
        throughput = (tensor_bytes * 8) / (avg_time / 1000) / 1e9  # Gbps

        return BenchmarkResult(
            method="metadata+send/recv",
            tensor_shape=tensor_shape,
            dtype=dtype,
            device=str(device),
            num_iterations=num_iterations,
            total_time_ms=times_tensor.sum().item(),
            avg_time_ms=avg_time,
            std_time_ms=times_tensor.std().item(),
            throughput_gbps=throughput,
        )
    return None


def benchmark_broadcast_object(
    rank: int,
    tensor_shape: tuple,
    dtype: torch.dtype,
    device: torch.device,
    num_warmup: int,
    num_iterations: int,
) -> Optional[BenchmarkResult]:
    """Benchmark the broadcast_object_list approach."""
    times = []

    for i in range(num_warmup + num_iterations):
        if device.type == "cuda":
            torch.cuda.synchronize()
        dist.barrier()

        start = time.perf_counter()

        if rank == 0:
            tensor = torch.randn(tensor_shape, dtype=dtype, device=device)
            send_tensor_broadcast_object(tensor, src=0)
        else:
            tensor = recv_tensor_broadcast_object(src=0, device=device)

        if device.type == "cuda":
            torch.cuda.synchronize()

        elapsed = time.perf_counter() - start

        if i >= num_warmup:
            times.append(elapsed * 1000)

    if rank == 0:
        times_tensor = torch.tensor(times)
        tensor_bytes = torch.empty(tensor_shape, dtype=dtype).numel() * torch.empty(1, dtype=dtype).element_size()
        avg_time = times_tensor.mean().item()
        throughput = (tensor_bytes * 8) / (avg_time / 1000) / 1e9

        return BenchmarkResult(
            method="broadcast_object_list",
            tensor_shape=tensor_shape,
            dtype=dtype,
            device=str(device),
            num_iterations=num_iterations,
            total_time_ms=times_tensor.sum().item(),
            avg_time_ms=avg_time,
            std_time_ms=times_tensor.std().item(),
            throughput_gbps=throughput,
        )
    return None


def run_benchmarks(args):
    """Run all benchmarks."""
    rank = dist.get_rank()
    world_size = dist.get_world_size()

    if world_size != 2:
        if rank == 0:
            print(f"Error: This benchmark requires exactly 2 processes, got {world_size}")
        return

    # Determine device
    if args.device == "cuda" and torch.cuda.is_available():
        local_rank = int(os.environ.get("LOCAL_RANK", 0))
        device = torch.device(f"cuda:{local_rank}")
        torch.cuda.set_device(device)
    else:
        device = torch.device("cpu")

    if rank == 0:
        print("=" * 80)
        print("Tensor Transfer Benchmark: metadata+send/recv vs broadcast_object_list")
        print("=" * 80)
        print(f"Device: {device}")
        print(f"Backend: {dist.get_backend()}")
        print(f"Warmup iterations: {args.warmup}")
        print(f"Benchmark iterations: {args.iterations}")
        print("=" * 80)

    # Test configurations
    shapes = [
        (100,),                    # 400 B (float32)
        (1000,),                   # 4 KB
        (10000,),                  # 40 KB
        (100000,),                 # 400 KB
        (1000000,),                # 4 MB
        (10000000,),               # 40 MB
        (256, 256),                # 256 KB
        (1024, 1024),              # 4 MB
        (4096, 4096),              # 64 MB
        (128, 256, 256),           # 32 MB (3D)
    ]

    if args.small_only:
        shapes = shapes[:5]

    dtypes = [torch.float32]
    if args.test_dtypes:
        dtypes = [torch.float32, torch.float16, torch.bfloat16]

    results = []

    for dtype in dtypes:
        for shape in shapes:
            tensor_bytes = torch.empty(shape, dtype=dtype).numel() * torch.empty(1, dtype=dtype).element_size()

            if rank == 0:
                print(f"\nTensor: shape={shape}, dtype={dtype}, size={format_size(tensor_bytes)}")
                print("-" * 60)

            # Benchmark metadata approach
            result1 = benchmark_metadata_approach(
                rank, shape, dtype, device, args.warmup, args.iterations
            )
            if result1:
                results.append(result1)
                print(f"  metadata+send/recv:    {result1.avg_time_ms:8.3f} ms ± {result1.std_time_ms:.3f} ms  "
                      f"({result1.throughput_gbps:.2f} Gbps)")

            dist.barrier()

            # Benchmark broadcast_object_list
            result2 = benchmark_broadcast_object(
                rank, shape, dtype, device, args.warmup, args.iterations
            )
            if result2:
                results.append(result2)
                print(f"  broadcast_object_list: {result2.avg_time_ms:8.3f} ms ± {result2.std_time_ms:.3f} ms  "
                      f"({result2.throughput_gbps:.2f} Gbps)")

            # Print speedup
            if result1 and result2:
                speedup = result2.avg_time_ms / result1.avg_time_ms
                print(f"  Speedup (metadata approach): {speedup:.2f}x")

            dist.barrier()

    # Summary
    if rank == 0:
        print("\n" + "=" * 80)
        print("SUMMARY")
        print("=" * 80)

        metadata_results = [r for r in results if r.method == "metadata+send/recv"]
        broadcast_results = [r for r in results if r.method == "broadcast_object_list"]

        if metadata_results and broadcast_results:
            avg_speedup = sum(
                b.avg_time_ms / m.avg_time_ms
                for m, b in zip(metadata_results, broadcast_results)
            ) / len(metadata_results)

            print(f"\nAverage speedup of metadata+send/recv over broadcast_object_list: {avg_speedup:.2f}x")

            # Find where each method performs best
            print("\nBest method by tensor size:")
            for m, b in zip(metadata_results, broadcast_results):
                winner = "metadata+send/recv" if m.avg_time_ms < b.avg_time_ms else "broadcast_object_list"
                size_str = format_size(
                    torch.empty(m.tensor_shape, dtype=m.dtype).numel() *
                    torch.empty(1, dtype=m.dtype).element_size()
                )
                ratio = max(m.avg_time_ms, b.avg_time_ms) / min(m.avg_time_ms, b.avg_time_ms)
                print(f"  {size_str:>10}: {winner} ({ratio:.2f}x faster)")


def main():
    parser = argparse.ArgumentParser(description="Benchmark tensor transfer methods")
    parser.add_argument("--device", type=str, default="cuda", choices=["cuda", "cpu"],
                        help="Device to use (cuda or cpu)")
    parser.add_argument("--warmup", type=int, default=5,
                        help="Number of warmup iterations")
    parser.add_argument("--iterations", type=int, default=20,
                        help="Number of benchmark iterations")
    parser.add_argument("--small-only", action="store_true",
                        help="Only test small tensor sizes")
    parser.add_argument("--test-dtypes", action="store_true",
                        help="Test multiple dtypes (float32, float16, bfloat16)")
    args = parser.parse_args()

    # Initialize distributed
    dist.init_process_group(backend="nccl" if args.device == "cuda" and torch.cuda.is_available() else "gloo")

    try:
        run_benchmarks(args)
    finally:
        dist.destroy_process_group()


if __name__ == "__main__":
    main()
```

</details>