### PR TITLE
[Offload] [2/2] Better abstractions for updating parameters

### DIFF
--- a/src/compressed_tensors/offload/README.md
+++ b/src/compressed_tensors/offload/README.md
@@ -476,6 +476,75 @@ update_offload_parameter(layer, "weight", quantized_weight)
 
 ---
 
+#### `update_onload_parameter(module, name, data)`
+
+Updates only the onloaded (in-memory, on-device) copy of a parameter or buffer. For offloaded modules, this only has an effect when offloading is disabled (i.e., within a `disable_offloading` context), since onloaded values are otherwise transient. For non-offloaded modules, updates the parameter directly.
+
+```python
+with disable_offloading():
+    update_onload_parameter(layer, "weight", modified_weight)
+```
+
+**Use when:** temporarily modifying weights during inference (e.g., applying runtime transformations) without persisting changes to the offloaded copy.
+
+---
+
+#### `update_parameter(module, name, data, update_onload=True, update_offload=True)`
+
+Synchronously updates one or both copies of a parameter with distributed-aware coordination.
+
+When `update_offload=True`:
+- Only the source rank writes to the offloaded copy (shared CPU memory, disk files, etc.)
+- A barrier ensures all ranks wait for the write to complete
+
+When `update_onload=True`:
+- Data is broadcast from the source rank to all other ranks
+- All ranks then update their local onloaded copies
+
+```python
+# Update both offloaded and onloaded copies (default)
+# In distributed: source rank writes offload, broadcasts data, all ranks update onload
+update_parameter(layer, "weight", new_weight)
+
+# Update only the offloaded copy
+# In distributed: source rank writes offload, barrier to synchronize
+update_parameter(layer, "weight", new_weight, update_onload=False)
+
+# Update only the onloaded copy
+# In distributed: data is broadcast, all ranks update local onloads
+update_parameter(layer, "weight", new_weight, update_offload=False)
+```
+
+> **Note:** This function uses barriers and broadcasts to ensure consistent state across ranks. For asynchronous updates without synchronization, use `update_parameter_async`.
+
+**Use when:** you need to update parameters in a distributed context and require synchronization across ranks.
+
+---
+
+#### `update_parameter_async(module, name, data, update_onload=True, update_offload=True)`
+
+Asynchronously updates one or both copies of a parameter without distributed synchronization.
+
+This is a convenience wrapper around `update_offload_parameter` and `update_onload_parameter` that updates the requested copies without any barriers or broadcasts.
+
+```python
+# Update both offloaded and onloaded copies asynchronously
+update_parameter_async(layer, "weight", new_weight)
+
+# Update only the offloaded copy
+update_parameter_async(layer, "weight", new_weight, update_onload=False)
+
+# Update only the onloaded copy (within disable_offloading context)
+with disable_offloading():
+    update_parameter_async(layer, "weight", new_weight, update_offload=False)
+```
+
+> **Caution:** In distributed contexts, this function does not synchronize across ranks. The caller is responsible for ensuring consistent state if needed.
+
+**Use when:** you need maximum performance and can manage synchronization manually, or when working in non-distributed contexts.
+
+---
+
 #### `get_execution_device(module, default=None) → torch.device | "disk"`
 
 Returns the device that input tensors should be moved to before running the module's forward pass.

--- a/src/compressed_tensors/offload/__init__.py
+++ b/src/compressed_tensors/offload/__init__.py
@@ -110,6 +110,7 @@ def disable_onloading():
         yield
 
 
+@torch.no_grad()
 def update_offload_parameter(module: torch.nn.Module, name: str, data: torch.Tensor):
     """
     Update the offload and onload data of an existing parameter/buffer. Supports both
@@ -127,13 +128,6 @@ def update_offload_parameter(module: torch.nn.Module, name: str, data: torch.Ten
     :param data: tensor to update parameter with
     """
     if isinstance(module._parameters, OffloadCache):
-        # | Component | Update Implementation       |
-        # | --------- | --------------------------- |
-        # | CPU       | Copy into shared cpu memory |
-        # | Disk      | Write file to disk          |
-        # | Device    | Copy into local device      |
-        # | --------- | --------------------------- |
-        # all implementations update onloaded data if applicable
         if name in module._parameters:
             cache = module._parameters
         elif name in module._buffers:
