### PR TITLE
[bugfix][kv_cache_scheme] update KV_CACHE_TARGETS and use it

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -20,6 +20,7 @@ from compressed_tensors.quantization.quant_config import (
     QuantizationStatus,
 )
 from compressed_tensors.quantization.quant_scheme import QuantizationScheme
+from compressed_tensors.quantization.utils import KV_CACHE_TARGETS
 from compressed_tensors.utils.match import (
     is_narrow_match,
     match_named_modules,
@@ -158,7 +159,7 @@ def _apply_kv_cache_scheme(
     # this step cannot come after attention apply/initialize
     # otherwise it will override the attention qparams
     scheme = QuantizationScheme(
-        targets=[".*self_attn$"],  # is never read in practice
+        targets=KV_CACHE_TARGETS.copy(),  # is never read in practice
         input_activations=kv_cache_scheme,
     )
     for submodule in model.modules():

--- a/src/compressed_tensors/quantization/utils/helpers.py
+++ b/src/compressed_tensors/quantization/utils/helpers.py
@@ -42,7 +42,7 @@ __all__ = [
 
 # target the self_attn layer
 # QuantizedKVParameterCache is responsible for obtaining the k_scale and v_scale
-KV_CACHE_TARGETS = ["re:.*self_attn$"]
+KV_CACHE_TARGETS = ["re:.*(self_attn|attention)$"]
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
In conjunction with
* https://github.com/vllm-project/llm-compressor/pull/2477

this PR resolves user issue where kv cache scheme was not being applied correctly to modules named `.attention` or `.self_attention`:

> This regex misses attention modules with different names (e.g. "attention", "self_attention"), leaving their observers uninitialized and KV cache scales as garbage values.