### PR TITLE
fix: use file reference counting to handle shared tensor deletion

### DIFF
--- a/src/compressed_tensors/offload/cache/disk.py
+++ b/src/compressed_tensors/offload/cache/disk.py
@@ -36,6 +36,8 @@ class DiskCache(OffloadCache):
     index: ClassVar[dict[torch.Tensor, dict[str, str]]] = {}
 
     # file path -> reference count, to handle shared tensors (fixes #638)
+    # prevents double deletions, but will keep files alive for too long
+    # when references are dropped when not using `__del__`
     _file_refcounts: ClassVar[defaultdict[str, int]] = defaultdict(int)
 
     # directory where new tensors are written to
@@ -132,6 +134,8 @@ class DiskCache(OffloadCache):
             del self._file_refcounts[file_path]
             assert os.path.basename(file_path).startswith(self._new_file_prefix)
             os.remove(file_path)
+            del self.index[offloaded]
+
         super().__delitem__(key)
 
     def update_offload(self, offloaded: torch.Tensor, data: torch.Tensor | None):

--- a/src/compressed_tensors/offload/cache/disk.py
+++ b/src/compressed_tensors/offload/cache/disk.py
@@ -3,7 +3,7 @@
 
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, ClassVar, Literal, Optional
 
 import torch
 from compressed_tensors.distributed import is_source_process
@@ -32,7 +32,10 @@ class DiskCache(OffloadCache):
     offload_device = "disk"
 
     # offloaded tensors -> weight info
-    index: dict[torch.Tensor, dict[str, str]] = dict()
+    index: ClassVar[dict[torch.Tensor, dict[str, str]]] = {}
+
+    # file path -> reference count, to handle shared tensors (fixes #638)
+    _file_refcounts: ClassVar[dict[str, int]] = {}
 
     # directory where new tensors are written to
     offload_dir: str
@@ -104,6 +107,9 @@ class DiskCache(OffloadCache):
             "weight_name": "weight",
             "dtype": str(tensor.dtype).removeprefix("torch."),
         }
+        self._file_refcounts[file_path] = (
+            self._file_refcounts.get(file_path, 0) + 1
+        )
 
         save_file({"weight": tensor}, file_path)
         return offloaded
@@ -111,17 +117,25 @@ class DiskCache(OffloadCache):
     def __delitem__(self, key: str):
         """
         Remove the offload associated with `key`. If a new file was created to store
-        updated tensor data, that new tensor data file is deleted.
+        updated tensor data, that new tensor data file is deleted only when all
+        references to it have been removed (handles shared/tied tensors, fixes #638).
 
         Any references to onloaded tensors held by this class are invalidated.
 
         :param key: name of tensor to invalidate
         """
         offloaded = self.offloaded_values[key]
-        file_path = self.index[offloaded]["safetensors_file"]
-        if os.path.basename(file_path).startswith(self._new_file_prefix):
-            os.remove(file_path)
-        del self.index[offloaded]
+        weight_info = self.index.pop(offloaded, None)
+        if weight_info is not None:
+            file_path = weight_info["safetensors_file"]
+            self._file_refcounts[file_path] = self._file_refcounts.get(file_path, 0) - 1
+            if self._file_refcounts[file_path] <= 0:
+                del self._file_refcounts[file_path]
+                if os.path.basename(file_path).startswith(self._new_file_prefix):
+                    try:
+                        os.remove(file_path)
+                    except FileNotFoundError:
+                        pass
         super().__delitem__(key)
 
     def update_offload(self, offloaded: torch.Tensor, data: torch.Tensor | None):
@@ -172,6 +186,7 @@ class DiskCache(OffloadCache):
             "weight_name": weight_info["weight_name"],
             "dtype": weight_info["dtype"],
         }
+        cls._file_refcounts[file_path] = cls._file_refcounts.get(file_path, 0) + 1
 
 
 def _get_safe_open_device(device: "DeviceLikeType") -> str:

