### PR TITLE
[offload] DiskCache.clean_offload_dir

### DIFF
--- a/src/compressed_tensors/offload/cache/disk.py
+++ b/src/compressed_tensors/offload/cache/disk.py
@@ -172,6 +172,47 @@ class DiskCache(OffloadCache):
             "dtype": weight_info["dtype"],
         }
 
+    @classmethod
+    def clean_offload_dir(cls, offload_dir: str | os.PathLike | None = None) -> int:
+        """
+        Clean up all intermediate safetensors files created by DiskCache.
+
+        Removes files and symlinks in offload_dir with the ct_disk_cache prefix.
+        - Symlinks: removes the symlink itself, NOT the original checkpoint it points to
+        - Regular files: removes intermediate tensors created during quantization
+
+        :param offload_dir: If provided, only clean files in this directory.
+                           If None, clean all files in the shared index.
+        :return: Number of files cleaned up
+        """
+        if offload_dir is not None:
+            offload_dir = str(Path(offload_dir).resolve())
+
+        files_cleaned = 0
+        for offloaded in list(cls.index.keys()):
+            file_path = cls.index[offloaded]["safetensors_file"]
+
+            # Only delete files in the specified dir (if provided)
+            if offload_dir is not None and not file_path.startswith(offload_dir):
+                continue
+
+            # Only delete files we created (with our prefix)
+            if os.path.basename(file_path).startswith(cls._new_file_prefix):
+                try:
+                    # os.unlink removes symlink itself, not target
+                    # os.remove removes regular file
+                    if os.path.islink(file_path):
+                        os.unlink(file_path)
+                    else:
+                        os.remove(file_path)
+                    files_cleaned += 1
+                except FileNotFoundError:
+                    pass  # Already deleted
+
+            del cls.index[offloaded]
+
+        return files_cleaned
+
 
 def _get_safe_open_device(device: "DeviceLikeType") -> str | int:
     """

--- a/src/compressed_tensors/offload/cache/dist_disk.py
+++ b/src/compressed_tensors/offload/cache/dist_disk.py
@@ -64,3 +64,33 @@ class DistributedDiskCache(DiskCache):
             offloaded = self.offloaded_values[key]
             del self.index[offloaded]
             super(DiskCache, self).__delitem__(key)
+
+    @classmethod
+    def clean_offload_dir(cls, offload_dir: str | None = None) -> int:
+        """
+        Clean up all intermediate safetensors files created by DiskCache.
+        In distributed settings, only rank 0 performs the actual file deletion.
+
+        :param offload_dir: If provided, only clean files in this directory.
+                           If None, clean all files in the shared index.
+        :return: Number of files cleaned up (only on rank 0, 0 on other ranks)
+        """
+        if dist.get_rank() == 0:
+            files_cleaned = super().clean_offload_dir(offload_dir)
+            dist.barrier()
+            return files_cleaned
+        else:
+            # Non-source processes still clear their index
+            if offload_dir is not None:
+                from pathlib import Path
+
+                offload_dir = str(Path(offload_dir).resolve())
+
+            for offloaded in list(cls.index.keys()):
+                file_path = cls.index[offloaded]["safetensors_file"]
+                if offload_dir is not None and not file_path.startswith(offload_dir):
+                    continue
+                del cls.index[offloaded]
+
+            dist.barrier()
+            return 0

--- a/tests/test_offload/cache/test_disk.py
+++ b/tests/test_offload/cache/test_disk.py
@@ -128,3 +128,69 @@ def test_files(tmp_path):
     files = os.listdir(offload_dir)
     assert len(DiskCache.index) == 0
     assert len(files) == 0
+
+
+@pytest.mark.unit
+def test_clean_offload_dir(tmp_path):
+    offload_dir = tmp_path / "offload_dir"
+    os.mkdir(offload_dir)
+
+    # Create multiple cache entries
+    DiskCache.index = {}
+    cache = DiskCache("cpu", offload_dir=str(offload_dir))
+    cache["weight1"] = torch.zeros(10)
+    cache["weight2"] = torch.ones(10)
+    cache["weight3"] = torch.randn(10)
+
+    # Verify files were created
+    files = os.listdir(offload_dir)
+    assert len(DiskCache.index) == 3
+    assert len(files) == 3
+
+    # Clean up all files
+    files_cleaned = DiskCache.clean_offload_dir()
+    assert files_cleaned == 3
+
+    # Verify cleanup
+    files = os.listdir(offload_dir)
+    assert len(DiskCache.index) == 0
+    assert len(files) == 0
+
+
+@pytest.mark.unit
+def test_clean_offload_dir_with_symlinks(tmp_path):
+    offload_dir = tmp_path / "offload_dir"
+    checkpoint_dir = tmp_path / "checkpoint"
+    os.mkdir(offload_dir)
+    os.mkdir(checkpoint_dir)
+
+    # Create a checkpoint file
+    checkpoint_file = checkpoint_dir / "model.safetensors"
+    from safetensors.torch import save_file
+
+    save_file({"weight": torch.zeros(10)}, str(checkpoint_file))
+
+    # Create symlink via create_checkpoint_symlink
+    DiskCache.index = {}
+    offloaded = torch.empty(10, device="meta")
+    weight_info = {
+        "safetensors_file": str(checkpoint_file),
+        "weight_name": "weight",
+        "dtype": "float32",
+    }
+    DiskCache.create_checkpoint_symlink(offloaded, weight_info, str(offload_dir))
+
+    # Verify symlink was created
+    files = os.listdir(offload_dir)
+    assert len(files) == 1
+    assert os.path.islink(offload_dir / files[0])
+
+    # Clean up should remove symlink but not target
+    files_cleaned = DiskCache.clean_offload_dir()
+    assert files_cleaned == 1
+
+    # Verify symlink removed but target still exists
+    files = os.listdir(offload_dir)
+    assert len(files) == 0
+    assert checkpoint_file.exists()
+    assert len(DiskCache.index) == 0


### PR DESCRIPTION
Corequisite:
* https://github.com/vllm-project/llm-compressor/pull/2605

The DiskCache creates several hundreds of intermediate files in user-provided `offload_dir` during normal operation with large models. These are either symlinks or intermediate tensors that are not necessary/valuable to keep around after successfully running an entrypoint.

PR adds helpers to clean any intermediate files that were added during normal operation.