### PR TITLE
[Offload][bugfix] resolve source_path absolute path before symlinking

### DIFF
--- a/src/compressed_tensors/offload/cache/disk.py
+++ b/src/compressed_tensors/offload/cache/disk.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Optional
 
 import torch
@@ -51,7 +52,6 @@ class DiskCache(OffloadCache):
                 "Must provide an `offload_dir` to perform disk offloading "
                 "(add `offload_folder` argument to `from_pretrained`)"
             )
-        self.offload_dir = offload_dir
 
     def onload(self, offloaded: torch.Tensor | None) -> torch.Tensor | None:
         """
@@ -161,7 +161,9 @@ class DiskCache(OffloadCache):
         file_name = f"{cls._new_file_prefix}{id(offloaded)}.safetensors"
         file_path = os.path.join(offload_dir, file_name)
 
-        os.symlink(weight_info["safetensors_file"], file_path)
+        # Resolve relative paths to absolute paths for symlink creation
+        source_path = Path(weight_info["safetensors_file"]).resolve()
+        os.symlink(source_path, file_path)
         cls.index[offloaded] = {
             "safetensors_file": file_path,
             "weight_name": weight_info["weight_name"],

--- a/src/compressed_tensors/offload/cache/disk.py
+++ b/src/compressed_tensors/offload/cache/disk.py
@@ -52,7 +52,8 @@ class DiskCache(OffloadCache):
                 "Must provide an `offload_dir` to perform disk offloading "
                 "(add `offload_folder` argument to `from_pretrained`)"
             )
-        self.offload_dir = offload_dir
+        # Resolve relative paths to absolute paths for symlink creation
+        self.offload_dir = Path(offload_dir).resolve()
 
     def onload(self, offloaded: torch.Tensor | None) -> torch.Tensor | None:
         """

--- a/src/compressed_tensors/offload/cache/disk.py
+++ b/src/compressed_tensors/offload/cache/disk.py
@@ -52,6 +52,7 @@ class DiskCache(OffloadCache):
                 "Must provide an `offload_dir` to perform disk offloading "
                 "(add `offload_folder` argument to `from_pretrained`)"
             )
+        self.offload_dir = offload_dir
 
     def onload(self, offloaded: torch.Tensor | None) -> torch.Tensor | None:
         """

--- a/tests/test_offload/test_interface.py
+++ b/tests/test_offload/test_interface.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import tempfile
+from pathlib import Path
 
 import pytest
 import torch
@@ -172,7 +173,7 @@ def test_get_cache_kwargs_disk():
         offload_module(linear, ONLOAD_DEVICE, "disk", offload_dir=tmpdir)
 
         kwargs = get_cache_kwargs(linear)
-        assert kwargs == {"offload_dir": tmpdir}
+        assert kwargs == {"offload_dir": Path(tmpdir).resolve()}
 
 
 @pytest.mark.unit
@@ -219,7 +220,7 @@ def test_get_cache_init_kwargs_disk():
         # Verify the new module has the same offload settings including offload_dir
         assert_device_equal(new_linear._parameters.onload_device, ONLOAD_DEVICE)
         assert new_linear._parameters.offload_device == "disk"
-        assert new_linear._parameters.offload_dir == tmpdir
+        assert new_linear._parameters.offload_dir == Path(tmpdir).resolve()
         # Verify weights work correctly
         assert_device_equal(new_linear.weight.device, ONLOAD_DEVICE)
 
@@ -265,7 +266,7 @@ def test_register_offload_module_disk():
         assert parent.sub is sub
         assert_device_equal(sub._parameters.onload_device, ONLOAD_DEVICE)
         assert sub._parameters.offload_device == "disk"
-        assert sub._parameters.offload_dir == tmpdir
+        assert sub._parameters.offload_dir == Path(tmpdir).resolve()
         # Verify weights work correctly
         assert_device_equal(sub.weight.device, ONLOAD_DEVICE)
 


### PR DESCRIPTION
Previously offload symlinking used relative paths instead of absolute paths, which would error out if user used `MODEL_ID="./path/to/Model"` instead of `MODEL_ID="/path/to/Model"` and `offload_folder="./offload_folder"`, because the symlink would be broken:
`./offload_folder/ct_disk_cache140118015212704.safetensors -> ./path/to/Model/model-x-of-x.safetensors`
It needs to be:
`./offload_folder/ct_disk_cache140118015212704.safetensors -> ../path/to/Model/model-x-of-x.safetensors`

This changes to absolute paths:
`./offload_folder/ct_disk_cache140118015212704.safetensors -> /absolute/.../path/to/Model/model-x-of-x.safetensors`

This will fix example provided in https://github.com/vllm-project/llm-compressor/pull/2491/changes#diff-d01a405d3c59813946a5764a9b24e497b1ef07c2d0a896136a44671368ae9f74