### PR TITLE
[Transform] Fix WEIGHT_OUTPUT to also transform bias

### DIFF
--- a/src/compressed_tensors/transform/factory/base.py
+++ b/src/compressed_tensors/transform/factory/base.py
@@ -127,6 +127,17 @@ class TransformFactory(RegistryMixin, ABC):
             with torch.no_grad(), align_module_device(module):
                 update_offload_parameter(module, "weight", transform(module.weight))
 
+                # For WEIGHT_OUTPUT, the bias must also be transformed:
+                #   y' = R @ (W @ x + b) = (R @ W) @ x + R @ b
+                # Without this, models with bias (e.g. Qwen2 attention)
+                # produce incorrect outputs under head-wise rotations (R2).
+                if (
+                    args.location == TransformLocation.WEIGHT_OUTPUT
+                    and getattr(module, "bias", None) is not None
+                ):
+                    new_bias = transform(module.bias.unsqueeze(-1)).squeeze(-1)
+                    update_offload_parameter(module, "bias", new_bias)
+
             if self.scheme.requires_grad:
                 # for training, the weight changes with every forward pass
                 # so we can leverage parametrization to propagate the gradient

--- a/tests/test_transform/factory/test_correctness.py
+++ b/tests/test_transform/factory/test_correctness.py
@@ -146,6 +146,96 @@ def test_correctness_attention_heads(type, randomize, head_dim, input_batch_size
     assert torch.allclose(true_output, output, atol=1e-5, rtol=0.0)
 
 
+@pytest.mark.parametrize("type", ("hadamard", "random-hadamard", "random-matrix"))
+@pytest.mark.parametrize("randomize", (True, False))
+@pytest.mark.parametrize("head_dim", (None, 2, 4))
+@pytest.mark.parametrize("input_batch_size", (1, 5))
+def test_correctness_linear_with_bias(type, randomize, head_dim, input_batch_size):
+    """Test that WEIGHT_OUTPUT transforms correctly handle bias.
+
+    For WEIGHT_OUTPUT on a Linear with bias:
+        y' = R @ (W @ x + b) = (R @ W) @ x + (R @ b)
+    Both weight and bias must be transformed.
+    """
+    size = (4, 8)
+    module = torch.nn.Linear(*size, bias=True)
+    scheme = TransformScheme(type=type, randomize=randomize, head_dim=head_dim)
+    factory = TransformFactory.from_scheme(scheme, name="")
+
+    input = torch.rand((input_batch_size, 5, size[0]))
+    true_output = module(input)
+
+    # Apply WEIGHT_OUTPUT (transforms weight AND bias) then WEIGHT_INPUT inverse
+    config = TransformConfig(
+        config_groups={
+            "": TransformScheme(
+                type=type,
+                randomize=randomize,
+                head_dim=head_dim,
+                apply=[
+                    TransformArgs(targets="0", location="weight_output"),
+                    TransformArgs(targets="1", location="weight_input", inverse=True),
+                ],
+            )
+        }
+    )
+    model = torch.nn.Sequential(module, torch.nn.Linear(size[1], 16, bias=False))
+    true_output_full = model(input)
+    apply_transform_config(model, config)
+
+    output = model(input)
+    assert torch.allclose(true_output_full, output, atol=1e-5, rtol=0.0)
+
+
+@pytest.mark.parametrize("type", ("hadamard", "random-hadamard", "random-matrix"))
+@pytest.mark.parametrize("randomize", (True, False))
+@pytest.mark.parametrize("head_dim", (4, 8))
+@pytest.mark.parametrize("input_batch_size", (1, 5))
+def test_correctness_attention_heads_with_bias(
+    type, randomize, head_dim, input_batch_size
+):
+    """Test R2 head-wise rotation with attention bias (e.g. Qwen2 v_proj).
+
+    When v_proj has bias and R2 WEIGHT_OUTPUT is applied, the bias must also
+    be rotated for the o_proj WEIGHT_INPUT inverse to correctly cancel out.
+    """
+    hidden_size = 64
+    num_attention_heads = 8
+
+    attention = MockAttention(
+        hidden_size=hidden_size,
+        num_attention_heads=num_attention_heads,
+        num_key_value_heads=head_dim,
+    )
+    # Add bias to v_proj to simulate Qwen2-like architecture
+    attention.v_proj.bias = torch.nn.Parameter(
+        torch.randn(attention.v_proj.out_features)
+    )
+
+    input = torch.rand(input_batch_size, 5, hidden_size)
+    true_output = attention(input)
+
+    config = TransformConfig(
+        config_groups={
+            "R2": TransformScheme(
+                type=type,
+                randomize=randomize,
+                head_dim=head_dim,
+                apply=[
+                    TransformArgs(targets="v_proj", location="weight_output"),
+                    TransformArgs(
+                        targets="o_proj", location="weight_input", inverse=True
+                    ),
+                ],
+            )
+        }
+    )
+    apply_transform_config(attention, config)
+
+    output = attention(input)
+    assert torch.allclose(true_output, output, atol=1e-5, rtol=0.0)
+
+
 @pytest.mark.parametrize("type", ("hadamard", "random-hadamard"))
 @pytest.mark.parametrize("randomize", (True, False))
 @pytest.mark.parametrize("head_dim", (4, 8))

--- a/tests/test_transform/factory/test_correctness.py
+++ b/tests/test_transform/factory/test_correctness.py
@@ -159,11 +159,8 @@ def test_correctness_linear_with_bias(type, randomize, head_dim, input_batch_siz
     """
     size = (4, 8)
     module = torch.nn.Linear(*size, bias=True)
-    scheme = TransformScheme(type=type, randomize=randomize, head_dim=head_dim)
-    factory = TransformFactory.from_scheme(scheme, name="")
 
     input = torch.rand((input_batch_size, 5, size[0]))
-    true_output = module(input)
 
     # Apply WEIGHT_OUTPUT (transforms weight AND bias) then WEIGHT_INPUT inverse
     config = TransformConfig(


### PR DESCRIPTION
When applying a WEIGHT_OUTPUT transform (e.g. SpinQuant R2 head-wise rotation), only the weight matrix was being transformed. For layers with bias (e.g. Qwen2 attention q/k/v_proj), the bias must also be transformed:

    y' = R @ (W @ x + b) = (R @ W) @ x + (R @ b)

Without this fix, the untransformed bias causes the inverse transform on the downstream layer (e.g. o_proj WEIGHT_INPUT) to produce incorrect results, leading to catastrophic model degradation (PPL going from ~42 to 1.5M+ on Qwen2.5-0.5B).

The fix applies the same rotation to the bias vector by unsqueezing it to 2D, applying the transform, then squeezing back.

Added test coverage:
- test_correctness_linear_with_bias: verifies WEIGHT_OUTPUT correctly handles bias on plain Linear layers
- test_correctness_attention_heads_with_bias: verifies the R2 head-wise rotation scenario with biased v_proj (Qwen2-like)