### PR TITLE
fix: skip double offload when from_pretrained wrapper runs twice

### DIFF
--- a/src/compressed_tensors/offload/convert/from_accelerate.py
+++ b/src/compressed_tensors/offload/convert/from_accelerate.py
@@ -11,7 +11,7 @@ from compressed_tensors.distributed import (
     is_distributed,
     is_source_process,
 )
-from compressed_tensors.offload.cache import DiskCache
+from compressed_tensors.offload.cache import DiskCache, OffloadCache
 from compressed_tensors.offload.convert.helpers import (
     DEFAULT_OFFLOAD_DEVICE,
     get_tensors,
@@ -46,6 +46,13 @@ def from_accelerate(model: torch.nn.Module) -> tuple["DeviceMap", str | None]:
 
     :param model: accelerate-offloaded model if source process, no constraint otherwise
     """
+    # Early exit if the model has already been converted to compressed-tensors
+    # offloading. This guards against redundant conversion when `from_pretrained`
+    # is patched by multiple wrappers in the same MRO chain (e.g.
+    # `AutoModelForCausalLM` delegating to `Qwen3ForCausalLM`).
+    if _is_offloaded(model):
+        return {}, None
+
     device_map, offload_dir = remove_accelerate(model)
 
     broadcast_obj = [device_map, offload_dir]
@@ -237,3 +244,7 @@ def _set_or_validate_offload(current: str | None, new: str) -> str:
     if current not in (None, new):
         raise ValueError("Expected all accelerate tensors to share offload")
     return new
+
+
+def _is_offloaded(model: torch.nn.Module) -> bool:
+    return any(isinstance(m._parameters, OffloadCache) for m in model.modules())

--- a/src/compressed_tensors/offload/load.py
+++ b/src/compressed_tensors/offload/load.py
@@ -11,7 +11,6 @@ from types import FrameType
 import psutil
 import torch
 from compressed_tensors.distributed import is_distributed, is_source_process
-from compressed_tensors.offload.cache import OffloadCache
 from compressed_tensors.offload.convert import from_accelerate
 from loguru import logger
 from transformers import PreTrainedModel
@@ -80,11 +79,7 @@ def patch_from_pretrained(obj: cls_to_patch, extra_cpu_mem: int):
             kwargs["max_memory"] = _get_device_memory() | _get_cpu_memory(extra_cpu_mem)
 
         model = original_func(cls, *args, **kwargs)
-
-        # Skip if the model was already converted by an inner wrapper (e.g.
-        # AutoModelForCausalLM delegates to Qwen3ForCausalLM, both wrapped)
-        if not _is_offloaded(model):
-            from_accelerate(model)
+        from_accelerate(model)  # rank 0 shares weights with ranks via offload/broadcast
 
         return model
 
@@ -124,10 +119,6 @@ def _get_shared_memory() -> int:
             "Could not find shared memory at `/dev/shm`. Please add platform suppport"
         )
         return psutil.virtual_memory().available
-
-
-def _is_offloaded(model: torch.nn.Module) -> bool:
-    return any(isinstance(m._parameters, OffloadCache) for m in model.modules())
 
 
 def _get_caller_frame() -> FrameType:

--- a/src/compressed_tensors/offload/load.py
+++ b/src/compressed_tensors/offload/load.py
@@ -12,6 +12,7 @@ import psutil
 import torch
 import torch.distributed as dist
 from compressed_tensors.distributed import is_distributed, is_source_process
+from compressed_tensors.offload.cache import OffloadCache
 from compressed_tensors.offload.convert import from_accelerate
 from loguru import logger
 from transformers import PreTrainedModel
@@ -80,7 +81,12 @@ def patch_from_pretrained(obj: cls_to_patch, extra_cpu_mem: int):
             kwargs["max_memory"] = _get_device_memory() | _get_cpu_memory(extra_cpu_mem)
 
         model = original_func(cls, *args, **kwargs)
-        from_accelerate(model)  # rank 0 shares weights with ranks via offload/broadcast
+
+        # Skip if the model was already converted by an inner wrapper (e.g.
+        # AutoModelForCausalLM delegates to Qwen3ForCausalLM, both wrapped)
+        if not _is_offloaded(model):
+            from_accelerate(model)
+
         return model
 
     try:
@@ -120,6 +126,10 @@ def _get_shared_memory() -> int:
             "Could not find shared memory at `/dev/shm`. Please add platform suppport"
         )
         return psutil.virtual_memory().available
+
+
+def _is_offloaded(model: torch.nn.Module) -> bool:
+    return any(isinstance(m._parameters, OffloadCache) for m in model.modules())
 
 
 def _get_caller_frame() -> FrameType:


### PR DESCRIPTION
## Summary
- Fixes an edge case where `load_offloaded_model` wraps `from_pretrained` on both a specific model class (e.g. `Qwen3ForCausalLM`) and `AutoModelForCausalLM`, causing `offload_module` to be called twice and raising a `ValueError`
- Adds a guard in the wrapper that checks whether the model is already offloaded (via `OffloadCache`) before calling `from_accelerate`, skipping the redundant conversion

## Test plan
- [x] Reproduce the original issue: import both `Qwen3ForCausalLM` and `AutoModelForCausalLM`, then call `AutoModelForCausalLM.from_pretrained(...)` inside `load_offloaded_model()` — verify no `ValueError`
- [x] Verify single-class usage (only `AutoModelForCausalLM` imported) still works as before
- [x] Run existing offload tests: `pytest tests/test_offload/`

Fixes https://github.com/vllm-project/compressed-tensors/issues/625