@@ -141,12 +135,13 @@ def update_offload_parameter(module: torch.nn.Module, name: str, data: torch.Ten
         else:
             raise AttributeError(f"{type(module)} has no attribute {name}")
 
-        # triggers update if shapes match
-        cache[name] = data
+        offloaded = cache.offloaded_values[name]
+        if offloaded is None:
+            raise ValueError(f"Cannot update offload value `None` for param {name}")
+        cache.update_offload(offloaded, data)
 
     else:
-        with torch.no_grad():
-            getattr(module, name).copy_(data)
+        getattr(module, name).copy_(data)
 
 
 def get_execution_device(

--- a/src/compressed_tensors/offload/__init__.py
+++ b/src/compressed_tensors/offload/__init__.py
@@ -6,7 +6,13 @@ from collections.abc import Iterable
 from typing import Literal
 
 import torch
-from compressed_tensors.distributed.utils import set_source_process
+import torch.distributed as dist
+from compressed_tensors.distributed.utils import (
+    get_source_rank,
+    is_distributed,
+    is_source_process,
+    set_source_process,
+)
 from compressed_tensors.offload.cache import OffloadCache
 from compressed_tensors.offload.convert import from_accelerate, to_accelerate
 from compressed_tensors.offload.dispatch import (  # noqa: F401
@@ -17,12 +23,7 @@ from compressed_tensors.offload.dispatch import (  # noqa: F401
     remove_dispatch,
     set_onload_device,
 )
-from compressed_tensors.offload.dist_utils import (
-    as_broadcastable,
-    init_dist,
-    is_distributed,
-    is_rank0,
-)
+from compressed_tensors.offload.dist_utils import as_broadcastable, init_dist, is_rank0
 from compressed_tensors.offload.load import load_offloaded_model
 from compressed_tensors.offload.module import offload_module, unwrap_offload_forward
 from compressed_tensors.offload.utils import (
@@ -55,6 +56,9 @@ __all__ = [
     "disable_offloading",
     # manipulate parameters
     "update_offload_parameter",
+    "update_onload_parameter",
+    "update_parameter",
+    "update_parameter_async",
     "get_execution_device",
     "get_offloaded_device",
     "register_offload_module",
@@ -142,6 +146,91 @@ def update_offload_parameter(module: torch.nn.Module, name: str, data: torch.Ten
 
     else:
         getattr(module, name).copy_(data)
+
+
+@torch.no_grad()
+def update_onload_parameter(module: torch.nn.Module, name: str, data: torch.Tensor):
+    """
+    Update only the onloaded (in-memory, on-device) copy of a parameter/buffer.
+    For offloaded modules, this only has an effect when offloading is disabled
+    (i.e., within a `disable_offloading` context), since onloaded values are
+    otherwise transient. For non-offloaded modules, updates the parameter directly.
+
+    :param module: module containing the parameter to update
+    :param name: name of module parameter to update
+    :param data: tensor to update parameter with
+    """
+    if (
+        not isinstance(module._parameters, OffloadCache)
+        or not module._parameters.offloading_disabled
+    ):
+        getattr(module, name).copy_(data)
+
+
+def update_parameter(
+    module: torch.nn.Module,
+    name: str,
+    data: torch.Tensor,
+    update_offload: bool = True,
+    update_onload: bool = True,
+):
+    """
+    Synchronously update the onloaded and/or offloaded data of an existing
+    parameter/buffer.
+
+    When updating offloads, only the source rank will write to shared offload
+    When updating onloads, data will be broadcast before writing to local onloads
+
+    :param module: module containing the parameter to update
+    :param name: name of module parameter to update
+    :param data: tensor to update parameter with
+    :param update_offload: if True, update the offloaded value
+    :param update_onload: if True, update the onloaded value
+    """
+    if update_offload:
+        if is_source_process():
+            # only source rank updates offload
+            update_offload_parameter(module, name, data)
+
+        # ensure writes finish before moving on
+        # can optionally hide barrier behind update_onload
+        if not update_onload and is_distributed():
+            dist.barrier()
+
+    if update_onload:
+        if is_distributed():
+            # only source rank has data; synchronize
+            dist.broadcast(data, src=get_source_rank())
+
+        # now all ranks have data: update local onloads
+        update_onload_parameter(module, name, data)
+
+
+def update_parameter_async(
+    module: torch.nn.Module,
+    name: str,
+    data: torch.Tensor,
+    update_offload: bool = True,
+    update_onload: bool = True,
+):
+    """
+    Asynchronously update the onloaded and/or offloaded data of an existing
+    parameter/buffer.
+
+    Convenience wrapper around `update_offload_parameter` and
+    `update_onload_parameter`, both of which are asynchronous.
+
+    :param module: module containing the parameter to update
+    :param name: name of module parameter to update
+    :param data: tensor to update parameter with
+    :param update_offload: if True, update the offloaded value
+    :param update_onload: if True, update the onloaded value
+    """
+    if update_offload:
+        update_offload_parameter(module, name, data)
+
+    if update_onload:
+        update_onload_parameter(module, name, data)
 
 
 def get_execution_device(

--- a/src/compressed_tensors/offload/__init__.py
+++ b/src/compressed_tensors/offload/__init__.py
@@ -162,7 +162,7 @@ def update_onload_parameter(module: torch.nn.Module, name: str, data: torch.Tens
     """
     if (
         not isinstance(module._parameters, OffloadCache)
-        or not module._parameters.offloading_disabled
+        or module._parameters.offloading_disabled
     ):
         getattr(module, name).copy_(data)
 
@@ -200,6 +200,8 @@ def update_parameter(
     if update_onload:
         if is_distributed():
             # only source rank has data; synchronize
+            device = get_execution_device(module)
+            data = data.to(device, copy=True)  # not very performant
             dist.broadcast(data, src=get_source_rank())
 
         # now all ranks have data: update local onloads

--- a/src/compressed_tensors/offload/cache/base.py
+++ b/src/compressed_tensors/offload/cache/base.py
@@ -207,11 +207,8 @@ class OffloadCache(MutableMapping, ABC):
             self.offloaded_values[key] = value
             return
 
-        # invalidate onload cache
-        offloaded = self.offloaded_values.get(key, None)
-        if offloaded in self.keep_onloaded_values:
-            del self.keep_onloaded_values[offloaded]
-        del offloaded
+        if key in self:
+            del self[key]
 
         # synchronously offload value
         self.offloaded_values[key] = self.offload(value)

--- a/src/compressed_tensors/offload/cache/base.py
+++ b/src/compressed_tensors/offload/cache/base.py
@@ -207,18 +207,14 @@ class OffloadCache(MutableMapping, ABC):
             self.offloaded_values[key] = value
             return
 
-        # if the key already exists, update with the new value
+        # invalidate onload cache
         offloaded = self.offloaded_values.get(key, None)
-        if offloaded is not None and torch.is_same_size(offloaded, value):
-            self.update_offload(offloaded, value)
+        if offloaded in self.keep_onloaded_values:
+            del self.keep_onloaded_values[offloaded]
+        del offloaded
 
-            onloaded = self.keep_onloaded_values.get(offloaded, None)
-            if onloaded is not None and onloaded is not offloaded:
-                onloaded.copy_(value)
-
-        # if the key does not exist (or the value is None), offload the new value
-        else:
-            self.offloaded_values[key] = self.offload(value)
+        # synchronously offload value
+        self.offloaded_values[key] = self.offload(value)
 
     def __delitem__(self, key: Hashable):
         """

--- a/tests/test_offload/cache/test_disk.py
+++ b/tests/test_offload/cache/test_disk.py
@@ -112,7 +112,7 @@ def test_files(tmp_path):
         read_tensor = file.get_tensor("weight")
         assert_tensor_equal(read_tensor, tensor)
 
-    # modify
+    # rewrite
     tensor = torch.ones(10)
     cache["weight"] = tensor
 

--- a/tests/test_offload/conftest.py
+++ b/tests/test_offload/conftest.py
@@ -140,7 +140,7 @@ def torchrun(
                     "--nproc_per_node",
                     str(world_size),
                     "--log-dir",
-                    "/tmp/torchrun-logs",
+                    "tmp/torchrun-logs",
                     "--tee",
                     "3",
                     "--role",
@@ -149,6 +149,7 @@ def torchrun(
                     "pytest",
                     f"{file_path}::{func_name}",
                     "-sx",
+                    '--basetemp="tmp"',
                 ]
 
                 proc = subprocess.run(cmd)

--- a/tests/test_offload/conftest.py
+++ b/tests/test_offload/conftest.py
@@ -140,7 +140,7 @@ def torchrun(
                     "--nproc_per_node",
                     str(world_size),
                     "--log-dir",
-                    "tmp/torchrun-logs",
+                    "/tmp/torchrun-logs",
                     "--tee",
                     "3",
                     "--role",
@@ -149,7 +149,6 @@ def torchrun(
                     "pytest",
                     f"{file_path}::{func_name}",
                     "-sx",
-                    '--basetemp="tmp"',
                 ]
 
                 proc = subprocess.run(cmd)

--- a/tests/test_offload/test_interface.py
+++ b/tests/test_offload/test_interface.py
@@ -80,8 +80,6 @@ def test_update_offload_parameter(linear: torch.nn.Linear, cache, offload):
     if offload:
         offload_module(linear, ONLOAD_DEVICE, OFFLOAD_DEVICE)
 
-    assert linear.weight == 0
-
     update_offload_parameter(linear, "weight", torch.tensor(1))
     assert linear.weight == 1
 
@@ -94,6 +92,22 @@ def test_update_offload_parameter(linear: torch.nn.Linear, cache, offload):
         update_offload_parameter(linear, "weight", torch.tensor(3))
         assert linear.weight == 3
     assert linear.weight == 3
+
+
+@pytest.mark.unit
+@requires_gpu
+def test_update_offload_parameter_only(offloaded_linear: torch.nn.Linear):
+    offloaded_linear.weight = torch.nn.Parameter(torch.tensor(0.0))
+
+    with disable_offloading():
+        _ = offloaded_linear.weight
+        update_offload_parameter(offloaded_linear, "weight", torch.tensor(1))
+
+        # updating offload does not update onload
+        with disable_onloading():
+            offload = offloaded_linear.weight
+        assert offload == 1
+        assert offloaded_linear.weight != offload
 
 
 @pytest.mark.unit

--- a/tests/test_offload/test_interface.py
+++ b/tests/test_offload/test_interface.py
@@ -16,6 +16,9 @@ from compressed_tensors.offload import (
     get_execution_device,
     get_offloaded_device,
     update_offload_parameter,
+    update_onload_parameter,
+    update_parameter,
+    update_parameter_async,
 )
 from compressed_tensors.offload.cache import CPUCache
 from compressed_tensors.offload.module import offload_module
@@ -108,6 +111,78 @@ def test_update_offload_parameter_only(offloaded_linear: torch.nn.Linear):
             offload = offloaded_linear.weight
         assert offload == 1
         assert offloaded_linear.weight != offload
+
+
+@pytest.mark.unit
+@requires_gpu
+@pytest.mark.parametrize("offload", (True, False))
+def test_update_onload_parameter(linear: torch.nn.Linear, cache, offload):
+    init_data = torch.tensor(0.0, device=OFFLOAD_DEVICE)
+    linear.weight = torch.nn.Parameter(init_data, requires_grad=False)
+    if offload:
+        offload_module(linear, ONLOAD_DEVICE, OFFLOAD_DEVICE)
+
+    assert linear.weight == 0
+
+    # when offloading is active, update_onload_parameter is a no-op
+    update_onload_parameter(linear, "weight", torch.tensor(1))
+    if offload:
+        assert linear.weight == 0
+    else:
+        assert linear.weight == 1
+
+    # when offloading is disabled, onloaded values can be updated
+    with disable_offloading():
+        update_onload_parameter(linear, "weight", torch.tensor(2))
+        assert linear.weight == 2
+
+    # after exiting disable_offloading, offloaded value is restored
+    if offload:
+        assert linear.weight == 0
+    else:
+        assert linear.weight == 2
+
+
+@pytest.mark.unit
+@requires_gpu
+@pytest.mark.parametrize("offload", (True, False))
+def test_update_parameter(linear: torch.nn.Linear, offload):
+    linear.weight = torch.nn.Parameter(torch.tensor(0.0, device=OFFLOAD_DEVICE))
+    if offload:
+        offload_module(linear, ONLOAD_DEVICE, OFFLOAD_DEVICE)
+
+    # Update both (default behavior)
+    update_parameter(linear, "weight", torch.tensor(1.0))
+    assert linear.weight == 1.0
+
+    # Update only offload
+    update_parameter(linear, "weight", torch.tensor(2.0), update_onload=False)
+    assert linear.weight == 2.0
+
+    # Update only onload - no effect when offloading is active
+    update_parameter(linear, "weight", torch.tensor(3.0), update_offload=False)
+    if offload:
+        assert linear.weight == 2.0  # offload value unchanged
+    else:
+        assert linear.weight == 3.0
+
+
+@pytest.mark.unit
+@requires_gpu
+@pytest.mark.parametrize("offload", (True, False))
+def test_update_parameter_async(linear: torch.nn.Linear, offload):
+    """Test update_parameter_async updates without synchronization barriers."""
+    linear.weight = torch.nn.Parameter(torch.tensor(0.0, device=OFFLOAD_DEVICE))
+    if offload:
+        offload_module(linear, ONLOAD_DEVICE, OFFLOAD_DEVICE)
+
+    # Update both (default behavior)
+    update_parameter_async(linear, "weight", torch.tensor(1.0))
+    assert linear.weight == 1.0
+
+    # Update only offload
+    update_parameter_async(linear, "weight", torch.tensor(2.0), update_onload=False)
+    assert linear.weight == 2.0
 
 
 @pytest.mark.unit

--- a/tests/test_offload/test_interface.py
+++ b/tests/test_offload/test_interface.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 import torch
+import torch.distributed as dist
+from compressed_tensors.distributed.utils import set_source_process
 from compressed_tensors.offload import (
     align_module_device,
     align_modules,
@@ -22,7 +24,11 @@ from compressed_tensors.offload import (
 )
 from compressed_tensors.offload.cache import CPUCache
 from compressed_tensors.offload.module import offload_module
-from tests.test_offload.conftest import assert_device_equal, assert_tensor_equal
+from tests.test_offload.conftest import (
+    assert_device_equal,
+    assert_tensor_equal,
+    torchrun,
+)
 from tests.testing_utils import requires_gpu
 
 
@@ -114,6 +120,18 @@ def test_update_offload_parameter_only(offloaded_linear: torch.nn.Linear):
 
 
 @pytest.mark.unit
+def test_update_offload_parameter_with_grad(linear: torch.nn.Linear):
+    zeros = torch.nn.Parameter(torch.zeros(5, 5), requires_grad=True)
+    update_offload_parameter(linear, "weight", zeros)
+    assert_tensor_equal(linear.weight, zeros)
+
+    ones = torch.nn.Parameter(torch.ones(5, 5), requires_grad=True)
+    offload_module(linear, ONLOAD_DEVICE, OFFLOAD_DEVICE)
+    update_offload_parameter(linear, "weight", ones)
+    assert_tensor_equal(linear.weight, ones, ONLOAD_DEVICE)
+
+
+@pytest.mark.unit
 @requires_gpu
 @pytest.mark.parametrize("offload", (True, False))
 def test_update_onload_parameter(linear: torch.nn.Linear, cache, offload):
@@ -133,6 +151,7 @@ def test_update_onload_parameter(linear: torch.nn.Linear, cache, offload):
 
     # when offloading is disabled, onloaded values can be updated
     with disable_offloading():
+        _ = linear.weight
         update_onload_parameter(linear, "weight", torch.tensor(2))
         assert linear.weight == 2
 
@@ -168,33 +187,87 @@ def test_update_parameter(linear: torch.nn.Linear, offload):
 
 
 @pytest.mark.unit
-@requires_gpu
-@pytest.mark.parametrize("offload", (True, False))
-def test_update_parameter_async(linear: torch.nn.Linear, offload):
-    """Test update_parameter_async updates without synchronization barriers."""
-    linear.weight = torch.nn.Parameter(torch.tensor(0.0, device=OFFLOAD_DEVICE))
-    if offload:
-        offload_module(linear, ONLOAD_DEVICE, OFFLOAD_DEVICE)
+@requires_gpu(2)
+@torchrun(world_size=2, init_dist=True)
+def test_update_parameter_distributed():
+    """Test update_parameter synchronizes across ranks in distributed context."""
+    module = torch.nn.Module()
+    module.weight = torch.nn.Parameter(torch.tensor(-1.0))
+    offload_module(module, ONLOAD_DEVICE, OFFLOAD_DEVICE)
 
-    # Update both (default behavior)
-    update_parameter_async(linear, "weight", torch.tensor(1.0))
-    assert linear.weight == 1.0
+    rank_data = torch.tensor(dist.get_rank())
 
-    # Update only offload
-    update_parameter_async(linear, "weight", torch.tensor(2.0), update_onload=False)
-    assert linear.weight == 2.0
+    # only update onload
+    with set_source_process(0):
+        with disable_offloading():
+            _ = module.weight
+
+            update_parameter(
+                module,
+                "weight",
+                rank_data,
+                update_offload=False,
+                update_onload=True,
+            )
+
+            with disable_onloading():
+                assert module.weight == -1
+            assert module.weight == 0
+
+    # only update offload
+    with set_source_process(1):
+        with disable_offloading():
+            _ = module.weight
+
+            update_parameter(
+                module,
+                "weight",
+                rank_data,
+                update_offload=True,
+                update_onload=False,
+            )
+
+            with disable_onloading():
+                assert module.weight == 1  # changed
+            assert module.weight == -1  # unchanged
 
 
 @pytest.mark.unit
-def test_update_offload_parameter_with_grad(linear: torch.nn.Linear):
-    zeros = torch.nn.Parameter(torch.zeros(5, 5), requires_grad=True)
-    update_offload_parameter(linear, "weight", zeros)
-    assert_tensor_equal(linear.weight, zeros)
+@requires_gpu(2)
+@torchrun(world_size=2, init_dist=True)
+def test_update_parameter_async_distributed():
+    """Test update_parameter_async updates without barriers or broadcasts."""
+    # Create module with two parameters, both starting at -1
+    module = torch.nn.Module()
+    module.param0 = torch.nn.Parameter(torch.tensor(-1.0))
+    module.param1 = torch.nn.Parameter(torch.tensor(-1.0))
+    offload_module(module, ONLOAD_DEVICE, OFFLOAD_DEVICE)
 
-    ones = torch.nn.Parameter(torch.ones(5, 5), requires_grad=True)
-    offload_module(linear, ONLOAD_DEVICE, OFFLOAD_DEVICE)
-    update_offload_parameter(linear, "weight", ones)
-    assert_tensor_equal(linear.weight, ones, ONLOAD_DEVICE)
+    rank = dist.get_rank()
+    param_name = f"param{rank}"
+    rank_data = torch.tensor(dist.get_rank())
+    update_onload = rank == 0
+
+    with disable_offloading():
+        _ = getattr(module, param_name)
+
+        update_parameter_async(
+            module,
+            param_name,
+            rank_data,
+            update_offload=True,
+            update_onload=update_onload,
+        )
+
+        if update_onload:
+            # check onload updated
+            assert getattr(module, param_name) == rank_data
+
+    # check offloads updated
+    dist.barrier()
+    with disable_onloading():
+        assert getattr(module, param_name) == rank_data
+        assert getattr(module, param_name) == rank_data
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Purpose ##
* Add better utils and a plan for better abstraction around updating onloaded/offloaded values
  * `register_offload_parameter`: synchronous create new parameter (sync)
  * `update_offload_parameter`: asynchronous update parameter (async)
  * `update_onload_parameter`: only updates the parameter onload (async)
  * Helper functions
    * `update_parameter`: convenience function for broadcasting and updating onload/offload parameters (sync)
    * `update_parameter_async`: convenience function for updating offload/onload parameters (async)

## Usages ##
The added utils are built around the following use cases:

Asynchronous offload updates (GPTQ async update)
```python3
def worker_thread(...):
  update_parameter_async(..., update_offload=True, update_onload=False)
```

Synchronous onload updates (GPTQ broadcast)
```python3
for module in modules:
  with set_source_rank(assigned_rank[module]):
    for name, data in update_dict.items():
      update_parameter(..., update_offload=False, update_onload=True)
```

Asynchronous onload updates (AWQ grid search)
```python3
for ... in grid:
  update_parameter_async(..., update_offload=False, update_onload=True)
```

Asynchronous offload and onload updates (AWQ smoothing/update)
```python3
for module in modules:
  update_parameter_async(..., update_offload=is_source_rank(), update_onload=True)
```

## Single Threaded -> Distributed ##
One of the original goals of the `offload` module was to allow easy and safe replacement of non-distributed operations with distributed versions. This is achieved through `update_parameter`, with the other utilities allowing greater complexity + performance tradeoffs.

## Changes ##
* Add `update_onload_parameter`, `update_parameter`, and `update_parameter_async`
* Add documentation for newly added functions

## Testing ##
* Added tests