### PR TITLE
[Bugfix] [Offload] Make sure disk operations only happen on rank 0

### DIFF
--- a/src/compressed_tensors/offload/convert/from_accelerate.py
+++ b/src/compressed_tensors/offload/convert/from_accelerate.py
@@ -181,7 +181,7 @@ def _save_ct_index_entry(
         # create a symlink that points to the model safetensor file
         # if the value is ever updated, the symlink is broken and a real file
         # is written to that location
-        DiskCache.create_checkpoint_symlink(offloaded, entry, dataset.offload_folder)
+        DiskCache.create_checkpoint_symlink(offloaded, entry, dataset.save_folder)
 
     else:
         # unfortunately, ct's implementation does not support loading non-safetensors


### PR DESCRIPTION
## Purpose ##
* Fix bug where symlinks and safetensors files were being written to by multiple ranks

## Background ##
The purpose of `from_accelerate` is to convert an accelerate offloaded model loaded from HF into a CT offloaded model. From the docstring:
> Rank 0 is always expected to provide an accelerate-offloaded model.
Other ranks (if they exist) may provide a model on any device, with or
without accelerate offloading.

The second part (with or without offloading) is typically (without) when loading from HF, as other ranks start on the meta device. However, this is not the case when converting back after `accelerate` has been called. When both ranks have accelerate, this means that both ranks call `_save_ct_index_entry`, and both ranks attempt to modify disk at the same time.

## Changes ##
* Ensure that only rank 0 writes files during conversion