--- a/src/compressed_tensors/offload/cache/disk.py
+++ b/src/compressed_tensors/offload/cache/disk.py
@@ -23,7 +23,7 @@ class DiskCache(OffloadCache):
     """
     Handles offloading and onloading tensors from/to disk.
 
-    Tensors usually start as a key in safetensors file, converted by (TODO NAME).
+    The DiskCache index is usually populated from `accelerate` at model load time.
     New or updated tensors are written to new safetensors files in `offload_dir`.
 
     Tensors are stored in memory as meta tensors. The mapping between offloaded meta

--- a/src/compressed_tensors/offload/cache/disk.py
+++ b/src/compressed_tensors/offload/cache/disk.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import os
+from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Literal, Optional
 
@@ -35,7 +36,7 @@ class DiskCache(OffloadCache):
     index: ClassVar[dict[torch.Tensor, dict[str, str]]] = {}
 
     # file path -> reference count, to handle shared tensors (fixes #638)
-    _file_refcounts: ClassVar[dict[str, int]] = {}
+    _file_refcounts: ClassVar[defaultdict[str, int]] = defaultdict(int)
 
     # directory where new tensors are written to
     offload_dir: str
@@ -107,9 +108,7 @@ class DiskCache(OffloadCache):
             "weight_name": "weight",
             "dtype": str(tensor.dtype).removeprefix("torch."),
         }
-        self._file_refcounts[file_path] = (
-            self._file_refcounts.get(file_path, 0) + 1
-        )
+        self._file_refcounts[file_path] += 1
 
         save_file({"weight": tensor}, file_path)
         return offloaded
@@ -118,24 +117,21 @@ class DiskCache(OffloadCache):
         """
         Remove the offload associated with `key`. If a new file was created to store
         updated tensor data, that new tensor data file is deleted only when all
