### PR TITLE
Add AutoAWQ checkpoint converter

### DIFF
--- a/examples/convert_checkpoint/autoawq_example.py
+++ b/examples/convert_checkpoint/autoawq_example.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from compressed_tensors.config import CompressionFormat
+from compressed_tensors.entrypoints.convert import AutoAWQConverter, convert_checkpoint
+from transformers import AutoConfig
+
+
+MODEL_ID = "AMead10/Llama-3.2-3B-Instruct-AWQ"
+SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1]
+
+autoawq_config = AutoConfig.from_pretrained(MODEL_ID).quantization_config
+
+# Convert AutoAWQ GEMM tensors into compressed-tensors W4A16 format.
+convert_checkpoint(
+    model_stub=MODEL_ID,
+    save_directory=SAVE_DIR,
+    converter=AutoAWQConverter.from_autoawq_config(
+        autoawq_config,
+        quantization_format=CompressionFormat.naive_quantized.value,
+    ),
+    max_workers=8,
+)

--- a/examples/convert_checkpoint/autoawq_example.py
+++ b/examples/convert_checkpoint/autoawq_example.py
@@ -1,23 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from compressed_tensors.config import CompressionFormat
 from compressed_tensors.entrypoints.convert import AutoAWQConverter, convert_checkpoint
-from transformers import AutoConfig
 
 
-MODEL_ID = "AMead10/Llama-3.2-3B-Instruct-AWQ"
+MODEL_ID = "Qwen/Qwen2.5-14B-Instruct-AWQ"
 SAVE_DIR = MODEL_ID.rstrip("/").split("/")[-1]
-
-autoawq_config = AutoConfig.from_pretrained(MODEL_ID).quantization_config
 
 # Convert AutoAWQ GEMM tensors into compressed-tensors W4A16 format.
 convert_checkpoint(
     model_stub=MODEL_ID,
     save_directory=SAVE_DIR,
-    converter=AutoAWQConverter.from_autoawq_config(
-        autoawq_config,
-        quantization_format=CompressionFormat.naive_quantized.value,
-    ),
+    converter=AutoAWQConverter.from_pretrained(MODEL_ID),
     max_workers=8,
 )

--- a/src/compressed_tensors/entrypoints/convert/README.md
+++ b/src/compressed_tensors/entrypoints/convert/README.md
@@ -30,6 +30,11 @@ The conversion logic is implemented through the `Converter` protocol, which defi
 - Inverts scale tensors to match compressed-tensors conventions
 - Supports targeted conversion with `ignore` and `targets` patterns
 
+**AutoAWQConverter**: Converts AutoAWQ GEMM checkpoints to compressed-tensors W4A16 format
+- Unpacks AutoAWQ `qweight` and `qzeros` tensors
+- Reorders packed values from AutoAWQ's bit layout into compressed-tensors' signed integer convention
+- Supports `naive-quantized` and `pack-quantized` output formats
+
 ## Usage Example
 
 Examples available at `examples/convert_checkpoint`.

--- a/src/compressed_tensors/entrypoints/convert/README.md
+++ b/src/compressed_tensors/entrypoints/convert/README.md
@@ -33,7 +33,7 @@ The conversion logic is implemented through the `Converter` protocol, which defi
 **AutoAWQConverter**: Converts AutoAWQ GEMM checkpoints to compressed-tensors W4A16 format
 - Unpacks AutoAWQ `qweight` and `qzeros` tensors
 - Reorders packed values from AutoAWQ's bit layout into compressed-tensors' signed integer convention
-- Supports `naive-quantized` and `pack-quantized` output formats
+- Emits `pack-quantized` compressed-tensors checkpoints
 
 ## Usage Example
 

--- a/src/compressed_tensors/entrypoints/convert/converters/__init__.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/__init__.py
@@ -7,3 +7,4 @@
 from .base import *
 from .modelopt_nvfp4 import *
 from .fp8block_dequantizer import *
+from .autoawq import *

--- a/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
@@ -36,54 +36,6 @@ class AutoAWQConverter(Converter):
 
     AWQ_REVERSE_ORDER = [0, 4, 1, 5, 2, 6, 3, 7]
 
