### PR TITLE
Catch CPU OOM and mmap errors with user warning (#648)

### DIFF
--- a/src/compressed_tensors/offload/cache/__init__.py
+++ b/src/compressed_tensors/offload/cache/__init__.py
@@ -10,3 +10,4 @@ from .disk import DiskCache
 from .dist_cpu import DistributedCPUCache
 from .dist_device import DistributedDeviceCache
 from .dist_disk import DistributedDiskCache
+from .utils import catch_cpu_mem_error

--- a/src/compressed_tensors/offload/cache/cpu.py
+++ b/src/compressed_tensors/offload/cache/cpu.py
@@ -3,6 +3,7 @@
 
 import torch
 from compressed_tensors.offload.cache.base import OffloadCache
+from compressed_tensors.offload.cache.utils import catch_cpu_mem_error
 from compressed_tensors.offload.utils import send_tensors
 
 
@@ -25,6 +26,7 @@ class CPUCache(OffloadCache):
         """
         return send_tensors(offloaded, device=self.onload_device, copy=False)
 
+    @catch_cpu_mem_error
     def offload(self, tensor: torch.Tensor | None) -> torch.Tensor | None:
         """
         Offload a tensor from any device to cpu

--- a/src/compressed_tensors/offload/cache/dist_cpu.py
+++ b/src/compressed_tensors/offload/cache/dist_cpu.py
@@ -4,6 +4,7 @@
 import torch
 import torch.distributed as dist
 from compressed_tensors.offload.cache.cpu import CPUCache
+from compressed_tensors.offload.cache.utils import catch_cpu_mem_error
 from compressed_tensors.offload.utils import send_tensors, to_empty
 
 
@@ -12,6 +13,7 @@ class DistributedCPUCache(CPUCache):
     Handles offloading and onloading tensors from/to cpu memory shared across processes
     """
 
+    @catch_cpu_mem_error
     def offload(self, tensor: torch.Tensor | None) -> torch.Tensor | None:
         """
         Synchronously create shared cpu memory for offload
@@ -26,8 +28,8 @@ class DistributedCPUCache(CPUCache):
         tensor = tensor.contiguous()
 
         if dist.get_rank() == 0:
-            # create shared memory cpu tensor
-            tensor = super().offload(tensor).share_memory_()
+            tensor = super().offload(tensor)
+            tensor = tensor.share_memory_()
             handle, filename, nbytes = tensor.untyped_storage()._share_filename_cpu_()
             broadcast_obj = [handle, filename, nbytes]
         else:

--- a/src/compressed_tensors/offload/cache/dist_cpu.py
+++ b/src/compressed_tensors/offload/cache/dist_cpu.py
@@ -28,8 +28,8 @@ class DistributedCPUCache(CPUCache):
         tensor = tensor.contiguous()
 
         if dist.get_rank() == 0:
-            tensor = super().offload(tensor)
-            tensor = tensor.share_memory_()
+            # create shared memory cpu tensor
+            tensor = super().offload(tensor).share_memory_()
             handle, filename, nbytes = tensor.untyped_storage()._share_filename_cpu_()
             broadcast_obj = [handle, filename, nbytes]
         else:

--- a/src/compressed_tensors/offload/cache/utils.py
+++ b/src/compressed_tensors/offload/cache/utils.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import errno
+from functools import wraps
+
+from loguru import logger
+
+
+_CPU_MEMORY_KEYWORDS = (
+    "defaultcpuallocator",
+    "can't allocate memory",
+    "cannot allocate memory",
+    "failed to allocate",
+    "out of memory",
+    "mmap",
+    "shm_open",
+)
+
+_CPU_MEMORY_REMEDIATION = (
+    "CPU offloading ran out of host RAM or mmap descriptors. "
+    "Switch to disk offloading (`offload_device='disk'`) or "
+    "increase the OS mmap limit."
+)
+
+
+def _is_cpu_memory_error(exc: BaseException) -> bool:
+    errno_value = getattr(exc, "errno", None)
+    if errno_value == errno.ENOMEM:
+        return True
+    message = str(exc).lower()
+    return any(kw in message for kw in _CPU_MEMORY_KEYWORDS)
+
+
+def catch_cpu_mem_error(func):
+    """
+    Decorator to catch CPU memory errors and log a remediation warning.
+    Prevents duplicate logs if nested functions also use this decorator.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except (RuntimeError, OSError) as exc:
+            # Prevent duplicate logs when DistributedCPUCache calls super().offload()
+            if getattr(exc, "_cpu_mem_logged", False):
+                raise
+
+            if _is_cpu_memory_error(exc):
+                logger.warning(_CPU_MEMORY_REMEDIATION)
+                exc._cpu_mem_logged = True
+            raise
+
+    return wrapper

--- a/tests/test_offload/cache/test_cpu.py
+++ b/tests/test_offload/cache/test_cpu.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import compressed_tensors.offload.cache.cpu as cpu_cache
 import pytest
 import torch
+from loguru import logger as loguru_logger
 from tests.test_offload.cache.helpers import (
     _test_delete,
     _test_disable_offloading,
@@ -80,3 +82,63 @@ def test_shared_attributes(offload_device, onload_device, offload_cache):
 @requires_gpu
 def test_tensor_subclass(offload_device, onload_device, offload_cache):
     _test_tensor_subclass(offload_device, onload_device, offload_cache)
+
+
+@pytest.mark.unit
+@requires_gpu
+def test_offload_logs_memory_hint(onload_device):
+    cache = cpu_cache.CPUCache(onload_device)
+
+    original_send_tensors = cpu_cache.send_tensors
+
+    def raise_memory_error(*args, **kwargs):
+        raise RuntimeError("mmap failed: Cannot allocate memory")
+
+    cpu_cache.send_tensors = raise_memory_error
+
+    warnings = []
+    handler_id = loguru_logger.add(
+        lambda msg: warnings.append(msg.record["message"]), level="WARNING"
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="Cannot allocate memory"):
+            cache.offload(torch.zeros(1, device=onload_device))
+    finally:
+        cpu_cache.send_tensors = original_send_tensors
+        loguru_logger.remove(handler_id)
+
+    assert any(
+        "CPU offloading ran out of host RAM or mmap descriptors." in w for w in warnings
+    )
+
+
+@pytest.mark.unit
+@requires_gpu
+def test_offload_logs_memory_hint_oserror(onload_device):
+    import errno
+
+    cache = cpu_cache.CPUCache(onload_device)
+
+    original_send_tensors = cpu_cache.send_tensors
+
+    def raise_memory_error(*args, **kwargs):
+        raise OSError(errno.ENOMEM, "Cannot allocate memory")
+
+    cpu_cache.send_tensors = raise_memory_error
+
+    warnings = []
+    handler_id = loguru_logger.add(
+        lambda msg: warnings.append(msg.record["message"]), level="WARNING"
+    )
+
+    try:
+        with pytest.raises(OSError):
+            cache.offload(torch.zeros(1, device=onload_device))
+    finally:
+        cpu_cache.send_tensors = original_send_tensors
+        loguru_logger.remove(handler_id)
+
+    assert any(
+        "CPU offloading ran out of host RAM or mmap descriptors." in w for w in warnings
+    )

--- a/tests/test_offload/cache/test_dist_cpu.py
+++ b/tests/test_offload/cache/test_dist_cpu.py
@@ -6,6 +6,7 @@ import torch
 import torch.distributed as dist
 from compressed_tensors.offload import disable_onloading
 from compressed_tensors.offload.cache.dist_cpu import DistributedCPUCache
+from loguru import logger as loguru_logger
 from tests.test_offload.cache.helpers import (
     _test_delete,
     _test_disable_offloading,
@@ -178,3 +179,38 @@ def test_distributed_async_update(onload_device):
         offloaded_1 = cache["tensor_1"]
         assert torch.allclose(offloaded_0.cpu(), torch.ones(10) * 1.0)
         assert torch.allclose(offloaded_1.cpu(), torch.ones(10) * 2.0)
+
+
+@pytest.mark.unit
+@requires_gpu(2)
+@torchrun(world_size=2)
+def test_distributed_offload_logs_memory_hint(onload_device):
+    cache = DistributedCPUCache(onload_device)
+
+    original_share_memory = torch.Tensor.share_memory_
+
+    def raise_memory_error(*args, **kwargs):
+        raise RuntimeError("mmap failed: Cannot allocate memory")
+
+    torch.Tensor.share_memory_ = raise_memory_error
+
+    warnings = []
+    handler_id = loguru_logger.add(
+        lambda msg: warnings.append(msg.record["message"]), level="WARNING"
+    )
+
+    try:
+        # Only Rank 0 calls offload(), which throws an error *before* the dist.broadcast barrier.
+        # This cleanly avoids the hang since Rank 1 safely exits without waiting.
+        if dist.get_rank() == 0:
+            with pytest.raises(RuntimeError, match="Cannot allocate memory"):
+                cache.offload(torch.zeros(1, device=onload_device))
+    finally:
+        torch.Tensor.share_memory_ = original_share_memory
+        loguru_logger.remove(handler_id)
+
+    if dist.get_rank() == 0:
+        assert any(
+            "CPU offloading ran out of host RAM or mmap descriptors." in w
+            for w in warnings
+        )

--- a/tests/test_offload/cache/test_dist_cpu.py
+++ b/tests/test_offload/cache/test_dist_cpu.py
@@ -200,8 +200,9 @@ def test_distributed_offload_logs_memory_hint(onload_device):
     )
 
     try:
-        # Only Rank 0 calls offload(), which throws an error *before* the dist.broadcast barrier.
-        # This cleanly avoids the hang since Rank 1 safely exits without waiting.
+        # Only Rank 0 calls offload(), which throws an error *before* the
+        # dist.broadcast barrier. This cleanly avoids the hang since Rank 1
+        # safely exits without waiting.
         if dist.get_rank() == 0:
             with pytest.raises(RuntimeError, match="Cannot allocate memory"):
                 cache.offload(torch.zeros(1, device=onload_device))


### PR DESCRIPTION
Closes #648

## Summary
Catches `RuntimeError` and `OSError` raised during CPU offloading 
due to OOM or mmap exhaustion, and emits a helpful warning directing 
users to switch to disk offloading or increase the OS mmap limit.

## Changes
- `cpu.py`: Added `_is_cpu_memory_error`, `_CPU_MEMORY_REMEDIATION`, 
  and wrapped `send_tensors` call in `CPUCache.offload` with error handling
- `dist_cpu.py`: Wrapped `share_memory_()` and `_new_shared_filename_cpu` 
  calls with the same error handling
- Added tests for both

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error handling for CPU offloading operations. When tensor offloading fails due to insufficient host memory or mmap resource limits, users now receive a helpful diagnostic message to aid troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->