-        references to it have been removed (handles shared/tied tensors, fixes #638).
+        references to it have been removed (handles shared/tied tensors).
 
         Any references to onloaded tensors held by this class are invalidated.
 
         :param key: name of tensor to invalidate
         """
         offloaded = self.offloaded_values[key]
-        weight_info = self.index.pop(offloaded, None)
-        if weight_info is not None:
-            file_path = weight_info["safetensors_file"]
-            self._file_refcounts[file_path] = self._file_refcounts.get(file_path, 0) - 1
-            if self._file_refcounts[file_path] <= 0:
-                del self._file_refcounts[file_path]
-                if os.path.basename(file_path).startswith(self._new_file_prefix):
-                    try:
-                        os.remove(file_path)
-                    except FileNotFoundError:
-                        pass
+        weight_info = self.index.pop(offloaded)
+        file_path = weight_info["safetensors_file"]
+
+        self._file_refcounts[file_path] -= 1
+        if self._file_refcounts[file_path] <= 0:
+            del self._file_refcounts[file_path]
+            assert os.path.basename(file_path).startswith(self._new_file_prefix)
+            os.remove(file_path)
         super().__delitem__(key)
 
     def update_offload(self, offloaded: torch.Tensor, data: torch.Tensor | None):
@@ -186,7 +182,7 @@ class DiskCache(OffloadCache):
             "weight_name": weight_info["weight_name"],
             "dtype": weight_info["dtype"],
         }
-        cls._file_refcounts[file_path] = cls._file_refcounts.get(file_path, 0) + 1
+        cls._file_refcounts[file_path] += 1
 
 
 def _get_safe_open_device(device: "DeviceLikeType") -> str:

--- a/tests/test_offload/cache/test_disk.py
+++ b/tests/test_offload/cache/test_disk.py
@@ -128,3 +128,62 @@ def test_files(tmp_path):
     files = os.listdir(offload_dir)
     assert len(DiskCache.index) == 0
     assert len(files) == 0
+
+
+@pytest.mark.unit
+def test_shared_tensor_refcounts(tmp_path):
+    """
+    Test that the file reference counting mechanism correctly handles shared
+    tensors (like tied lm_head and embed_tokens weights) by not deleting files
+    until all references are removed.
+    """
+    offload_dir = tmp_path / "offload_dir"
+    os.mkdir(offload_dir)
+
+    # Reset class state
+    DiskCache.index = {}
+    DiskCache._file_refcounts.clear()
+
+    cache = DiskCache("cpu", offload_dir=str(offload_dir))
+
+    # Create a tensor and offload it
+    tensor = torch.zeros(10)
+    cache["weight1"] = tensor
+
+    # Get the file path for the first weight
+    files = os.listdir(offload_dir)
+    assert len(files) == 1
+    file_path = str(offload_dir / files[0])
+
+    # Verify reference count is 1
+    assert DiskCache._file_refcounts[file_path] == 1
+
+    # Simulate tied tensors by creating a second meta tensor that points
+    # to the same file. This mimics what happens when lm_head and
+    # embed_tokens share the same weights
+    from compressed_tensors.offload.utils import send_tensors
+
+    offloaded2 = send_tensors(tensor, device="meta")
+    cache.offloaded_values["weight2"] = offloaded2
+
+    # Manually set up the index entry to point to the same file
+    # (simulating tied tensors)
+    DiskCache.index[offloaded2] = {
+        "safetensors_file": file_path,
+        "weight_name": "weight",
+        "dtype": "float32",
+    }
+    DiskCache._file_refcounts[file_path] += 1
+    assert DiskCache._file_refcounts[file_path] == 2
+
+    # Delete first reference - file should NOT be deleted
+    del cache["weight1"]
+    files = os.listdir(offload_dir)
+    assert len(files) == 1, "File should still exist after first deletion"
+    assert DiskCache._file_refcounts[file_path] == 1
+
+    # Delete second reference - now file SHOULD be deleted
+    del cache["weight2"]
+    files = os.listdir(offload_dir)
+    assert len(files) == 0, "File should be deleted after all references removed"
+    assert file_path not in DiskCache._file_refcounts

--- a/tests/test_offload/cache/test_dist_disk.py
+++ b/tests/test_offload/cache/test_dist_disk.py
@@ -239,3 +239,88 @@ def test_distributed_async_update(tmp_path):
         offloaded_1 = cache["tensor_1"]
         assert_tensor_equal(offloaded_0, torch.ones(10) * 1.0, "disk")
         assert_tensor_equal(offloaded_1, torch.ones(10) * 2.0, "disk")
+
+
+@pytest.mark.unit
+@requires_gpu(2)
+@torchrun(world_size=2)
+def test_distributed_shared_tensor_refcounts(tmp_path):
+    """
+    Test that the file reference counting mechanism correctly handles shared
+    tensors in a distributed setting.
+    """
+    # Broadcast directory path from rank 0 to all ranks
+    if dist.get_rank() == 0:
+        offload_dir = tmp_path / "offload_dir"
+        os.mkdir(offload_dir)
+        broadcast_obj = [str(offload_dir)]
+    else:
+        broadcast_obj = [None]
+
+    dist.broadcast_object_list(broadcast_obj, src=0)
+    offload_dir = broadcast_obj[0]
+
+    # Ensure directory creation completes before other ranks proceed
+    dist.barrier()
+
+    # Reset class state
+    DiskCache.index = {}
+    DiskCache._file_refcounts.clear()
+
+    cache = DistributedDiskCache("cpu", offload_dir=offload_dir)
+
+    # Create a tensor and offload it
+    tensor = torch.zeros(10)
+    cache["weight1"] = tensor
+
+    # Verify reference count is 1
+    if dist.get_rank() == 0:
+        files = os.listdir(offload_dir)
+        assert len(files) == 1
+        file_path = str(offload_dir) + "/" + files[0]
+        assert DiskCache._file_refcounts[file_path] == 1
+
+    dist.barrier()
+
+    # Simulate tied tensors by creating a second meta tensor that points
+    # to the same file
+    from compressed_tensors.offload.utils import send_tensors
+
+    offloaded2 = send_tensors(tensor, device="meta")
+    cache.offloaded_values["weight2"] = offloaded2
+
+    # Get the file path from weight1's index entry
+    offloaded1 = cache.offloaded_values["weight1"]
+    shared_file_path = DiskCache.index[offloaded1]["safetensors_file"]
+
+    # Manually set up the index entry to point to the same file
+    DiskCache.index[offloaded2] = {
+        "safetensors_file": shared_file_path,
+        "weight_name": "weight",
+        "dtype": "float32",
+    }
+    DiskCache._file_refcounts[shared_file_path] += 1
+
+    # Verify reference count is 2
+    if dist.get_rank() == 0:
+        assert DiskCache._file_refcounts[file_path] == 2
+
+    dist.barrier()
+
+    # Delete first reference - file should NOT be deleted
+    del cache["weight1"]
+    if dist.get_rank() == 0:
+        files = os.listdir(offload_dir)
+        assert len(files) == 1, "File should still exist after first deletion"
+        assert DiskCache._file_refcounts[file_path] == 1
+
+    dist.barrier()
+
+    # Delete second reference - now file SHOULD be deleted
+    del cache["weight2"]
+    if dist.get_rank() == 0:
+        files = os.listdir(offload_dir)
+        assert len(files) == 0, "File should be deleted after all references removed"
+        assert file_path not in DiskCache._file_refcounts
+
+    dist.barrier()


### PR DESCRIPTION
## Summary

Fixes #638

## Problem

When multiple modules share a parameter (e.g. tied weights like `embed_tokens` and `lm_head` in transformers) and both are offloaded to disk, deleting one module's parameter removes the disk file. When the second module's parameter is later deleted, it attempts to delete the already-deleted file, causing a `FileNotFoundError`.

## Root Cause

`DiskCache.index` is a class-level dict shared across all instances. When a file is deleted in `__delitem__`, there's no check whether other entries (from other cache instances) still reference the same file.

## Fix

Add a class-level `_file_refcounts` dict that tracks how many index entries reference each file path:

- **`offload()`** and **`create_checkpoint_symlink()`**: increment refcount when adding to index
- **`__delitem__()`**: decrement refcount, only delete file when it reaches 0
- Use `index.pop(offloaded, None)` and catch `FileNotFoundError` for defensive robustness

## Test Plan

- [x] Logic verified: refcount increments on offload, decrements on delete, file deleted only at 0
- [ ] Add regression test for shared tensor deletion scenario
- [ ] CI: existing tests pass