### PR TITLE
Remove upper limit on torch version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ def _setup_packages() -> List:
     )
 
 def _setup_install_requires() -> List:
-    return ["torch>=1.7.0,<2.11", "transformers>=4.45.0", "pydantic>=2.0", "loguru"]
+    return ["torch>=1.7.0", "transformers>=4.45.0", "pydantic>=2.0", "loguru"]
 
 def _setup_extras() -> Dict:
     return {


### PR DESCRIPTION
Runners are blocked so tested through a custom flow: https://github.com/neuralmagic/llm-compressor-testing/actions/runs/24204588352