### PR TITLE
[configure_logger] UX fixes

### DIFF
--- a/src/compressed_tensors/logger.py
+++ b/src/compressed_tensors/logger.py
@@ -20,29 +20,6 @@ __all__ = ["LoggerConfig", "configure_logger", "logger"]
 _logged_once = set()
 
 
-def _parse_bool_env(value: Optional[str]) -> Optional[bool]:
-    """
-    Parse a boolean environment variable value.
-    Returns:
-        - None if the value is unset or unrecognized
-        - True for recognized truthy tokens
-        - False for recognized falsy tokens
-
-    Accepts: "1", "true", "True", "TRUE", "yes", "Yes", "YES" as True
-    Accepts: "0", "false", "False", "FALSE", "no", "No", "NO", "" as False
-    """
-    if value is None:
-        return None
-
-    value_lower = value.lower().strip()
-    if value_lower in ("1", "true", "yes"):
-        return True
-    elif value_lower in ("0", "false", "no", ""):
-        return False
-    else:
-        return None
-
-
 @dataclass
 class LoggerConfig:
     disabled: bool = False
@@ -69,11 +46,11 @@ def configure_logger(config: Optional[LoggerConfig] = None):
     logger_config = config or LoggerConfig()
 
     # env vars get priority
-    disabled_env = _parse_bool_env(os.getenv("COMPRESSED_TENSORS_LOG_DISABLED"))
+    disabled_env = parse_bool_env(os.getenv("COMPRESSED_TENSORS_LOG_DISABLED"))
     if disabled_env is not None:
         logger_config.disabled = disabled_env
 
-    clear_loggers_env = _parse_bool_env(os.getenv("COMPRESSED_TENSORS_CLEAR_LOGGERS"))
+    clear_loggers_env = parse_bool_env(os.getenv("COMPRESSED_TENSORS_CLEAR_LOGGERS"))
     if clear_loggers_env is not None:
         logger_config.clear_loggers = clear_loggers_env
 
@@ -114,6 +91,29 @@ def configure_logger(config: Optional[LoggerConfig] = None):
             serialize=True,
             filter=support_log_once,
         )
+
+
+def parse_bool_env(value: Optional[str]) -> Optional[bool]:
+    """
+    Parse a boolean environment variable value.
+    Returns:
+        - None if the value is unset or unrecognized
+        - True for recognized truthy tokens
+        - False for recognized falsy tokens
+
+    Accepts: "1", "true", "True", "TRUE", "yes", "Yes", "YES" as True
+    Accepts: "0", "false", "False", "FALSE", "no", "No", "NO", "" as False
+    """
+    if value is None:
+        return None
+
+    value_lower = value.lower().strip()
+    if value_lower in ("1", "true", "yes"):
+        return True
+    elif value_lower in ("0", "false", "no", ""):
+        return False
+    else:
+        return None
 
 
 def support_log_once(record: Dict[str, Any]) -> bool:

