### PR TITLE
Restrict group activation ordering to group quantization strategies

### DIFF
--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -332,13 +332,13 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
             raise ValueError(f"Block structure requires block strategy\n{model}")
 
         # validate activation ordering and strategy
-        if actorder is not None and strategy not in (
+        if actorder == ActivationOrdering.GROUP and strategy not in (
             QuantizationStrategy.GROUP,
             QuantizationStrategy.TENSOR_GROUP,
         ):
             raise ValueError(
                 "Must use group or tensor_group quantization strategy in "
-                "order to apply activation ordering"
+                "order to apply group activation ordering"
             )
 
         # infer observer w.r.t. dynamic

--- a/tests/test_quantization/test_quant_args.py
+++ b/tests/test_quantization/test_quant_args.py
@@ -80,21 +80,9 @@ def test_actorder():
     with pytest.raises(ValueError):
         QuantizationArgs(group_size=None, actorder="group")
     with pytest.raises(ValueError):
-        QuantizationArgs(group_size=None, actorder="weight")
-    with pytest.raises(ValueError):
-        QuantizationArgs(group_size=None, actorder="static")
-    with pytest.raises(ValueError):
         QuantizationArgs(group_size=-1, actorder="group")
     with pytest.raises(ValueError):
-        QuantizationArgs(group_size=-1, actorder="weight")
-    with pytest.raises(ValueError):
-        QuantizationArgs(group_size=-1, actorder="static")
-    with pytest.raises(ValueError):
         QuantizationArgs(strategy="tensor", actorder="group")
-    with pytest.raises(ValueError):
-        QuantizationArgs(strategy="tensor", actorder="weight")
-    with pytest.raises(ValueError):
-        QuantizationArgs(strategy="tensor", actorder="static")
 
     # test boolean and none defaulting
     assert (


### PR DESCRIPTION
- Modify the validation logic for explicitly defined `actorder` in quant_args.
- Restrict `ActivationOrdering.GROUP` to group-based strategies, which implicitly permits `ActivationOrdering.WEIGHT` when `strategy="block"` is passed.
- This further allows closing this [issue](https://github.com/vllm-project/llm-compressor/issues/2587).
- Remove value error tests since `actorder="weight"` is no longer limited to group strategies only.