### PR TITLE
Update `generate_gparam` calculation to handle NaNs and Infs

### DIFF
--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -323,8 +323,7 @@ def generate_gparam(
     min_vals = torch.min(updated_min_val, torch.zeros_like(updated_min_val))
     max_vals = torch.max(updated_max_val, torch.zeros_like(updated_max_val))
     max_val_pos = torch.max(torch.abs(min_vals), torch.abs(max_vals))
-    max_val_pos = max_val_pos.to(torch.float32)
-    max_val_pos = torch.clamp(max_val_pos, min=torch.finfo(torch.float32).tiny)
+    max_val_pos = torch.clamp(max_val_pos, min=torch.finfo(max_val_pos.dtype).tiny)
     global_scale = scale_data.max * quant_data.max / max_val_pos
 
     # Replace any NaN or Inf with 1.0. NaN arises when max_val_pos was NaN


### PR DESCRIPTION
Summary
- Clamp very small or 0 values for `max_val_pos` (such as in the case of dead weights with almost all or all 0s)
- Add a failsafe to handle NaNs and Infs to be 1