--- a/src/compressed_tensors/logger.py
+++ b/src/compressed_tensors/logger.py
@@ -23,7 +23,10 @@ _logged_once = set()
 def _parse_bool_env(value: Optional[str]) -> Optional[bool]:
     """
     Parse a boolean environment variable value.
-    Returns None if the value is None, True/False otherwise.
+    Returns:
+        - None if the value is unset or unrecognized
+        - True for recognized truthy tokens
+        - False for recognized falsy tokens
 
     Accepts: "1", "true", "True", "TRUE", "yes", "Yes", "YES" as True
     Accepts: "0", "false", "False", "FALSE", "no", "No", "NO", "" as False

--- a/src/compressed_tensors/logger.py
+++ b/src/compressed_tensors/logger.py
@@ -58,9 +58,7 @@ def configure_logger(config: Optional[LoggerConfig] = None):
     Note: Environment variables take precedence over the function parameters.
 
     By default, this function does NOT clear existing loggers or add new handlers,
-    making it safe to use in library code. Applications can opt-in to the previous
-    behavior by setting COMPRESSED_TENSORS_CLEAR_LOGGERS=1 and
-    COMPRESSED_TENSORS_LOG_LEVEL=INFO.
+    making it safe to use in library code.
 
     :param config: The configuration for the logger to use.
     :type config: LoggerConfig

--- a/src/compressed_tensors/logger.py
+++ b/src/compressed_tensors/logger.py
@@ -20,11 +20,33 @@ __all__ = ["LoggerConfig", "configure_logger", "logger"]
 _logged_once = set()
 
 
+def _parse_bool_env(value: Optional[str]) -> Optional[bool]:
+    """
+    Parse a boolean environment variable value.
+    Returns None if the value is None, True/False otherwise.
+
+    Accepts: "1", "true", "True", "TRUE", "yes", "Yes", "YES" as True
+    Accepts: "0", "false", "False", "FALSE", "no", "No", "NO", "" as False
+    """
+    if value is None:
+        return None
+
+    value_lower = value.lower().strip()
+    if value_lower in ("1", "true", "yes"):
+        return True
+    elif value_lower in ("0", "false", "no", ""):
+        return False
+    else:
+        # For backwards compatibility, any other non-empty string is treated as True
+        # but we should warn about this
+        return bool(value)
+
+
 @dataclass
 class LoggerConfig:
     disabled: bool = False
-    clear_loggers: bool = True
-    console_log_level: Optional[str] = "INFO"
+    clear_loggers: bool = False
+    console_log_level: Optional[str] = None
     log_file: Optional[str] = None
     log_file_level: Optional[str] = None
 
@@ -37,20 +59,31 @@ def configure_logger(config: Optional[LoggerConfig] = None):
 
     Note: Environment variables take precedence over the function parameters.
 
+    By default, this function does NOT clear existing loggers or add new handlers,
+    making it safe to use in library code. Applications can opt-in to the previous
+    behavior by setting COMPRESSED_TENSORS_CLEAR_LOGGERS=1 and
+    COMPRESSED_TENSORS_LOG_LEVEL=INFO.
+
     :param config: The configuration for the logger to use.
     :type config: LoggerConfig
     """
     logger_config = config or LoggerConfig()
 
     # env vars get priority
-    if bool(os.getenv("COMPRESSED_TENSORS_LOG_DISABLED")):
-        logger_config.disabled = True
-    if bool(os.getenv("COMPRESSED_TENSORS_CLEAR_LOGGERS")):
-        logger_config.clear_loggers = True
+    disabled_env = _parse_bool_env(os.getenv("COMPRESSED_TENSORS_LOG_DISABLED"))
+    if disabled_env is not None:
+        logger_config.disabled = disabled_env
+
+    clear_loggers_env = _parse_bool_env(os.getenv("COMPRESSED_TENSORS_CLEAR_LOGGERS"))
+    if clear_loggers_env is not None:
+        logger_config.clear_loggers = clear_loggers_env
+
     if (console_log_level := os.getenv("COMPRESSED_TENSORS_LOG_LEVEL")) is not None:
         logger_config.console_log_level = console_log_level.upper()
+
     if (log_file := os.getenv("COMPRESSED_TENSORS_LOG_FILE")) is not None:
         logger_config.log_file = log_file
+
     if (log_file_level := os.getenv("COMPRESSED_TENSORS_LOG_FILE_LEVEL")) is not None:
         logger_config.log_file_level = log_file_level.upper()
 

--- a/src/compressed_tensors/logger.py
+++ b/src/compressed_tensors/logger.py
@@ -38,7 +38,6 @@ def _parse_bool_env(value: Optional[str]) -> Optional[bool]:
         return False
     else:
         # For backwards compatibility, any other non-empty string is treated as True
-        # but we should warn about this
         return bool(value)
 
 

--- a/src/compressed_tensors/logger.py
+++ b/src/compressed_tensors/logger.py
@@ -37,8 +37,7 @@ def _parse_bool_env(value: Optional[str]) -> Optional[bool]:
     elif value_lower in ("0", "false", "no", ""):
         return False
     else:
-        # For backwards compatibility, any other non-empty string is treated as True
-        return bool(value)
+        return None
 
 
 @dataclass


### PR DESCRIPTION
Resolves #658 while retaining call to `configure_logger` in file:

1. no longer clear loggers by default
2. fix boolean env var parsing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deterministic parsing of boolean-like environment variables for logging, distinguishing unset, false, and true.
  * Existing loggers are no longer cleared by default.
  * Console logging is disabled by default and will only be enabled when an explicit console log level is set or provided via environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->