### PR TITLE
Improve DiskCache error message with file path

### DIFF
--- a/src/compressed_tensors/offload/cache/disk.py
+++ b/src/compressed_tensors/offload/cache/disk.py
@@ -69,13 +69,19 @@ class DiskCache(OffloadCache):
         weight_info = self.index[offloaded]
         device = _get_safe_open_device(self.onload_device)
 
-        with safe_open(
-            weight_info["safetensors_file"], framework="pt", device=device
-        ) as file:
-            onloaded = file.get_tensor(weight_info["weight_name"])
-            onloaded = to_tensor(onloaded, offloaded)
-            onloaded = onloaded.to(getattr(torch, weight_info["dtype"]))
-            return onloaded
+        try:
+            with safe_open(
+                weight_info["safetensors_file"], framework="pt", device=device
+            ) as file:
+                onloaded = file.get_tensor(weight_info["weight_name"])
+                onloaded = to_tensor(onloaded, offloaded)
+                onloaded = onloaded.to(getattr(torch, weight_info["dtype"]))
+                return onloaded
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to load tensor '{weight_info['weight_name']}' from "
+                f"safetensors file: {weight_info['safetensors_file']}"
+            ) from e
 
     def offload(
         self, tensor: torch.Tensor | None, offloaded: Optional[torch.Tensor] = None


### PR DESCRIPTION
related to https://github.com/vllm-project/llm-compressor/issues/2665

## Summary
- Add try-except block in `DiskCache.onload()` to catch safetensors loading errors and re-raise with context
- Error messages now include the specific safetensors file path and weight name that failed to load
- Makes debugging "header too small" and similar safetensors errors much easier

## Example
Before:
```
safetensors_rust.SafetensorError: Error while deserializing header: header too small
```

After:
```
RuntimeError: Failed to load tensor 'model.layers.0.weight' from safetensors file: /path/to/file.safetensors
  (caused by) safetensors_rust.SafetensorError: Error while deserializing header: header too small
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)