### PR TITLE
Extend rounding to support FP16 and FP64

### DIFF
--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -22,7 +22,9 @@ __all__ = [
     "FP8_E4M3_DATA",
     "FP4_E2M1_DATA",
     "BFLOAT16_DATA",
+    "FLOAT16_DATA",
     "FLOAT32_DATA",
+    "FLOAT64_DATA",
     "FloatArgs",
     "QuantizationType",
     "QuantizationStrategy",
@@ -80,9 +82,19 @@ class BFLOAT16_DATA(FloatArgs):
     mantissa = 7
 
 
+class FLOAT16_DATA(FloatArgs):
+    exponent = 5
+    mantissa = 10
+
+
 class FLOAT32_DATA(FloatArgs):
     exponent = 8
     mantissa = 23
+
+
+class FLOAT64_DATA(FloatArgs):
+    exponent = 11
+    mantissa = 52
 
 
 class QuantizationType(str, Enum):

--- a/src/compressed_tensors/quantization/utils/mxfp_utils.py
+++ b/src/compressed_tensors/quantization/utils/mxfp_utils.py
@@ -70,7 +70,7 @@ def maybe_convert_from_mx_exp(
 def round_to_power_2(x: torch.Tensor) -> torch.Tensor:
     """
     Round values to the closest power of 2.
-    This is done by masking the values with BFLOAT16_SIGN_EXPONENT_MASK
+    This is done by masking the values with SIGN_EXPONENT_MASK,
     which essentially removes the mantissa and keeps the exponent.
     i.e the closest power of 2 for the input_value.
 
@@ -97,11 +97,12 @@ def round_to_power_2(x: torch.Tensor) -> torch.Tensor:
         int_dtype = torch.uint32
         mantissa = FLOAT32_DATA.mantissa
         exponent = FLOAT32_DATA.exponent
-    else:
-        assert scale_dtype is torch.float64
+    elif scale_dtype is torch.float64:
         int_dtype = torch.uint64
         mantissa = FLOAT64_DATA.mantissa
         exponent = FLOAT64_DATA.exponent
+    else:
+        raise TypeError(f"Unsupported dtype {scale_dtype}")
 
     if int_dtype in (torch.uint16, torch.uint32):
         x = x.view(int_dtype).to(torch.int32)
@@ -115,7 +116,7 @@ def round_to_power_2(x: torch.Tensor) -> torch.Tensor:
     # mask to only keep exponent - we conservatively round down
     # to better represent smaller numbers / prevent overflow
     block_max_uint = torch.bitwise_and(x + VAL_TO_ADD, SIGN_EXPONENT_MASK)
-    if scale_dtype is torch.bfloat16:
+    if int_dtype is torch.uint16:
         return block_max_uint.to(int_dtype).view(scale_dtype)
     return block_max_uint.view(scale_dtype)
 

--- a/src/compressed_tensors/quantization/utils/mxfp_utils.py
+++ b/src/compressed_tensors/quantization/utils/mxfp_utils.py
@@ -6,7 +6,9 @@ import math
 import torch
 from compressed_tensors.quantization.quant_args import (
     BFLOAT16_DATA,
+    FLOAT16_DATA,
     FLOAT32_DATA,
+    FLOAT64_DATA,
     FP4_E2M1_DATA,
     FP8_E4M3_DATA,
     QuantizationArgs,
@@ -87,13 +89,24 @@ def round_to_power_2(x: torch.Tensor) -> torch.Tensor:
         int_dtype = torch.uint16
         mantissa = BFLOAT16_DATA.mantissa
         exponent = BFLOAT16_DATA.exponent
-    else:
-        assert scale_dtype is torch.float32
+    elif scale_dtype is torch.float16:
+        int_dtype = torch.uint16
+        mantissa = FLOAT16_DATA.mantissa
+        exponent = FLOAT16_DATA.exponent
+    elif scale_dtype is torch.float32:
         int_dtype = torch.uint32
         mantissa = FLOAT32_DATA.mantissa
         exponent = FLOAT32_DATA.exponent
+    else:
+        assert scale_dtype is torch.float64
+        int_dtype = torch.uint64
+        mantissa = FLOAT64_DATA.mantissa
+        exponent = FLOAT64_DATA.exponent
 
-    x = x.view(int_dtype).to(torch.int32)
+    if int_dtype in (torch.uint16, torch.uint32):
+        x = x.view(int_dtype).to(torch.int32)
+    else:
+        x = x.view(int_dtype).to(torch.int64)
 
     # Find closest power of 2
     VAL_TO_ADD = 1 << (mantissa - FP4_E2M1_DATA.mantissa - 1)

--- a/tests/test_quantization/test_utils/test_mxfp4_utils.py
+++ b/tests/test_quantization/test_utils/test_mxfp4_utils.py
@@ -51,7 +51,9 @@ def test_round_power_2():
     assert torch.equal(rounded, x_rounded)
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize(
+    "dtype", [torch.bfloat16, torch.float16, torch.float32, torch.float64]
+)
 def test_mxfp4_scales_e2e(dtype):
     from compressed_tensors.quantization.quant_args import (
         QuantizationArgs,

--- a/tests/test_quantization/test_utils/test_mxfp8_utils.py
+++ b/tests/test_quantization/test_utils/test_mxfp8_utils.py
@@ -64,7 +64,9 @@ def test_should_generate_mx_scales_wrong_group_size():
     assert should_generate_mx_scales(args) is False
 
 
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize(
+    "dtype", [torch.bfloat16, torch.float16, torch.float32, torch.float64]
+)
 def test_mxfp8_scales_e2e(dtype):
     """End-to-end test for MXFP8 scale generation and conversion."""
     mock_weight = torch.normal(mean=0.0002, std=0.0576, size=(2880, 2880))


### PR DESCRIPTION
- Closes #670 
- Add FLOAT16_DATA and FLOAT64_DATA with relevant exponent / mantissa data
- Extend tests to consider FP16 and FP64 weights