-    @staticmethod
-    def unpack_awq(
-        qweight: torch.Tensor, qzeros: torch.Tensor | None, bits: int
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        """
-        Unpack AutoAWQ GEMM int32-packed weights and zero-points into int8 values.
-        """
-        shifts = torch.arange(0, 32, bits, device=qweight.device)
-
-        iweights = torch.bitwise_right_shift(
-            qweight[:, :, None], shifts[None, None, :]
-        ).to(torch.int8)
-        iweights = iweights.view(iweights.shape[0], -1)
-
-        if qzeros is None:
-            return iweights, None
-
-        izeros = torch.bitwise_right_shift(
-            qzeros[:, :, None], shifts[None, None, :]
-        ).to(torch.int8)
-        izeros = izeros.view(izeros.shape[0], -1)
-
-        return iweights, izeros
-
-    @staticmethod
-    def reverse_awq_order(
-        iweights: torch.Tensor, izeros: torch.Tensor | None, bits: int
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        """
-        Undo AutoAWQ's special intra-int32 packing order.
-        """
-        reverse_order_tensor = torch.arange(
-            iweights.shape[-1],
-            dtype=torch.int32,
-            device=iweights.device,
-        )
-        reverse_order_tensor = reverse_order_tensor.view(-1, 32 // bits)
-        reverse_order_tensor = reverse_order_tensor[
-            :, AutoAWQConverter.AWQ_REVERSE_ORDER
-        ]
-        reverse_order_tensor = reverse_order_tensor.view(-1)
-
-        iweights = iweights[:, reverse_order_tensor]
-        if izeros is not None:
-            izeros = izeros[:, reverse_order_tensor]
-
-        return iweights, izeros
-
     def __init__(
         self,
         bits: int = 4,
@@ -179,7 +131,7 @@ class AutoAWQConverter(Converter):
 
     def validate(self, tensors: dict[str, torch.Tensor]):
         for name in tensors:
-            module_name, param_name = name.rsplit(".", 1)
+            module_name, _, param_name = name.rpartition(".")
 
             if param_name in {"qweight", "qzeros", "scales"}:
                 if not self._is_targeted(module_name):
@@ -216,7 +168,7 @@ class AutoAWQConverter(Converter):
         )
 
     def get_dependencies(self, weight_name: str) -> set[str]:
-        module_name, suffix = weight_name.rsplit(".", 1)
+        module_name, _, suffix = weight_name.rpartition(".")
         if suffix == "qweight" and self._is_targeted(module_name):
             dependencies = {f"{module_name}.scales"}
             if self.zero_point:
@@ -262,3 +214,51 @@ class AutoAWQConverter(Converter):
             return True
 
         return any(match_name(module_name, target) for target in self.targets)
+
+    @staticmethod
+    def unpack_awq(
+        qweight: torch.Tensor, qzeros: torch.Tensor | None, bits: int
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """
+        Unpack AutoAWQ GEMM int32-packed weights and zero-points into int8 values.
+        """
+        shifts = torch.arange(0, 32, bits, device=qweight.device)
+
+        iweights = torch.bitwise_right_shift(
+            qweight[:, :, None], shifts[None, None, :]
+        ).to(torch.int8)
+        iweights = iweights.view(iweights.shape[0], -1)
+
+        if qzeros is None:
+            return iweights, None
+
+        izeros = torch.bitwise_right_shift(
+            qzeros[:, :, None], shifts[None, None, :]
+        ).to(torch.int8)
+        izeros = izeros.view(izeros.shape[0], -1)
+
+        return iweights, izeros
+
+    @staticmethod
+    def reverse_awq_order(
+        iweights: torch.Tensor, izeros: torch.Tensor | None, bits: int
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """
+        Undo AutoAWQ's special intra-int32 packing order.
+        """
+        reverse_order_tensor = torch.arange(
+            iweights.shape[-1],
+            dtype=torch.int32,
+            device=iweights.device,
+        )
+        reverse_order_tensor = reverse_order_tensor.view(-1, 32 // bits)
+        reverse_order_tensor = reverse_order_tensor[
+            :, AutoAWQConverter.AWQ_REVERSE_ORDER
+        ]
+        reverse_order_tensor = reverse_order_tensor.view(-1)
+
+        iweights = iweights[:, reverse_order_tensor]
+        if izeros is not None:
+            izeros = izeros[:, reverse_order_tensor]
+
+        return iweights, izeros

--- a/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
@@ -6,7 +6,6 @@ from collections.abc import Iterable
 from typing import Any, cast
 
 import torch
-from transformers import AutoConfig
 from compressed_tensors.compressors.pack_quantized.helpers import pack_to_int32
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.entrypoints.convert.converters import Converter
@@ -19,6 +18,7 @@ from compressed_tensors.quantization import (
     QuantizationType,
 )
 from compressed_tensors.utils.match import match_name
+from transformers import AutoConfig
 
 
 __all__ = ["AutoAWQConverter"]
@@ -64,7 +64,6 @@ class AutoAWQConverter(Converter):
         targets: Iterable[str] = ("Linear",),
         trust_remote_code: bool = False,
     ) -> "AutoAWQConverter":
-        
 
         config = AutoConfig.from_pretrained(
             model_name_or_path, trust_remote_code=trust_remote_code
@@ -118,9 +117,7 @@ class AutoAWQConverter(Converter):
             )
 
             tensors[f"{module_name}.weight_scale"] = weight_scale
-            tensors[f"{module_name}.weight_packed"] = pack_to_int32(
-                weight, self.bits
-            )
+            tensors[f"{module_name}.weight_packed"] = pack_to_int32(weight, self.bits)
             tensors[f"{module_name}.weight_shape"] = torch.tensor(weight.shape)
 
             if weight_zero_point is not None:

--- a/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
@@ -123,7 +123,7 @@ class AutoAWQConverter(Converter):
             if weight_zero_point is not None:
                 weight_zero_point = pack_to_int32(
                     weight_zero_point, self.bits, packed_dim=0
-                )
+                ).contiguous()
                 tensors[f"{module_name}.weight_zero_point"] = weight_zero_point
 
     def validate(self, tensors: dict[str, torch.Tensor]):

--- a/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
@@ -3,9 +3,10 @@
 
 import re
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, cast
 
 import torch
+from transformers import AutoConfig
 from compressed_tensors.compressors.pack_quantized.helpers import pack_to_int32
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.entrypoints.convert.converters import Converter
@@ -20,56 +21,7 @@ from compressed_tensors.quantization import (
 from compressed_tensors.utils.match import match_name
 
 
-__all__ = ["AutoAWQConverter", "unpack_awq", "reverse_awq_order"]
-
-
-AWQ_REVERSE_ORDER = [0, 4, 1, 5, 2, 6, 3, 7]
-
-
-def unpack_awq(
-    qweight: torch.Tensor, qzeros: torch.Tensor | None, bits: int
-) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """
-    Unpack AutoAWQ GEMM int32-packed weights and zero-points into int8 values.
-    """
-    shifts = torch.arange(0, 32, bits, device=qweight.device)
-
-    iweights = torch.bitwise_right_shift(
-        qweight[:, :, None], shifts[None, None, :]
-    ).to(torch.int8)
-    iweights = iweights.view(iweights.shape[0], -1)
-
-    if qzeros is None:
-        return iweights, None
-
-    izeros = torch.bitwise_right_shift(qzeros[:, :, None], shifts[None, None, :]).to(
-        torch.int8
-    )
-    izeros = izeros.view(izeros.shape[0], -1)
-
-    return iweights, izeros
-
-
-def reverse_awq_order(
-    iweights: torch.Tensor, izeros: torch.Tensor | None, bits: int
-) -> tuple[torch.Tensor, torch.Tensor | None]:
-    """
-    Undo AutoAWQ's special intra-int32 packing order.
-    """
-    reverse_order_tensor = torch.arange(
-        iweights.shape[-1],
-        dtype=torch.int32,
-        device=iweights.device,
-    )
-    reverse_order_tensor = reverse_order_tensor.view(-1, 32 // bits)
-    reverse_order_tensor = reverse_order_tensor[:, AWQ_REVERSE_ORDER]
-    reverse_order_tensor = reverse_order_tensor.view(-1)
-
-    iweights = iweights[:, reverse_order_tensor]
-    if izeros is not None:
-        izeros = izeros[:, reverse_order_tensor]
-
-    return iweights, izeros
+__all__ = ["AutoAWQConverter"]
 
 
 class AutoAWQConverter(Converter):
@@ -82,6 +34,56 @@ class AutoAWQConverter(Converter):
     weight_zero_point.
     """
 
+    AWQ_REVERSE_ORDER = [0, 4, 1, 5, 2, 6, 3, 7]
+
+    @staticmethod
+    def unpack_awq(
+        qweight: torch.Tensor, qzeros: torch.Tensor | None, bits: int
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """
+        Unpack AutoAWQ GEMM int32-packed weights and zero-points into int8 values.
+        """
+        shifts = torch.arange(0, 32, bits, device=qweight.device)
+
+        iweights = torch.bitwise_right_shift(
+            qweight[:, :, None], shifts[None, None, :]
+        ).to(torch.int8)
+        iweights = iweights.view(iweights.shape[0], -1)
+
+        if qzeros is None:
+            return iweights, None
+
+        izeros = torch.bitwise_right_shift(
+            qzeros[:, :, None], shifts[None, None, :]
+        ).to(torch.int8)
+        izeros = izeros.view(izeros.shape[0], -1)
+
+        return iweights, izeros
+
+    @staticmethod
+    def reverse_awq_order(
+        iweights: torch.Tensor, izeros: torch.Tensor | None, bits: int
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """
+        Undo AutoAWQ's special intra-int32 packing order.
+        """
+        reverse_order_tensor = torch.arange(
+            iweights.shape[-1],
+            dtype=torch.int32,
+            device=iweights.device,
+        )
+        reverse_order_tensor = reverse_order_tensor.view(-1, 32 // bits)
+        reverse_order_tensor = reverse_order_tensor[
+            :, AutoAWQConverter.AWQ_REVERSE_ORDER
+        ]
+        reverse_order_tensor = reverse_order_tensor.view(-1)
+
+        iweights = iweights[:, reverse_order_tensor]
+        if izeros is not None:
+            izeros = izeros[:, reverse_order_tensor]
+
+        return iweights, izeros
+
     def __init__(
         self,
         bits: int = 4,
@@ -90,19 +92,11 @@ class AutoAWQConverter(Converter):
         version: str = "gemm",
         ignore: Iterable[str] = ("lm_head",),
         targets: Iterable[str] = ("Linear",),
-        quantization_format: str = CompressionFormat.naive_quantized.value,
     ):
         if bits != 4:
             raise ValueError("AutoAWQConverter currently supports only 4-bit weights")
         if version != "gemm":
             raise ValueError(f"Unsupported AutoAWQ version: {version}")
-        if quantization_format not in {
-            CompressionFormat.naive_quantized.value,
-            CompressionFormat.pack_quantized.value,
-        }:
-            raise ValueError(
-                "AutoAWQConverter supports only naive-quantized and pack-quantized"
-            )
 
         self.bits = bits
         self.group_size = group_size
@@ -110,14 +104,37 @@ class AutoAWQConverter(Converter):
         self.version = version
         self.ignore = list(ignore)
         self.targets = list(targets)
-        self.quantization_format = quantization_format
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name_or_path: str,
+        targets: Iterable[str] = ("Linear",),
+        trust_remote_code: bool = False,
+    ) -> "AutoAWQConverter":
+        
+
+        config = AutoConfig.from_pretrained(
+            model_name_or_path, trust_remote_code=trust_remote_code
+        )
+        autoawq_config = getattr(config, "quantization_config", None)
+        if autoawq_config is None:
+            raise ValueError("Model config does not contain quantization_config")
+
+        autoawq_config = cast(dict[str, Any], autoawq_config)
+        if autoawq_config.get("quant_method") != "awq":
+            raise ValueError("Model config is not an AutoAWQ config")
+
+        return cls.from_autoawq_config(
+            autoawq_config,
+            targets=targets,
+        )
 
     @classmethod
     def from_autoawq_config(
         cls,
         autoawq_config: dict[str, Any],
         targets: Iterable[str] = ("Linear",),
-        quantization_format: str = CompressionFormat.naive_quantized.value,
     ) -> "AutoAWQConverter":
         ignore = ["lm_head"]
         for module in autoawq_config.get("modules_to_not_convert") or []:
@@ -130,7 +147,6 @@ class AutoAWQConverter(Converter):
             version=autoawq_config.get("version", "gemm"),
             ignore=ignore,
             targets=targets,
-            quantization_format=quantization_format,
         )
 
     def process(self, tensors: dict[str, torch.Tensor]):
@@ -142,7 +158,24 @@ class AutoAWQConverter(Converter):
             if not self._is_targeted(module_name):
                 continue
 
-            self._convert_gemm_module(tensors, module_name)
+            qweight = tensors.pop(f"{module_name}.qweight")
+            qzeros = tensors.pop(f"{module_name}.qzeros", None)
+            scales = tensors.pop(f"{module_name}.scales")
+            weight, weight_scale, weight_zero_point = self._convert_gemm_module(
+                qweight, scales, qzeros
+            )
+
+            tensors[f"{module_name}.weight_scale"] = weight_scale
+            tensors[f"{module_name}.weight_packed"] = pack_to_int32(
+                weight, self.bits
+            )
+            tensors[f"{module_name}.weight_shape"] = torch.tensor(weight.shape)
+
+            if weight_zero_point is not None:
+                weight_zero_point = pack_to_int32(
+                    weight_zero_point, self.bits, packed_dim=0
+                )
+                tensors[f"{module_name}.weight_zero_point"] = weight_zero_point
 
     def validate(self, tensors: dict[str, torch.Tensor]):
         for name in tensors:
@@ -174,59 +207,53 @@ class AutoAWQConverter(Converter):
                 "config_group_0": QuantizationScheme(
                     targets=self.targets,
                     weights=weights,
-                    format=self.quantization_format,
+                    format=CompressionFormat.pack_quantized.value,
                 )
             },
             ignore=self.ignore,
-            format=self.quantization_format,
+            format=CompressionFormat.pack_quantized.value,
             quantization_status=QuantizationStatus.COMPRESSED.value,
         )
 
     def get_dependencies(self, weight_name: str) -> set[str]:
         module_name, suffix = weight_name.rsplit(".", 1)
         if suffix == "qweight" and self._is_targeted(module_name):
-            return {f"{module_name}.qzeros", f"{module_name}.scales"}
+            dependencies = {f"{module_name}.scales"}
+            if self.zero_point:
+                dependencies.add(f"{module_name}.qzeros")
+
+            return dependencies
 
         return set()
 
     def _convert_gemm_module(
-        self, tensors: dict[str, torch.Tensor], module_name: str
-    ) -> None:
-        qweight = tensors.pop(f"{module_name}.qweight")
-        qzeros = tensors.pop(f"{module_name}.qzeros")
-        scales = tensors.pop(f"{module_name}.scales")
+        self,
+        qweight: torch.Tensor,
+        scales: torch.Tensor,
+        qzeros: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        if self.zero_point and qzeros is None:
+            raise ValueError("Found qweight without corresponding qzeros")
 
-        iweight, izeros = unpack_awq(qweight, qzeros, self.bits)
-        iweight, izeros = reverse_awq_order(iweight, izeros, self.bits)
-        assert izeros is not None
+        iweight, izeros = self.unpack_awq(qweight, qzeros, self.bits)
+        iweight, izeros = self.reverse_awq_order(iweight, izeros, self.bits)
 
         iweight = torch.bitwise_and(iweight, (2**self.bits) - 1)
-        izeros = torch.bitwise_and(izeros, (2**self.bits) - 1)
 
         quantized_weight = iweight - 2 ** (self.bits - 1)
 
-        zero_point = izeros
+        weight_zero_point = None
         if self.zero_point:
-            zero_point = zero_point - 2 ** (self.bits - 1)
+            assert izeros is not None
+            weight_zero_point = torch.bitwise_and(izeros, (2**self.bits) - 1)
+            weight_zero_point = weight_zero_point - 2 ** (self.bits - 1)
+            weight_zero_point = weight_zero_point.T.contiguous()
 
-        tensors[f"{module_name}.weight_scale"] = scales.T.contiguous()
-        quantized_weight = quantized_weight.T.contiguous()
-
-        if self.quantization_format == CompressionFormat.pack_quantized.value:
-            tensors[f"{module_name}.weight_packed"] = pack_to_int32(
-                quantized_weight, self.bits
-            )
-            tensors[f"{module_name}.weight_shape"] = torch.tensor(
-                quantized_weight.shape
-            )
-        else:
-            tensors[f"{module_name}.weight"] = quantized_weight
-
-        if self.zero_point:
-            zero_point = zero_point.T.contiguous()
-            if self.quantization_format == CompressionFormat.pack_quantized.value:
-                zero_point = pack_to_int32(zero_point, self.bits, packed_dim=0)
-            tensors[f"{module_name}.weight_zero_point"] = zero_point
+        return (
+            quantized_weight.T.contiguous(),
+            scales.T.contiguous(),
+            weight_zero_point,
+        )
 
     def _is_targeted(self, module_name: str) -> bool:
         if any(match_name(module_name, ignore) for ignore in self.ignore):

--- a/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
+++ b/src/compressed_tensors/entrypoints/convert/converters/autoawq.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import re
+from collections.abc import Iterable
+from typing import Any
+
+import torch
+from compressed_tensors.compressors.pack_quantized.helpers import pack_to_int32
+from compressed_tensors.config import CompressionFormat
+from compressed_tensors.entrypoints.convert.converters import Converter
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationConfig,
+    QuantizationScheme,
+    QuantizationStatus,
+    QuantizationStrategy,
+    QuantizationType,
+)
+from compressed_tensors.utils.match import match_name
+
+
+__all__ = ["AutoAWQConverter", "unpack_awq", "reverse_awq_order"]
+
+
+AWQ_REVERSE_ORDER = [0, 4, 1, 5, 2, 6, 3, 7]
+
+
+def unpack_awq(
+    qweight: torch.Tensor, qzeros: torch.Tensor | None, bits: int
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """
+    Unpack AutoAWQ GEMM int32-packed weights and zero-points into int8 values.
+    """
+    shifts = torch.arange(0, 32, bits, device=qweight.device)
+
+    iweights = torch.bitwise_right_shift(
+        qweight[:, :, None], shifts[None, None, :]
+    ).to(torch.int8)
+    iweights = iweights.view(iweights.shape[0], -1)
+
+    if qzeros is None:
+        return iweights, None
+
+    izeros = torch.bitwise_right_shift(qzeros[:, :, None], shifts[None, None, :]).to(
+        torch.int8
+    )
+    izeros = izeros.view(izeros.shape[0], -1)
+
+    return iweights, izeros
+
+
+def reverse_awq_order(
+    iweights: torch.Tensor, izeros: torch.Tensor | None, bits: int
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """
+    Undo AutoAWQ's special intra-int32 packing order.
+    """
+    reverse_order_tensor = torch.arange(
+        iweights.shape[-1],
+        dtype=torch.int32,
+        device=iweights.device,
+    )
+    reverse_order_tensor = reverse_order_tensor.view(-1, 32 // bits)
+    reverse_order_tensor = reverse_order_tensor[:, AWQ_REVERSE_ORDER]
+    reverse_order_tensor = reverse_order_tensor.view(-1)
+
+    iweights = iweights[:, reverse_order_tensor]
+    if izeros is not None:
+        izeros = izeros[:, reverse_order_tensor]
+
+    return iweights, izeros
+
+
+class AutoAWQConverter(Converter):
+    """
+    Convert AutoAWQ GEMM checkpoint tensors to compressed-tensors WNA16 tensors.
+
+    AutoAWQ GEMM stores quantized linear layers as qweight/qzeros/scales. This
+    converter unpacks qweight into compressed-tensors' signed integer convention
+    and preserves the per-group quantization parameters as weight_scale and
+    weight_zero_point.
+    """
+
+    def __init__(
+        self,
+        bits: int = 4,
+        group_size: int = 128,
+        zero_point: bool = True,
+        version: str = "gemm",
+        ignore: Iterable[str] = ("lm_head",),
+        targets: Iterable[str] = ("Linear",),
+        quantization_format: str = CompressionFormat.naive_quantized.value,
+    ):
+        if bits != 4:
+            raise ValueError("AutoAWQConverter currently supports only 4-bit weights")
+        if version != "gemm":
+            raise ValueError(f"Unsupported AutoAWQ version: {version}")
+        if quantization_format not in {
+            CompressionFormat.naive_quantized.value,
+            CompressionFormat.pack_quantized.value,
+        }:
+            raise ValueError(
+                "AutoAWQConverter supports only naive-quantized and pack-quantized"
+            )
+
+        self.bits = bits
+        self.group_size = group_size
+        self.zero_point = zero_point
+        self.version = version
+        self.ignore = list(ignore)
+        self.targets = list(targets)
+        self.quantization_format = quantization_format
+
+    @classmethod
+    def from_autoawq_config(
+        cls,
+        autoawq_config: dict[str, Any],
+        targets: Iterable[str] = ("Linear",),
+        quantization_format: str = CompressionFormat.naive_quantized.value,
+    ) -> "AutoAWQConverter":
+        ignore = ["lm_head"]
+        for module in autoawq_config.get("modules_to_not_convert") or []:
+            ignore.append(f"re:.*{re.escape(module)}.*")
+
+        return cls(
+            bits=autoawq_config.get("bits", 4),
+            group_size=autoawq_config.get("group_size", 128),
+            zero_point=autoawq_config.get("zero_point", True),
+            version=autoawq_config.get("version", "gemm"),
+            ignore=ignore,
+            targets=targets,
+            quantization_format=quantization_format,
+        )
+
+    def process(self, tensors: dict[str, torch.Tensor]):
+        for name in list(tensors):
+            if not name.endswith(".qweight"):
+                continue
+
+            module_name = name.removesuffix(".qweight")
+            if not self._is_targeted(module_name):
+                continue
+
+            self._convert_gemm_module(tensors, module_name)
+
+    def validate(self, tensors: dict[str, torch.Tensor]):
+        for name in tensors:
+            module_name, param_name = name.rsplit(".", 1)
+
+            if param_name in {"qweight", "qzeros", "scales"}:
+                if not self._is_targeted(module_name):
+                    raise ValueError(f"Found unexpected non-targeted tensor {name}")
+
+            if param_name != "qweight" or not self._is_targeted(module_name):
+                continue
+
+            for dependency in self.get_dependencies(name):
+                if dependency not in tensors:
+                    raise ValueError(
+                        f"Found qweight without corresponding {dependency}"
+                    )
+
+    def create_config(self) -> QuantizationConfig:
+        weights = QuantizationArgs(
+            num_bits=self.bits,
+            type=QuantizationType.INT,
+            symmetric=not self.zero_point,
+            group_size=self.group_size,
+            strategy=QuantizationStrategy.GROUP,
+        )
+        return QuantizationConfig(
+            config_groups={
+                "config_group_0": QuantizationScheme(
+                    targets=self.targets,
+                    weights=weights,
+                    format=self.quantization_format,
+                )
+            },
+            ignore=self.ignore,
+            format=self.quantization_format,
+            quantization_status=QuantizationStatus.COMPRESSED.value,
+        )
+
+    def get_dependencies(self, weight_name: str) -> set[str]:
+        module_name, suffix = weight_name.rsplit(".", 1)
+        if suffix == "qweight" and self._is_targeted(module_name):
+            return {f"{module_name}.qzeros", f"{module_name}.scales"}
+
+        return set()
+
+    def _convert_gemm_module(
+        self, tensors: dict[str, torch.Tensor], module_name: str
+    ) -> None:
+        qweight = tensors.pop(f"{module_name}.qweight")
+        qzeros = tensors.pop(f"{module_name}.qzeros")
+        scales = tensors.pop(f"{module_name}.scales")
+
+        iweight, izeros = unpack_awq(qweight, qzeros, self.bits)
+        iweight, izeros = reverse_awq_order(iweight, izeros, self.bits)
+        assert izeros is not None
+
+        iweight = torch.bitwise_and(iweight, (2**self.bits) - 1)
+        izeros = torch.bitwise_and(izeros, (2**self.bits) - 1)
+
+        quantized_weight = iweight - 2 ** (self.bits - 1)
+
+        zero_point = izeros
+        if self.zero_point:
+            zero_point = zero_point - 2 ** (self.bits - 1)
+
+        tensors[f"{module_name}.weight_scale"] = scales.T.contiguous()
+        quantized_weight = quantized_weight.T.contiguous()
+
+        if self.quantization_format == CompressionFormat.pack_quantized.value:
+            tensors[f"{module_name}.weight_packed"] = pack_to_int32(
+                quantized_weight, self.bits
+            )
+            tensors[f"{module_name}.weight_shape"] = torch.tensor(
+                quantized_weight.shape
+            )
+        else:
+            tensors[f"{module_name}.weight"] = quantized_weight
+
+        if self.zero_point:
+            zero_point = zero_point.T.contiguous()
+            if self.quantization_format == CompressionFormat.pack_quantized.value:
+                zero_point = pack_to_int32(zero_point, self.bits, packed_dim=0)
+            tensors[f"{module_name}.weight_zero_point"] = zero_point
+
+    def _is_targeted(self, module_name: str) -> bool:
+        if any(match_name(module_name, ignore) for ignore in self.ignore):
+            return False
+        if len(self.targets) == 0 or "Linear" in self.targets:
+            return True
+
+        return any(match_name(module_name, target) for target in self.targets)

--- a/tests/test_entrypoints/convert/converters/test_autoawq.py
+++ b/tests/test_entrypoints/convert/converters/test_autoawq.py
@@ -4,12 +4,9 @@
 import pytest
 import torch
 from compressed_tensors.config import CompressionFormat
-from compressed_tensors.entrypoints.convert import (
-    AutoAWQConverter,
-    reverse_awq_order,
-    unpack_awq,
-)
+from compressed_tensors.entrypoints.convert import AutoAWQConverter
 from compressed_tensors.quantization import QuantizationStatus
+from transformers import AutoConfig
 
 
 def _pack_int4(values: torch.Tensor) -> torch.Tensor:
@@ -25,8 +22,8 @@ def test_unpack_awq_and_reverse_order():
     packed_values = torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7]], dtype=torch.int8)
     qweight = _pack_int4(packed_values)
 
-    unpacked, _ = unpack_awq(qweight, None, bits=4)
-    reordered, _ = reverse_awq_order(unpacked, None, bits=4)
+    unpacked, _ = AutoAWQConverter.unpack_awq(qweight, None, bits=4)
+    reordered, _ = AutoAWQConverter.reverse_awq_order(unpacked, None, bits=4)
 
     assert torch.equal(torch.bitwise_and(unpacked, 15), packed_values)
     assert torch.equal(
@@ -36,10 +33,12 @@ def test_unpack_awq_and_reverse_order():
 
 
 @pytest.mark.unit
-def test_autoawq_converter_processes_gemm_tensors():
+@pytest.mark.parametrize("zero_point", [True, False])
+def test_autoawq_converter_processes_gemm_tensors(zero_point):
     converter = AutoAWQConverter(
         group_size=2,
         targets=[r"re:.*proj$"],
+        zero_point=zero_point,
     )
     qweight_values = torch.tensor(
         [
@@ -56,6 +55,8 @@ def test_autoawq_converter_processes_gemm_tensors():
         "model.layers.0.mlp.up_proj.scales": scales,
         "model.embed_tokens.weight": torch.ones(4, 4),
     }
+    if not zero_point:
+        del tensors["model.layers.0.mlp.up_proj.qzeros"]
 
     converter.validate(tensors)
     converter.process(tensors)
@@ -63,57 +64,18 @@ def test_autoawq_converter_processes_gemm_tensors():
     assert "model.layers.0.mlp.up_proj.qweight" not in tensors
     assert "model.layers.0.mlp.up_proj.qzeros" not in tensors
     assert "model.layers.0.mlp.up_proj.scales" not in tensors
-    assert tensors["model.layers.0.mlp.up_proj.weight"].shape == (8, 2)
-    assert tensors["model.layers.0.mlp.up_proj.weight"].dtype == torch.int8
-    assert tensors["model.layers.0.mlp.up_proj.weight_scale"].shape == (8, 1)
-    assert tensors["model.layers.0.mlp.up_proj.weight_scale"].is_contiguous()
-    assert tensors["model.layers.0.mlp.up_proj.weight_zero_point"].shape == (8, 1)
-
-    assert torch.equal(
-        tensors["model.layers.0.mlp.up_proj.weight_zero_point"],
-        torch.zeros(8, 1, dtype=torch.int8),
-    )
-    assert torch.equal(
-        tensors["model.layers.0.mlp.up_proj.weight"][:, 0],
-        torch.tensor([0, 4, 1, 5, 2, 6, 3, 7], dtype=torch.int8),
-    )
-    assert torch.equal(
-        tensors["model.layers.0.mlp.up_proj.weight"][:, 1],
-        torch.tensor([-8, -4, -7, -3, -6, -2, -5, -1], dtype=torch.int8),
-    )
-
-
-@pytest.mark.unit
-def test_autoawq_converter_processes_packed_gemm_tensors():
-    converter = AutoAWQConverter(
-        group_size=2,
-        targets=[r"re:.*proj$"],
-        quantization_format=CompressionFormat.pack_quantized.value,
-    )
-    tensors = {
-        "model.layers.0.mlp.up_proj.qweight": _pack_int4(
-            torch.tensor(
-                [
-                    [8, 9, 10, 11, 12, 13, 14, 15],
-                    [0, 1, 2, 3, 4, 5, 6, 7],
-                ],
-                dtype=torch.int8,
-            )
-        ),
-        "model.layers.0.mlp.up_proj.qzeros": _pack_int4(
-            torch.full((1, 8), 8, dtype=torch.int8)
-        ),
-        "model.layers.0.mlp.up_proj.scales": torch.ones(1, 8, dtype=torch.float16),
-    }
-
-    converter.process(tensors)
-
     assert "model.layers.0.mlp.up_proj.weight" not in tensors
     assert tensors["model.layers.0.mlp.up_proj.weight_packed"].shape == (8, 1)
     assert torch.equal(
         tensors["model.layers.0.mlp.up_proj.weight_shape"], torch.tensor([8, 2])
     )
-    assert tensors["model.layers.0.mlp.up_proj.weight_zero_point"].shape == (1, 1)
+    assert tensors["model.layers.0.mlp.up_proj.weight_scale"].shape == (8, 1)
+    assert tensors["model.layers.0.mlp.up_proj.weight_scale"].is_contiguous()
+
+    if zero_point:
+        assert tensors["model.layers.0.mlp.up_proj.weight_zero_point"].shape == (1, 1)
+    else:
+        assert "model.layers.0.mlp.up_proj.weight_zero_point" not in tensors
 
 
 @pytest.mark.unit
@@ -126,7 +88,6 @@ def test_autoawq_converter_config_from_autoawq_config():
             "version": "gemm",
             "modules_to_not_convert": ["vision_tower"],
         },
-        quantization_format=CompressionFormat.pack_quantized.value,
     )
 
     config = converter.create_config()
@@ -142,6 +103,37 @@ def test_autoawq_converter_config_from_autoawq_config():
 
 
 @pytest.mark.unit
+def test_autoawq_converter_from_pretrained(monkeypatch):
+    class MockConfig:
+        quantization_config = {
+            "quant_method": "awq",
+            "bits": 4,
+            "group_size": 32,
+            "zero_point": True,
+            "version": "gemm",
+            "modules_to_not_convert": ["visual"],
+        }
+
+    def mock_from_pretrained(model_name_or_path, trust_remote_code=False):
+        assert model_name_or_path == "test/model"
+        assert trust_remote_code is True
+        return MockConfig()
+
+    monkeypatch.setattr(AutoConfig, "from_pretrained", mock_from_pretrained)
+
+    converter = AutoAWQConverter.from_pretrained(
+        "test/model",
+        trust_remote_code=True,
+    )
+
+    assert converter.bits == 4
+    assert converter.group_size == 32
+    assert converter.zero_point is True
+    assert converter.version == "gemm"
+    assert converter.ignore == ["lm_head", "re:.*visual.*"]
+
+
+@pytest.mark.unit
 def test_autoawq_converter_dependencies():
     converter = AutoAWQConverter(targets=[r"re:.*down_proj$"])
 
@@ -150,6 +142,14 @@ def test_autoawq_converter_dependencies():
         "model.layers.0.mlp.down_proj.scales",
     }
     assert converter.get_dependencies("model.layers.0.mlp.up_proj.qweight") == set()
+
+    symmetric_converter = AutoAWQConverter(
+        targets=[r"re:.*down_proj$"],
+        zero_point=False,
+    )
+    assert symmetric_converter.get_dependencies(
+        "model.layers.0.mlp.down_proj.qweight"
+    ) == {"model.layers.0.mlp.down_proj.scales"}
 
 
 @pytest.mark.unit

--- a/tests/test_entrypoints/convert/converters/test_autoawq.py
+++ b/tests/test_entrypoints/convert/converters/test_autoawq.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+from compressed_tensors.config import CompressionFormat
+from compressed_tensors.entrypoints.convert import (
+    AutoAWQConverter,
+    reverse_awq_order,
+    unpack_awq,
+)
+from compressed_tensors.quantization import QuantizationStatus
+
+
+def _pack_int4(values: torch.Tensor) -> torch.Tensor:
+    values = values.to(torch.int32)
+    packed = torch.zeros(values.shape[0], values.shape[1] // 8, dtype=torch.int32)
+    for offset in range(8):
+        packed |= values[:, offset::8] << (offset * 4)
+    return packed
+
+
+@pytest.mark.unit
+def test_unpack_awq_and_reverse_order():
+    packed_values = torch.tensor([[0, 1, 2, 3, 4, 5, 6, 7]], dtype=torch.int8)
+    qweight = _pack_int4(packed_values)
+
+    unpacked, _ = unpack_awq(qweight, None, bits=4)
+    reordered, _ = reverse_awq_order(unpacked, None, bits=4)
+
+    assert torch.equal(torch.bitwise_and(unpacked, 15), packed_values)
+    assert torch.equal(
+        torch.bitwise_and(reordered, 15),
+        torch.tensor([[0, 4, 1, 5, 2, 6, 3, 7]], dtype=torch.int8),
+    )
+
+
+@pytest.mark.unit
+def test_autoawq_converter_processes_gemm_tensors():
+    converter = AutoAWQConverter(
+        group_size=2,
+        targets=[r"re:.*proj$"],
+    )
+    qweight_values = torch.tensor(
+        [
+            [8, 9, 10, 11, 12, 13, 14, 15],
+            [0, 1, 2, 3, 4, 5, 6, 7],
+        ],
+        dtype=torch.int8,
+    )
+    qzeros_values = torch.tensor([[8, 8, 8, 8, 8, 8, 8, 8]], dtype=torch.int8)
+    scales = torch.ones(1, 8, dtype=torch.float16)
+    tensors = {
+        "model.layers.0.mlp.up_proj.qweight": _pack_int4(qweight_values),
+        "model.layers.0.mlp.up_proj.qzeros": _pack_int4(qzeros_values),
+        "model.layers.0.mlp.up_proj.scales": scales,
+        "model.embed_tokens.weight": torch.ones(4, 4),
+    }
+
+    converter.validate(tensors)
+    converter.process(tensors)
+
+    assert "model.layers.0.mlp.up_proj.qweight" not in tensors
+    assert "model.layers.0.mlp.up_proj.qzeros" not in tensors
+    assert "model.layers.0.mlp.up_proj.scales" not in tensors
+    assert tensors["model.layers.0.mlp.up_proj.weight"].shape == (8, 2)
+    assert tensors["model.layers.0.mlp.up_proj.weight"].dtype == torch.int8
+    assert tensors["model.layers.0.mlp.up_proj.weight_scale"].shape == (8, 1)
+    assert tensors["model.layers.0.mlp.up_proj.weight_scale"].is_contiguous()
+    assert tensors["model.layers.0.mlp.up_proj.weight_zero_point"].shape == (8, 1)
+
+    assert torch.equal(
+        tensors["model.layers.0.mlp.up_proj.weight_zero_point"],
+        torch.zeros(8, 1, dtype=torch.int8),
+    )
+    assert torch.equal(
+        tensors["model.layers.0.mlp.up_proj.weight"][:, 0],
+        torch.tensor([0, 4, 1, 5, 2, 6, 3, 7], dtype=torch.int8),
+    )
+    assert torch.equal(
+        tensors["model.layers.0.mlp.up_proj.weight"][:, 1],
+        torch.tensor([-8, -4, -7, -3, -6, -2, -5, -1], dtype=torch.int8),
+    )
+
+
+@pytest.mark.unit
+def test_autoawq_converter_processes_packed_gemm_tensors():
+    converter = AutoAWQConverter(
+        group_size=2,
+        targets=[r"re:.*proj$"],
+        quantization_format=CompressionFormat.pack_quantized.value,
+    )
+    tensors = {
+        "model.layers.0.mlp.up_proj.qweight": _pack_int4(
+            torch.tensor(
+                [
+                    [8, 9, 10, 11, 12, 13, 14, 15],
+                    [0, 1, 2, 3, 4, 5, 6, 7],
+                ],
+                dtype=torch.int8,
+            )
+        ),
+        "model.layers.0.mlp.up_proj.qzeros": _pack_int4(
+            torch.full((1, 8), 8, dtype=torch.int8)
+        ),
+        "model.layers.0.mlp.up_proj.scales": torch.ones(1, 8, dtype=torch.float16),
+    }
+
+    converter.process(tensors)
+
+    assert "model.layers.0.mlp.up_proj.weight" not in tensors
+    assert tensors["model.layers.0.mlp.up_proj.weight_packed"].shape == (8, 1)
+    assert torch.equal(
+        tensors["model.layers.0.mlp.up_proj.weight_shape"], torch.tensor([8, 2])
+    )
+    assert tensors["model.layers.0.mlp.up_proj.weight_zero_point"].shape == (1, 1)
+
+
+@pytest.mark.unit
+def test_autoawq_converter_config_from_autoawq_config():
+    converter = AutoAWQConverter.from_autoawq_config(
+        {
+            "bits": 4,
+            "group_size": 64,
+            "zero_point": True,
+            "version": "gemm",
+            "modules_to_not_convert": ["vision_tower"],
+        },
+        quantization_format=CompressionFormat.pack_quantized.value,
+    )
+
+    config = converter.create_config()
+    scheme = config.config_groups["config_group_0"]
+
+    assert config.format == CompressionFormat.pack_quantized.value
+    assert config.quantization_status == QuantizationStatus.COMPRESSED
+    assert config.ignore == ["lm_head", "re:.*vision_tower.*"]
+    assert scheme.format == CompressionFormat.pack_quantized.value
+    assert scheme.weights.num_bits == 4
+    assert scheme.weights.group_size == 64
+    assert scheme.weights.symmetric is False
+
+
+@pytest.mark.unit
+def test_autoawq_converter_dependencies():
+    converter = AutoAWQConverter(targets=[r"re:.*down_proj$"])
+
+    assert converter.get_dependencies("model.layers.0.mlp.down_proj.qweight") == {
+        "model.layers.0.mlp.down_proj.qzeros",
+        "model.layers.0.mlp.down_proj.scales",
+    }
+    assert converter.get_dependencies("model.layers.0.mlp.up_proj.qweight") == set()
+
+
+@pytest.mark.unit
+def test_autoawq_converter_validate_requires_dependencies():
+    converter = AutoAWQConverter()
+
+    with pytest.raises(ValueError, match="without corresponding"):
+        converter.validate({"model.layers.0.mlp.down_proj.qweight": torch.zeros(1, 1)})


### PR DESCRIPTION
## Summary
This PR introduces an `AutoAWQConverter` to support conversion of AutoAWQ GEMM checkpoints through the existing `compressed_tensors.entrypoints.convert` pipeline. It refactors the core AutoAWQ conversion logic from [#531](https://github.com/vllm-project/compressed-tensors/pull/531) to align with the `Converter` interface.

## Changes 

- Adds `compressed_tensors.entrypoints.convert.converters.AutoAWQConverter`
- Converts AutoAWQ `qweight`, `qzeros`, and `scales` tensors into compressed-tensors-compatible tensors
- Supports `naive-quantized` and `pack-quantized` output formats
- Adds unit tests for unpacking, conversion, config creation, validation, and dependency handling
- Adds a convert checkpoint example
- Documents the converter in the convert README