### PR TITLE
[bugfix] Distributed Cache -- add barrier to update_offload to avoid race conditions

### DIFF
--- a/src/compressed_tensors/offload/__init__.py
+++ b/src/compressed_tensors/offload/__init__.py
@@ -115,9 +115,13 @@ def update_offload_parameter(module: torch.nn.Module, name: str, data: torch.Ten
     Update the offload and onload data of an existing parameter/buffer. Supports both
     parameters of both offloaded modules and non-offloaded modules.
 
-    NOTE: This function does not guard against multiple processes writing to offload
-    at the same time. It is the responsibility of the caller to ensure that, for any
-    parameter/buffer, only one rank calls this function at a time.
+    NOTE: When using DistributedDiskCache, DistributedCPUCache, or DistributedDeviceCache,
+    this function is safe to call from all ranks with the same data. Only the source rank
+    will perform the actual write, and a barrier ensures all ranks wait for completion.
+
+    NOTE: For non-distributed caches (DiskCache, CPUCache, DeviceCache), it is the
+    responsibility of the caller to ensure that only one rank calls this function at a
+    time to avoid race conditions.
 
     NOTE: This function does not update onloaded values across ranks. The caller is
     responsible for broadcasting any updates to other ranks, if they are onloaded.

--- a/src/compressed_tensors/offload/__init__.py
+++ b/src/compressed_tensors/offload/__init__.py
@@ -33,7 +33,6 @@ from compressed_tensors.offload.utils import (
 )
 from compressed_tensors.utils.helpers import deprecated, patch_attr
 
-
 __all__ = [
     # dispatch models
     "set_onload_device",
@@ -115,9 +114,10 @@ def update_offload_parameter(module: torch.nn.Module, name: str, data: torch.Ten
     Update the offload and onload data of an existing parameter/buffer. Supports both
     parameters of both offloaded modules and non-offloaded modules.
 
-    NOTE: When using DistributedDiskCache, DistributedCPUCache, or DistributedDeviceCache,
-    this function is safe to call from all ranks with the same data. Only the source rank
-    will perform the actual write, and a barrier ensures all ranks wait for completion.
+    NOTE: For distributed caches (DistributedDiskCache, DistributedCPUCache,
+    DistributedDeviceCache), this function is safe to call from all ranks with the same
+    data. Only the source rank will perform the actual write, and a synchronizing op
+    like torch.distributed.barrier() ensures all ranks wait for completion.
 
     NOTE: For non-distributed caches (DiskCache, CPUCache, DeviceCache), it is the
     responsibility of the caller to ensure that only one rank calls this function at a

--- a/src/compressed_tensors/offload/__init__.py
+++ b/src/compressed_tensors/offload/__init__.py
@@ -33,6 +33,7 @@ from compressed_tensors.offload.utils import (
 )
 from compressed_tensors.utils.helpers import deprecated, patch_attr
 
+
 __all__ = [
     # dispatch models
     "set_onload_device",

--- a/src/compressed_tensors/offload/cache/dist_cpu.py
+++ b/src/compressed_tensors/offload/cache/dist_cpu.py
@@ -59,3 +59,17 @@ class DistributedCPUCache(CPUCache):
         dist.barrier()
 
         return tensor
+
+    def update_offload(self, offloaded: torch.Tensor, data: torch.Tensor | None):
+        """
+        Update the offloaded cpu value with new data. Only rank 0 writes to avoid
+        race conditions, then all ranks wait at barrier.
+
+        :param offloaded: cpu tensor in shared memory to update
+        :param data: new data to copy from
+        """
+        if is_source_process():
+            super().update_offload(offloaded, data)
+
+        # wait for write to finish before any rank proceeds
+        dist.barrier()

--- a/src/compressed_tensors/offload/cache/dist_cpu.py
+++ b/src/compressed_tensors/offload/cache/dist_cpu.py
@@ -62,7 +62,7 @@ class DistributedCPUCache(CPUCache):
 
     def update_offload(self, offloaded: torch.Tensor, data: torch.Tensor | None):
         """
-        Update the offloaded cpu value with new data. Only rank 0 writes to avoid
+        Update the offloaded cpu value with new data. Only source rank writes to avoid
         race conditions, then all ranks wait at barrier.
 
         :param offloaded: cpu tensor in shared memory to update

--- a/src/compressed_tensors/offload/cache/dist_device.py
+++ b/src/compressed_tensors/offload/cache/dist_device.py
@@ -42,3 +42,17 @@ class DistributedDeviceCache(DeviceCache):
 
         dist.broadcast(as_broadcastable(tensor), src=get_source_rank())
         return tensor
+
+    def update_offload(self, offloaded: torch.Tensor, data: torch.Tensor | None):
+        """
+        Update the offloaded device value with new data, broadcasting from rank 0
+        to all other ranks.
+
+        :param offloaded: device tensor to update
+        :param data: new data to copy from
+        """
+        if is_source_process() and data is not None:
+            super().update_offload(offloaded, data)
+
+        # broadcast the updated data to all ranks
+        dist.broadcast(as_broadcastable(offloaded), src=get_source_rank())

--- a/src/compressed_tensors/offload/cache/dist_device.py
+++ b/src/compressed_tensors/offload/cache/dist_device.py
@@ -45,13 +45,13 @@ class DistributedDeviceCache(DeviceCache):
 
     def update_offload(self, offloaded: torch.Tensor, data: torch.Tensor | None):
         """
-        Update the offloaded device value with new data, broadcasting from rank 0
+        Update the offloaded device value with new data, broadcasting from source rank
         to all other ranks.
 
         :param offloaded: device tensor to update
         :param data: new data to copy from
         """
-        if is_source_process() and data is not None:
+        if is_source_process():
             super().update_offload(offloaded, data)
 
         # broadcast the updated data to all ranks

--- a/src/compressed_tensors/offload/cache/dist_disk.py
+++ b/src/compressed_tensors/offload/cache/dist_disk.py
@@ -49,6 +49,20 @@ class DistributedDiskCache(DiskCache):
         dist.barrier()
         return offloaded
 
+    def update_offload(self, offloaded: torch.Tensor, data: torch.Tensor | None):
+        """
+        Write new param data to file that already exists. Only rank 0 writes,
+        then all ranks wait at barrier to ensure write completes before reads.
+
+        :param offloaded: meta tensors representating parameter to update
+        :param data: new data
+        """
+        if is_source_process():
+            super().update_offload(offloaded, data)
+
+        # wait for write to finish before any rank tries to read
+        dist.barrier()
+
     def __delitem__(self, key: str):
         """
         Remove the offload associated with `key`. If a new file was created to store

--- a/src/compressed_tensors/offload/cache/dist_disk.py
+++ b/src/compressed_tensors/offload/cache/dist_disk.py
@@ -51,7 +51,7 @@ class DistributedDiskCache(DiskCache):
 
     def update_offload(self, offloaded: torch.Tensor, data: torch.Tensor | None):
         """
-        Write new param data to file that already exists. Only rank 0 writes,
+        Write new param data to file that already exists. Only source rank writes,
         then all ranks wait at barrier to ensure write completes before reads.
 
         :param offloaded: meta tensors representating parameter to update

--- a/tests/test_offload/cache/test_dist_disk.py
+++ b/tests/test_offload/cache/test_dist_disk.py
@@ -239,3 +239,41 @@ def test_distributed_async_update(tmp_path):
         offloaded_1 = cache["tensor_1"]
         assert_tensor_equal(offloaded_0, torch.ones(10) * 1.0, "disk")
         assert_tensor_equal(offloaded_1, torch.ones(10) * 2.0, "disk")
+
+
+@pytest.mark.unit
+@requires_gpu(2)
+@torchrun(world_size=2)
+def test_distributed_concurrent_update(tmp_path):
+    """
+    Test that all ranks can safely update the same tensor concurrently without
+    causing race conditions. This tests the fix for the safetensors "header too small"
+    error that occurs when one rank reads while another writes.
+    """
+    offload_dir = tmp_path / "offload_dir"
+    if dist.get_rank() == 0:
+        os.mkdir(offload_dir)
+
+    # Ensure directory creation completes before other ranks proceed
+    dist.barrier()
+
+    onload_device = torch.accelerator.current_accelerator()
+    cache = DistributedDiskCache(onload_device, offload_dir=str(offload_dir))
+
+    # Initialize tensor in the cache
+    cache["weight"] = torch.zeros(100, device=onload_device)
+
+    # All ranks update the same tensor concurrently with the same value
+    # This tests that update_offload properly synchronizes via barrier
+    for i in range(5):
+        new_value = torch.ones(100, device=onload_device) * float(i + 1)
+        cache["weight"] = new_value
+
+        # Verify all ranks can read the updated value without race conditions
+        read_value = cache["weight"]
+        assert torch.allclose(read_value.cpu(), new_value.cpu())
+
+    # Final verification that offloaded file is correct
+    with disable_onloading():
+        offloaded = cache["weight"]
+        assert_tensor_equal(offloaded, torch.ones(100) * 5.0, "disk")


### PR DESCRIPTION
* Resolves https://github.com/vllm-project/llm-compressor/issues/2665

Prior to this PR, `update_offload` calls on DistributedDisk/CPU/DeviceCache were concluded without a `dist.barrier` or other synchronizing torch.distributed op. This caused some ranks to continue to the next operation while the source rank was still writing, triggering a race condition which is the root cause of above issue if the next operation for some of the other ranks is to read from that file.

This PR updates to explicitly call dist.barrier or some other synchronizing function before update_offload ends.

TEST PLAN:
- [x] torchrun test to capture this
- [x] On main, the following example will trigger the error first raised in #llm-compressor/2665. On this branch, the example runs successfully.

<details><summary>Example creation script</summary>

```python
#############################################################################
# This script is adapted from ./llama_example.py and adds DDP functionality.
# run this with `torchrun --nproc_per_node=2 llama_example_ddp.py`
# or change nproc_per_node to your desired configuration
# to adapt other examples to use DDP, see the 2 altered sections below
#############################################################################

import time

import torch
from torch import distributed as dist
from compressed_tensors.offload import dispatch_model, init_dist, load_offloaded_model
from datasets import load_dataset
from transformers import AutoModelForCausalLM, AutoTokenizer

from llmcompressor import oneshot
from llmcompressor.datasets.utils import get_rank_partition
from llmcompressor.modifiers.quantization import QuantizationModifier
from llmcompressor.modifiers.transform.awq import AWQModifier

# Select model and load it.
MODEL_ID = "meta-llama/Meta-Llama-3-8B-Instruct"

init_dist()
with load_offloaded_model():
    model = AutoModelForCausalLM.from_pretrained(
        MODEL_ID,
        dtype="auto",
        device_map="auto_offload",
        offload_folder=f"./offload_dir",
        max_memory={"cpu": 10e9},  # don't exceed 10GB RAM
    )
tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, trust_remote_code=True)

# Select calibration dataset.
DATASET_ID = "HuggingFaceH4/ultrachat_200k"
DATASET_SPLIT = "train_sft"

# Select number of samples. 256 samples is a good place to start.
# Increasing the number of samples can improve accuracy.
NUM_CALIBRATION_SAMPLES = 256
MAX_SEQUENCE_LENGTH = 512

# Load dataset and preprocess.
ds = load_dataset(
    DATASET_ID, split=get_rank_partition(DATASET_SPLIT, NUM_CALIBRATION_SAMPLES)
)
ds = ds.shuffle(seed=42)


def preprocess(example):
    return {
        "text": tokenizer.apply_chat_template(
            example["messages"],
            tokenize=False,
        )
    }


ds = ds.map(preprocess)


# Tokenize inputs.
def tokenize(sample):
    return tokenizer(
        sample["text"],
        padding=False,
        max_length=MAX_SEQUENCE_LENGTH,
        truncation=True,
        add_special_tokens=False,
    )


# Configure the quantization algorithm to run.
recipe = [
    AWQModifier(duo_scaling="both"),
    QuantizationModifier(ignore=["lm_head"], scheme="W4A16_ASYM", targets=["Linear"]),
]

torch.cuda.reset_peak_memory_stats()
start_time = time.time()

# Apply algorithms.
oneshot(
    model=model,
    dataset=ds,
    recipe=recipe,
    max_seq_length=MAX_SEQUENCE_LENGTH,
    num_calibration_samples=NUM_CALIBRATION_SAMPLES,
)

elapsed_time = time.time() - start_time
peak_memory_gb = torch.cuda.max_memory_allocated() / (1024**3)
print("Quantization Complete")
print(f"Time: {elapsed_time / 60:.2f} minutes ({elapsed_time:.2f} seconds)")
print(f"Peak GPU Memory: {peak_memory_gb:.2f} GB")

# Confirm generations of the quantized model look sane.
print("\n\n")
print("========== SAMPLE GENERATION ==============")
dispatch_model(model)
input_ids = tokenizer("Hello my name is", return_tensors="pt").input_ids.to(
    model.device
)
output = model.generate(input_ids, max_new_tokens=100)
print(tokenizer.decode(output[0]))
print("==========================================\n\n")

# Save to disk compressed.
SAVE_DIR = (
    MODEL_ID.rstrip("/").split("/")[-1]
    + "-awq-asym-DDP"
    + str(torch.distributed.get_world_size())
)
model.save_pretrained(SAVE_DIR, save_compressed=True)
tokenizer.save_pretrained(SAVE_DIR)

torch.distributed.destroy_process_group()
```
</details> 