### PR TITLE
fixing some issues with @torchrun decorator

### DIFF
--- a/tests/test_compressors/distributed/test_distributed_compression.py
+++ b/tests/test_compressors/distributed/test_distributed_compression.py
@@ -8,6 +8,7 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from compressed_tensors.compressors.model_compressors import ModelCompressor
+from compressed_tensors.distributed import init_dist
 from compressed_tensors.offload import offload_module
 from compressed_tensors.quantization import (
     QuantizationArgs,
@@ -86,6 +87,7 @@ def setup_quantized_model(model: nn.Module, bits: int = 4) -> nn.Module:
 @torchrun(world_size=2)
 def test_distributed_model_compression():
     """Test end-to-end distributed model compression."""
+    init_dist()
     model = TwoLayerModel()
     setup_quantized_model(model)
 
@@ -113,6 +115,7 @@ def test_distributed_model_compression():
 @torchrun(world_size=2)
 def test_distributed_compression_consistency():
     """Test that all ranks have consistent state after distributed compression."""
+    init_dist()
     model = TwoLayerModel()
     setup_quantized_model(model)
 
@@ -154,6 +157,7 @@ def test_distributed_compression_consistency():
 @torchrun(world_size=2)
 def test_distributed_compression_with_offload():
     """Test distributed compression with offloaded modules."""
+    init_dist()
     model = TwoLayerModel()
     setup_quantized_model(model)
 
@@ -177,6 +181,7 @@ def test_distributed_compression_with_offload():
 @torchrun(world_size=2)
 def test_distributed_compression_decompress_roundtrip():
     """Test that distributed compression + decompression preserves values."""
+    init_dist()
     model = TwoLayerModel()
     setup_quantized_model(model)
 
@@ -209,6 +214,7 @@ def test_distributed_compression_decompress_roundtrip():
 @torchrun(world_size=2)
 def test_distributed_compression_many_layers():
     """Test distributed compression with many layers to ensure load balancing."""
+    init_dist()
 
     class ManyLayerModel(nn.Module):
         def __init__(self, num_layers=10):
@@ -243,6 +249,7 @@ def test_distributed_compression_many_layers():
 @torchrun(world_size=2)
 def test_distributed_compression_skips_non_quantized():
     """Test that non-quantized layers are skipped in distributed compression."""
+    init_dist()
 
     class MixedModel(nn.Module):
         def __init__(self):
@@ -299,6 +306,7 @@ def test_distributed_compression_skips_non_quantized():
 @torchrun(world_size=2)
 def test_distributed_compression_empty_model():
     """Test distributed compression with an empty model."""
+    init_dist()
     model = nn.Sequential()
 
     q_config = create_quantization_config(bits=4, format="pack-quantized")
@@ -314,6 +322,7 @@ def test_distributed_compression_empty_model():
 @torchrun(world_size=2)
 def test_distributed_compression_single_layer():
     """Test distributed compression with a single layer."""
+    init_dist()
 
     class SingleLayerModel(nn.Module):
         def __init__(self):

--- a/tests/test_compressors/distributed/test_distributed_compression.py
+++ b/tests/test_compressors/distributed/test_distributed_compression.py
@@ -8,7 +8,6 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from compressed_tensors.compressors.model_compressors import ModelCompressor
-from compressed_tensors.distributed import init_dist
 from compressed_tensors.offload import offload_module
 from compressed_tensors.quantization import (
     QuantizationArgs,
@@ -84,10 +83,9 @@ def setup_quantized_model(model: nn.Module, bits: int = 4) -> nn.Module:
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_model_compression():
     """Test end-to-end distributed model compression."""
-    init_dist()
     model = TwoLayerModel()
     setup_quantized_model(model)
 
@@ -112,10 +110,9 @@ def test_distributed_model_compression():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_compression_consistency():
     """Test that all ranks have consistent state after distributed compression."""
-    init_dist()
     model = TwoLayerModel()
     setup_quantized_model(model)
 
@@ -154,10 +151,9 @@ def test_distributed_compression_consistency():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_compression_with_offload():
     """Test distributed compression with offloaded modules."""
-    init_dist()
     model = TwoLayerModel()
     setup_quantized_model(model)
 
@@ -178,10 +174,9 @@ def test_distributed_compression_with_offload():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_compression_decompress_roundtrip():
     """Test that distributed compression + decompression preserves values."""
-    init_dist()
     model = TwoLayerModel()
     setup_quantized_model(model)
 
@@ -211,10 +206,9 @@ def test_distributed_compression_decompress_roundtrip():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_compression_many_layers():
     """Test distributed compression with many layers to ensure load balancing."""
-    init_dist()
 
     class ManyLayerModel(nn.Module):
         def __init__(self, num_layers=10):
@@ -246,10 +240,9 @@ def test_distributed_compression_many_layers():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_compression_skips_non_quantized():
     """Test that non-quantized layers are skipped in distributed compression."""
-    init_dist()
 
     class MixedModel(nn.Module):
         def __init__(self):
@@ -303,10 +296,9 @@ def test_distributed_compression_skips_non_quantized():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_compression_empty_model():
     """Test distributed compression with an empty model."""
-    init_dist()
     model = nn.Sequential()
 
     q_config = create_quantization_config(bits=4, format="pack-quantized")
@@ -319,10 +311,9 @@ def test_distributed_compression_empty_model():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_compression_single_layer():
     """Test distributed compression with a single layer."""
-    init_dist()
 
     class SingleLayerModel(nn.Module):
         def __init__(self):

--- a/tests/test_compressors/distributed/test_module_parallel.py
+++ b/tests/test_compressors/distributed/test_module_parallel.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from compressed_tensors.distributed import replace_module_parallel
+from compressed_tensors.distributed import init_dist, replace_module_parallel
 from compressed_tensors.offload import offload_module
 from compressed_tensors.offload.utils import module_size, to_meta
 from tests.test_offload.conftest import torchrun
@@ -35,6 +35,7 @@ class TwoLayerModel(nn.Module):
 @torchrun(world_size=2)
 def test_to_meta():
     """Test that to_meta correctly moves module tensors to meta device."""
+    init_dist()
     module = SimpleLinear(5, 5)
     original_weight = module.weight.data.clone()
     original_bias = module.bias.data.clone()
@@ -56,6 +57,7 @@ def test_to_meta():
 @torchrun(world_size=2)
 def test_replace_module_parallel_basic():
     """Test basic replace_module_parallel functionality."""
+    init_dist()
     modules = [SimpleLinear(10, 10) for _ in range(4)]
 
     # Track which modules were processed
@@ -86,6 +88,7 @@ def test_replace_module_parallel_basic():
 @torchrun(world_size=2)
 def test_replace_module_parallel_with_offload():
     """Test replace_module_parallel with offloaded modules."""
+    init_dist()
     modules = [SimpleLinear(10, 10) for _ in range(4)]
 
     # Offload modules to CPU
@@ -119,6 +122,7 @@ def test_replace_module_parallel_with_offload():
 @torchrun(world_size=2)
 def test_replace_module_parallel_state_broadcast():
     """Test that state is correctly broadcast across ranks."""
+    init_dist()
     modules = [SimpleLinear(5, 5) for _ in range(2)]
 
     # Each rank processes different modules and sets unique values
@@ -142,6 +146,7 @@ def test_replace_module_parallel_state_broadcast():
 @torchrun(world_size=2)
 def test_replace_module_parallel_non_processing_ranks_use_meta():
     """Test that non-processing ranks temporarily use meta device."""
+    init_dist()
     modules = [SimpleLinear(10, 10) for _ in range(2)]
 
     # Track device usage during processing
@@ -166,6 +171,7 @@ def test_replace_module_parallel_non_processing_ranks_use_meta():
 @torchrun(world_size=2)
 def test_replace_module_parallel_preserves_module_structure():
     """Test that module structure is preserved after parallel processing."""
+    init_dist()
     module = SimpleLinear(5, 5)
     original_weight_shape = module.weight.shape
     original_bias_shape = module.bias.shape
@@ -189,6 +195,7 @@ def test_replace_module_parallel_preserves_module_structure():
 @torchrun(world_size=2)
 def test_replace_module_parallel_empty_list():
     """Test replace_module_parallel with empty module list."""
+    init_dist()
     modules = []
 
     call_count = [0]
@@ -208,6 +215,7 @@ def test_replace_module_parallel_empty_list():
 @torchrun(world_size=2)
 def test_replace_module_parallel_single_module():
     """Test replace_module_parallel with a single module."""
+    init_dist()
     module = SimpleLinear(10, 10)
 
     def apply_fn(m):
@@ -224,6 +232,7 @@ def test_replace_module_parallel_single_module():
 @torchrun(world_size=2)
 def test_replace_module_parallel_many_modules():
     """Test replace_module_parallel with many modules."""
+    init_dist()
     modules = [SimpleLinear(10, 10) for _ in range(20)]
 
     processed = set()
@@ -247,6 +256,7 @@ def test_replace_module_parallel_many_modules():
 @torchrun(world_size=2)
 def test_replace_module_parallel_custom_weight_function():
     """Test replace_module_parallel with custom weight function."""
+    init_dist()
     modules = [SimpleLinear(10, 10) for _ in range(4)]
 
     # Custom weight function that returns constant weights
@@ -269,6 +279,7 @@ def test_replace_module_parallel_custom_weight_function():
 @torchrun(world_size=2)
 def test_replace_module_parallel_exception_handling():
     """Test that exceptions in apply_fn are properly propagated."""
+    init_dist()
     module = SimpleLinear(10, 10)
 
     def failing_apply_fn(m):
@@ -284,6 +295,7 @@ def test_replace_module_parallel_exception_handling():
 @torchrun(world_size=2)
 def test_replace_module_parallel_parameter_replacement():
     """Test replace_module_parallel when parameters are replaced."""
+    init_dist()
     module = SimpleLinear(10, 10)
     original_weight_shape = module.weight.shape
 
@@ -304,6 +316,7 @@ def test_replace_module_parallel_parameter_replacement():
 @torchrun(world_size=2)
 def test_replace_module_parallel_adds_new_parameters():
     """Test replace_module_parallel when new parameters are added."""
+    init_dist()
     module = SimpleLinear(10, 10)
 
     def add_parameter_fn(m):
@@ -322,6 +335,7 @@ def test_replace_module_parallel_adds_new_parameters():
 @torchrun(world_size=2)
 def test_replace_module_parallel_removes_parameters():
     """Test replace_module_parallel when parameters are removed."""
+    init_dist()
     module = SimpleLinear(10, 10)
 
     def remove_bias_fn(m):
@@ -340,6 +354,7 @@ def test_replace_module_parallel_removes_parameters():
 @torchrun(world_size=2)
 def test_replace_module_parallel_with_buffers():
     """Test replace_module_parallel with modules that have buffers."""
+    init_dist()
 
     class ModuleWithBuffer(nn.Module):
         def __init__(self):
@@ -365,6 +380,7 @@ def test_replace_module_parallel_with_buffers():
 @torchrun(world_size=2)
 def test_to_meta_preserves_parameter_properties():
     """Test that to_meta preserves parameter properties like requires_grad."""
+    init_dist()
     module = SimpleLinear(5, 5)
     module.weight.requires_grad = False
 
@@ -380,6 +396,7 @@ def test_to_meta_preserves_parameter_properties():
 @torchrun(world_size=2)
 def test_replace_module_parallel_rank_consistency():
     """Test that all ranks see the same final state."""
+    init_dist()
     modules = [SimpleLinear(5, 5) for _ in range(4)]
 
     def apply_fn(m):

--- a/tests/test_compressors/distributed/test_module_parallel.py
+++ b/tests/test_compressors/distributed/test_module_parallel.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 import torch.distributed as dist
 import torch.nn as nn
-from compressed_tensors.distributed import init_dist, replace_module_parallel
+from compressed_tensors.distributed import replace_module_parallel
 from compressed_tensors.offload import offload_module
 from compressed_tensors.offload.utils import module_size, to_meta
 from tests.test_offload.conftest import torchrun
@@ -32,10 +32,9 @@ class TwoLayerModel(nn.Module):
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_to_meta():
     """Test that to_meta correctly moves module tensors to meta device."""
-    init_dist()
     module = SimpleLinear(5, 5)
     original_weight = module.weight.data.clone()
     original_bias = module.bias.data.clone()
@@ -54,10 +53,9 @@ def test_to_meta():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replace_module_parallel_basic():
     """Test basic replace_module_parallel functionality."""
-    init_dist()
     modules = [SimpleLinear(10, 10) for _ in range(4)]
 
     # Track which modules were processed
@@ -85,10 +83,9 @@ def test_replace_module_parallel_basic():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replace_module_parallel_with_offload():
     """Test replace_module_parallel with offloaded modules."""
-    init_dist()
     modules = [SimpleLinear(10, 10) for _ in range(4)]
 
     # Offload modules to CPU
@@ -119,10 +116,9 @@ def test_replace_module_parallel_with_offload():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replace_module_parallel_state_broadcast():
     """Test that state is correctly broadcast across ranks."""
-    init_dist()
     modules = [SimpleLinear(5, 5) for _ in range(2)]
 
     # Each rank processes different modules and sets unique values
@@ -143,10 +139,9 @@ def test_replace_module_parallel_state_broadcast():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replace_module_parallel_non_processing_ranks_use_meta():
     """Test that non-processing ranks temporarily use meta device."""
-    init_dist()
     modules = [SimpleLinear(10, 10) for _ in range(2)]
 
     # Track device usage during processing
@@ -168,10 +163,9 @@ def test_replace_module_parallel_non_processing_ranks_use_meta():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replace_module_parallel_preserves_module_structure():
     """Test that module structure is preserved after parallel processing."""
-    init_dist()
     module = SimpleLinear(5, 5)
     original_weight_shape = module.weight.shape
     original_bias_shape = module.bias.shape
@@ -192,10 +186,9 @@ def test_replace_module_parallel_preserves_module_structure():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replace_module_parallel_empty_list():
     """Test replace_module_parallel with empty module list."""
-    init_dist()
     modules = []
 
     call_count = [0]
@@ -212,10 +205,9 @@ def test_replace_module_parallel_empty_list():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replace_module_parallel_single_module():
     """Test replace_module_parallel with a single module."""
-    init_dist()
     module = SimpleLinear(10, 10)
 
     def apply_fn(m):
@@ -229,10 +221,9 @@ def test_replace_module_parallel_single_module():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replace_module_parallel_many_modules():
     """Test replace_module_parallel with many modules."""
-    init_dist()
     modules = [SimpleLinear(10, 10) for _ in range(20)]
 
     processed = set()
@@ -253,10 +244,9 @@ def test_replace_module_parallel_many_modules():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replace_module_parallel_custom_weight_function():
     """Test replace_module_parallel with custom weight function."""
-    init_dist()
     modules = [SimpleLinear(10, 10) for _ in range(4)]
 
     # Custom weight function that returns constant weights
@@ -276,10 +266,9 @@ def test_replace_module_parallel_custom_weight_function():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replace_module_parallel_exception_handling():
     """Test that exceptions in apply_fn are properly propagated."""
-    init_dist()
     module = SimpleLinear(10, 10)
 
     def failing_apply_fn(m):
@@ -292,10 +281,9 @@ def test_replace_module_parallel_exception_handling():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replace_module_parallel_parameter_replacement():
     """Test replace_module_parallel when parameters are replaced."""
-    init_dist()
     module = SimpleLinear(10, 10)
     original_weight_shape = module.weight.shape
 
@@ -313,10 +301,9 @@ def test_replace_module_parallel_parameter_replacement():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replace_module_parallel_adds_new_parameters():
     """Test replace_module_parallel when new parameters are added."""
-    init_dist()
     module = SimpleLinear(10, 10)
 
     def add_parameter_fn(m):
@@ -332,10 +319,9 @@ def test_replace_module_parallel_adds_new_parameters():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replace_module_parallel_removes_parameters():
     """Test replace_module_parallel when parameters are removed."""
-    init_dist()
     module = SimpleLinear(10, 10)
 
     def remove_bias_fn(m):
@@ -351,10 +337,9 @@ def test_replace_module_parallel_removes_parameters():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replace_module_parallel_with_buffers():
     """Test replace_module_parallel with modules that have buffers."""
-    init_dist()
 
     class ModuleWithBuffer(nn.Module):
         def __init__(self):
@@ -377,10 +362,9 @@ def test_replace_module_parallel_with_buffers():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_to_meta_preserves_parameter_properties():
     """Test that to_meta preserves parameter properties like requires_grad."""
-    init_dist()
     module = SimpleLinear(5, 5)
     module.weight.requires_grad = False
 
@@ -393,10 +377,9 @@ def test_to_meta_preserves_parameter_properties():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replace_module_parallel_rank_consistency():
     """Test that all ranks see the same final state."""
-    init_dist()
     modules = [SimpleLinear(5, 5) for _ in range(4)]
 
     def apply_fn(m):

--- a/tests/test_compressors/model_compressors/test_model_compressor_distributed.py
+++ b/tests/test_compressors/model_compressors/test_model_compressor_distributed.py
@@ -8,6 +8,7 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from compressed_tensors import ModelCompressor
+from compressed_tensors.distributed import init_dist
 from compressed_tensors.quantization import (
     QuantizationArgs,
     QuantizationConfig,
@@ -79,6 +80,7 @@ class TwoLayerModel(nn.Module):
 @torchrun(world_size=2)
 def test_compress_model_distributed_basic():
     """Test basic distributed compression via ModelCompressor."""
+    init_dist()
     model = TwoLayerModel()
     setup_quantized_module(model.layer1)
     setup_quantized_module(model.layer2)
@@ -109,6 +111,7 @@ def test_compress_model_distributed_basic():
 @torchrun(world_size=2)
 def test_compress_model_distributed_consistency():
     """Test that all ranks have consistent state after distributed compression."""
+    init_dist()
     model = TwoLayerModel()
     setup_quantized_module(model.layer1)
     setup_quantized_module(model.layer2)
@@ -149,6 +152,7 @@ def test_compress_model_distributed_consistency():
 @torchrun(world_size=2)
 def test_compress_model_distributed_no_quantized_modules():
     """Test distributed compression with no quantized modules."""
+    init_dist()
     model = TwoLayerModel()
     # Don't set up quantization schemes
 
@@ -168,6 +172,7 @@ def test_compress_model_distributed_no_quantized_modules():
 @torchrun(world_size=2)
 def test_compress_model_distributed_partial_quantization():
     """Test distributed compression with only some modules quantized."""
+    init_dist()
     model = TwoLayerModel()
     setup_quantized_module(model.layer1)
     # Don't quantize layer2
@@ -187,6 +192,7 @@ def test_compress_model_distributed_partial_quantization():
 @torchrun(world_size=2)
 def test_compress_decompress_distributed_roundtrip():
     """Test compress then decompress in distributed mode."""
+    init_dist()
     model = TwoLayerModel()
     setup_quantized_module(model.layer1)
     setup_quantized_module(model.layer2)
@@ -228,6 +234,7 @@ def test_compress_decompress_distributed_roundtrip():
 @torchrun(world_size=2)
 def test_compress_model_distributed_many_layers():
     """Test distributed compression with many layers for load balancing."""
+    init_dist()
 
     class ManyLayerModel(nn.Module):
         def __init__(self, num_layers=10):
@@ -271,6 +278,7 @@ def test_compress_model_distributed_many_layers():
 @torchrun(world_size=2)
 def test_compress_model_distributed_force_format():
     """Test that force_compression_format works in distributed mode."""
+    init_dist()
     model = TwoLayerModel()
     setup_quantized_module(model.layer1)
     setup_quantized_module(model.layer2)
@@ -293,6 +301,7 @@ def test_compress_model_distributed_force_format():
 @torchrun(world_size=2)
 def test_compress_model_distributed_from_pretrained():
     """Test from_pretrained_model entrypoint works with distributed compression."""
+    init_dist()
     model = TwoLayerModel()
     setup_quantized_module(model.layer1)
     setup_quantized_module(model.layer2)
@@ -317,6 +326,7 @@ def test_compress_model_distributed_from_pretrained():
 @torchrun(world_size=2)
 def test_compress_model_distributed_hook_triggers():
     """Test that decompression hook triggers correctly in distributed mode."""
+    init_dist()
     model = TwoLayerModel()
     setup_quantized_module(model.layer1)
     setup_quantized_module(model.layer2)

--- a/tests/test_compressors/model_compressors/test_model_compressor_distributed.py
+++ b/tests/test_compressors/model_compressors/test_model_compressor_distributed.py
@@ -8,7 +8,6 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from compressed_tensors import ModelCompressor
-from compressed_tensors.distributed import init_dist
 from compressed_tensors.quantization import (
     QuantizationArgs,
     QuantizationConfig,
@@ -77,10 +76,9 @@ class TwoLayerModel(nn.Module):
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_compress_model_distributed_basic():
     """Test basic distributed compression via ModelCompressor."""
-    init_dist()
     model = TwoLayerModel()
     setup_quantized_module(model.layer1)
     setup_quantized_module(model.layer2)
@@ -108,10 +106,9 @@ def test_compress_model_distributed_basic():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_compress_model_distributed_consistency():
     """Test that all ranks have consistent state after distributed compression."""
-    init_dist()
     model = TwoLayerModel()
     setup_quantized_module(model.layer1)
     setup_quantized_module(model.layer2)
@@ -149,10 +146,9 @@ def test_compress_model_distributed_consistency():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_compress_model_distributed_no_quantized_modules():
     """Test distributed compression with no quantized modules."""
-    init_dist()
     model = TwoLayerModel()
     # Don't set up quantization schemes
 
@@ -169,10 +165,9 @@ def test_compress_model_distributed_no_quantized_modules():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_compress_model_distributed_partial_quantization():
     """Test distributed compression with only some modules quantized."""
-    init_dist()
     model = TwoLayerModel()
     setup_quantized_module(model.layer1)
     # Don't quantize layer2
@@ -189,10 +184,9 @@ def test_compress_model_distributed_partial_quantization():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_compress_decompress_distributed_roundtrip():
     """Test compress then decompress in distributed mode."""
-    init_dist()
     model = TwoLayerModel()
     setup_quantized_module(model.layer1)
     setup_quantized_module(model.layer2)
@@ -231,10 +225,9 @@ def test_compress_decompress_distributed_roundtrip():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_compress_model_distributed_many_layers():
     """Test distributed compression with many layers for load balancing."""
-    init_dist()
 
     class ManyLayerModel(nn.Module):
         def __init__(self, num_layers=10):
@@ -275,10 +268,9 @@ def test_compress_model_distributed_many_layers():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_compress_model_distributed_force_format():
     """Test that force_compression_format works in distributed mode."""
-    init_dist()
     model = TwoLayerModel()
     setup_quantized_module(model.layer1)
     setup_quantized_module(model.layer2)
@@ -298,10 +290,9 @@ def test_compress_model_distributed_force_format():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_compress_model_distributed_from_pretrained():
     """Test from_pretrained_model entrypoint works with distributed compression."""
-    init_dist()
     model = TwoLayerModel()
     setup_quantized_module(model.layer1)
     setup_quantized_module(model.layer2)
@@ -323,10 +314,9 @@ def test_compress_model_distributed_from_pretrained():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_compress_model_distributed_hook_triggers():
     """Test that decompression hook triggers correctly in distributed mode."""
-    init_dist()
     model = TwoLayerModel()
     setup_quantized_module(model.layer1)
     setup_quantized_module(model.layer2)

--- a/tests/test_offload/cache/test_dist_cpu.py
+++ b/tests/test_offload/cache/test_dist_cpu.py
@@ -7,6 +7,7 @@ import torch.distributed as dist
 from compressed_tensors.offload import disable_onloading
 from compressed_tensors.offload.cache.dist_cpu import DistributedCPUCache
 from loguru import logger as loguru_logger
+from compressed_tensors.distributed import init_dist
 from tests.test_offload.cache.helpers import (
     _test_delete,
     _test_disable_offloading,
@@ -18,6 +19,7 @@ from tests.test_offload.cache.helpers import (
     _test_shared_attributes,
     _test_tensor_subclass,
 )
+from compressed_tensors.distributed import init_dist
 from tests.test_offload.conftest import torchrun
 from tests.testing_utils import requires_gpu
 
@@ -36,6 +38,7 @@ def offload_device():
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_delete(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_delete(offload_device, onload_device, offload_cache)
 
 
@@ -43,6 +46,7 @@ def test_delete(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_disable_offloading(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_disable_offloading(offload_device, onload_device, offload_cache)
 
 
@@ -50,6 +54,7 @@ def test_disable_offloading(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_disable_onloading(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_disable_onloading(offload_device, onload_device, offload_cache)
 
 
@@ -57,6 +62,7 @@ def test_disable_onloading(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_garbage_collect(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_garbage_collect(offload_device, onload_device, offload_cache)
 
 
@@ -64,6 +70,7 @@ def test_garbage_collect(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_offload(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_offload(offload_device, onload_device, offload_cache)
 
 
@@ -71,6 +78,7 @@ def test_offload(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_onload(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_onload(offload_device, onload_device, offload_cache)
 
 
@@ -78,6 +86,7 @@ def test_onload(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_onloading(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_onloading(offload_device, onload_device, offload_cache)
 
 
@@ -85,6 +94,7 @@ def test_onloading(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_shared_attributes(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_shared_attributes(offload_device, onload_device, offload_cache)
 
 
@@ -92,6 +102,7 @@ def test_shared_attributes(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_tensor_subclass(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_tensor_subclass(offload_device, onload_device, offload_cache)
 
 
@@ -99,6 +110,7 @@ def test_tensor_subclass(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_distributed_offload(onload_device):
+    init_dist()
     cache = DistributedCPUCache(onload_device)
     tensor = torch.zeros((5, 2))
     cache["tensor"] = tensor
@@ -122,6 +134,7 @@ def test_distributed_offload(onload_device):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_shared_cpu_offload(onload_device):
+    init_dist()
     cache = DistributedCPUCache(onload_device)
     tensor = torch.zeros((5, 2))
     cache["tensor"] = tensor
@@ -148,6 +161,7 @@ def test_distributed_async_update(onload_device):
     Test that different ranks can update different tensors asynchronously,
     and that values are correct after a barrier.
     """
+    init_dist()
     cache = DistributedCPUCache(onload_device)
 
     # Initialize two tensors in the cache
@@ -185,6 +199,7 @@ def test_distributed_async_update(onload_device):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_distributed_offload_logs_memory_hint(onload_device):
+    init_dist()
     cache = DistributedCPUCache(onload_device)
 
     original_share_memory = torch.Tensor.share_memory_

--- a/tests/test_offload/cache/test_dist_cpu.py
+++ b/tests/test_offload/cache/test_dist_cpu.py
@@ -4,10 +4,10 @@
 import pytest
 import torch
 import torch.distributed as dist
+from compressed_tensors.distributed import init_dist
 from compressed_tensors.offload import disable_onloading
 from compressed_tensors.offload.cache.dist_cpu import DistributedCPUCache
 from loguru import logger as loguru_logger
-from compressed_tensors.distributed import init_dist
 from tests.test_offload.cache.helpers import (
     _test_delete,
     _test_disable_offloading,
@@ -19,7 +19,6 @@ from tests.test_offload.cache.helpers import (
     _test_shared_attributes,
     _test_tensor_subclass,
 )
-from compressed_tensors.distributed import init_dist
 from tests.test_offload.conftest import torchrun
 from tests.testing_utils import requires_gpu
 

--- a/tests/test_offload/cache/test_dist_cpu.py
+++ b/tests/test_offload/cache/test_dist_cpu.py
@@ -4,7 +4,6 @@
 import pytest
 import torch
 import torch.distributed as dist
-from compressed_tensors.distributed import init_dist
 from compressed_tensors.offload import disable_onloading
 from compressed_tensors.offload.cache.dist_cpu import DistributedCPUCache
 from loguru import logger as loguru_logger
@@ -35,81 +34,71 @@ def offload_device():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_delete(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_delete(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_disable_offloading(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_disable_offloading(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_disable_onloading(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_disable_onloading(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_garbage_collect(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_garbage_collect(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_offload(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_offload(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_onload(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_onload(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_onloading(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_onloading(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_shared_attributes(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_shared_attributes(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_tensor_subclass(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_tensor_subclass(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_offload(onload_device):
-    init_dist()
     cache = DistributedCPUCache(onload_device)
     tensor = torch.zeros((5, 2))
     cache["tensor"] = tensor
@@ -131,9 +120,8 @@ def test_distributed_offload(onload_device):
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_shared_cpu_offload(onload_device):
-    init_dist()
     cache = DistributedCPUCache(onload_device)
     tensor = torch.zeros((5, 2))
     cache["tensor"] = tensor
@@ -154,13 +142,12 @@ def test_shared_cpu_offload(onload_device):
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_async_update(onload_device):
     """
     Test that different ranks can update different tensors asynchronously,
     and that values are correct after a barrier.
     """
-    init_dist()
     cache = DistributedCPUCache(onload_device)
 
     # Initialize two tensors in the cache
@@ -196,9 +183,8 @@ def test_distributed_async_update(onload_device):
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_offload_logs_memory_hint(onload_device):
-    init_dist()
     cache = DistributedCPUCache(onload_device)
 
     original_share_memory = torch.Tensor.share_memory_

--- a/tests/test_offload/cache/test_dist_device.py
+++ b/tests/test_offload/cache/test_dist_device.py
@@ -9,6 +9,7 @@ import torch
 import torch.distributed as dist
 from compressed_tensors.offload import disable_onloading
 from compressed_tensors.offload.cache.dist_device import DistributedDeviceCache
+from compressed_tensors.distributed import init_dist
 from tests.test_offload.cache.helpers import (
     _test_delete,
     _test_disable_onloading,
@@ -18,6 +19,7 @@ from tests.test_offload.cache.helpers import (
     _test_shared_attributes,
     _test_tensor_subclass,
 )
+from compressed_tensors.distributed import init_dist
 from tests.test_offload.conftest import assert_device_equal, torchrun
 from tests.testing_utils import requires_gpu
 
@@ -40,6 +42,7 @@ def offload_device():
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_delete(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_delete(offload_device, onload_device, offload_cache)
 
 
@@ -47,6 +50,7 @@ def test_delete(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_disable_offloading(onload_device):
+    init_dist()
     # unlike other device caches, the onload is not garbage collected
     cache = DistributedDeviceCache(onload_device)
     cache["weight"] = torch.ones(10)
@@ -75,6 +79,7 @@ def test_disable_offloading(onload_device):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_disable_onloading(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_disable_onloading(offload_device, onload_device, offload_cache)
 
 
@@ -82,6 +87,7 @@ def test_disable_onloading(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_garbage_collect(onload_device):
+    init_dist()
     # unlike other device caches, the onload is not garbage collected
     cache = DistributedDeviceCache(onload_device)
     cache["weight"] = torch.ones(10)
@@ -97,6 +103,7 @@ def test_garbage_collect(onload_device):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_offload(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_offload(offload_device, onload_device, offload_cache)
 
 
@@ -104,6 +111,7 @@ def test_offload(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_onload(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_onload(offload_device, onload_device, offload_cache)
 
 
@@ -111,6 +119,7 @@ def test_onload(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_onloading(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_onloading(offload_device, onload_device, offload_cache)
 
 
@@ -118,6 +127,7 @@ def test_onloading(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_shared_attributes(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_shared_attributes(offload_device, onload_device, offload_cache)
 
 
@@ -125,6 +135,7 @@ def test_shared_attributes(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_tensor_subclass(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_tensor_subclass(offload_device, onload_device, offload_cache)
 
 
@@ -132,6 +143,7 @@ def test_tensor_subclass(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_distributed_offload(onload_device):
+    init_dist()
     cache = DistributedDeviceCache(onload_device)
     tensor = torch.zeros((5, 2))
     cache["tensor"] = tensor
@@ -156,6 +168,7 @@ def test_distributed_offload(onload_device):
 @torchrun(world_size=2)
 def test_distributed_offload_fp8(onload_device):
     """FP8 tensors should broadcast successfully and preserve their dtype"""
+    init_dist()
     float8_dtypes = [
         torch.float8_e4m3fn,
         torch.float8_e5m2,
@@ -176,6 +189,7 @@ def test_distributed_offload_fp8(onload_device):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_replicated_device_offload(onload_device):
+    init_dist()
     cache = DistributedDeviceCache(onload_device)
     tensor = torch.empty((5, 2))
     cache["tensor"] = tensor

--- a/tests/test_offload/cache/test_dist_device.py
+++ b/tests/test_offload/cache/test_dist_device.py
@@ -7,7 +7,6 @@ from weakref import ref
 import pytest
 import torch
 import torch.distributed as dist
-from compressed_tensors.distributed import init_dist
 from compressed_tensors.offload import disable_onloading
 from compressed_tensors.offload.cache.dist_device import DistributedDeviceCache
 from tests.test_offload.cache.helpers import (
@@ -39,17 +38,15 @@ def offload_device():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_delete(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_delete(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_disable_offloading(onload_device):
-    init_dist()
     # unlike other device caches, the onload is not garbage collected
     cache = DistributedDeviceCache(onload_device)
     cache["weight"] = torch.ones(10)
@@ -76,17 +73,15 @@ def test_disable_offloading(onload_device):
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_disable_onloading(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_disable_onloading(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_garbage_collect(onload_device):
-    init_dist()
     # unlike other device caches, the onload is not garbage collected
     cache = DistributedDeviceCache(onload_device)
     cache["weight"] = torch.ones(10)
@@ -100,49 +95,43 @@ def test_garbage_collect(onload_device):
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_offload(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_offload(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_onload(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_onload(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_onloading(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_onloading(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_shared_attributes(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_shared_attributes(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_tensor_subclass(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_tensor_subclass(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_offload(onload_device):
-    init_dist()
     cache = DistributedDeviceCache(onload_device)
     tensor = torch.zeros((5, 2))
     cache["tensor"] = tensor
@@ -164,10 +153,9 @@ def test_distributed_offload(onload_device):
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_offload_fp8(onload_device):
     """FP8 tensors should broadcast successfully and preserve their dtype"""
-    init_dist()
     float8_dtypes = [
         torch.float8_e4m3fn,
         torch.float8_e5m2,
@@ -186,9 +174,8 @@ def test_distributed_offload_fp8(onload_device):
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_replicated_device_offload(onload_device):
-    init_dist()
     cache = DistributedDeviceCache(onload_device)
     tensor = torch.empty((5, 2))
     cache["tensor"] = tensor

--- a/tests/test_offload/cache/test_dist_device.py
+++ b/tests/test_offload/cache/test_dist_device.py
@@ -7,9 +7,9 @@ from weakref import ref
 import pytest
 import torch
 import torch.distributed as dist
+from compressed_tensors.distributed import init_dist
 from compressed_tensors.offload import disable_onloading
 from compressed_tensors.offload.cache.dist_device import DistributedDeviceCache
-from compressed_tensors.distributed import init_dist
 from tests.test_offload.cache.helpers import (
     _test_delete,
     _test_disable_onloading,
@@ -19,7 +19,6 @@ from tests.test_offload.cache.helpers import (
     _test_shared_attributes,
     _test_tensor_subclass,
 )
-from compressed_tensors.distributed import init_dist
 from tests.test_offload.conftest import assert_device_equal, torchrun
 from tests.testing_utils import requires_gpu
 

--- a/tests/test_offload/cache/test_dist_disk.py
+++ b/tests/test_offload/cache/test_dist_disk.py
@@ -6,11 +6,11 @@ import os
 import pytest
 import torch
 import torch.distributed as dist
+from compressed_tensors.distributed import init_dist
 from compressed_tensors.offload import disable_onloading
 from compressed_tensors.offload.cache.disk import DiskCache
 from compressed_tensors.offload.cache.dist_disk import DistributedDiskCache
 from safetensors import safe_open
-from compressed_tensors.distributed import init_dist
 from tests.test_offload.cache.helpers import (
     _test_delete,
     _test_disable_offloading,
@@ -22,7 +22,6 @@ from tests.test_offload.cache.helpers import (
     _test_shared_attributes,
     _test_tensor_subclass,
 )
-from compressed_tensors.distributed import init_dist
 from tests.test_offload.conftest import assert_tensor_equal, torchrun
 from tests.testing_utils import requires_gpu
 

--- a/tests/test_offload/cache/test_dist_disk.py
+++ b/tests/test_offload/cache/test_dist_disk.py
@@ -6,7 +6,6 @@ import os
 import pytest
 import torch
 import torch.distributed as dist
-from compressed_tensors.distributed import init_dist
 from compressed_tensors.offload import disable_onloading
 from compressed_tensors.offload.cache.disk import DiskCache
 from compressed_tensors.offload.cache.dist_disk import DistributedDiskCache
@@ -38,81 +37,71 @@ def offload_device():
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_delete(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_delete(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_disable_offloading(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_disable_offloading(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_disable_onloading(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_disable_onloading(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_garbage_collect(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_garbage_collect(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_offload(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_offload(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_onload(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_onload(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_onloading(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_onloading(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_shared_attributes(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_shared_attributes(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_tensor_subclass(offload_device, onload_device, offload_cache):
-    init_dist()
     _test_tensor_subclass(offload_device, onload_device, offload_cache)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_offload(onload_device, tmp_path):
-    init_dist()
     # Broadcast directory path from rank 0 to all ranks
     if dist.get_rank() == 0:
         offload_dir = tmp_path / "offload_dir"
@@ -148,9 +137,8 @@ def test_distributed_offload(onload_device, tmp_path):
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_files(tmp_path):
-    init_dist()
     # Broadcast directory path from rank 0 to all ranks
     if dist.get_rank() == 0:
         offload_dir = tmp_path / "offload_dir"
@@ -206,13 +194,12 @@ def test_distributed_files(tmp_path):
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_distributed_async_update(tmp_path):
     """
     Test that different ranks can update different tensors asynchronously,
     and that values are correct after a barrier.
     """
-    init_dist()
     offload_dir = tmp_path / "offload_dir"
     if dist.get_rank() == 0:
         os.mkdir(offload_dir)

--- a/tests/test_offload/cache/test_dist_disk.py
+++ b/tests/test_offload/cache/test_dist_disk.py
@@ -10,6 +10,7 @@ from compressed_tensors.offload import disable_onloading
 from compressed_tensors.offload.cache.disk import DiskCache
 from compressed_tensors.offload.cache.dist_disk import DistributedDiskCache
 from safetensors import safe_open
+from compressed_tensors.distributed import init_dist
 from tests.test_offload.cache.helpers import (
     _test_delete,
     _test_disable_offloading,
@@ -21,6 +22,7 @@ from tests.test_offload.cache.helpers import (
     _test_shared_attributes,
     _test_tensor_subclass,
 )
+from compressed_tensors.distributed import init_dist
 from tests.test_offload.conftest import assert_tensor_equal, torchrun
 from tests.testing_utils import requires_gpu
 
@@ -39,6 +41,7 @@ def offload_device():
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_delete(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_delete(offload_device, onload_device, offload_cache)
 
 
@@ -46,6 +49,7 @@ def test_delete(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_disable_offloading(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_disable_offloading(offload_device, onload_device, offload_cache)
 
 
@@ -53,6 +57,7 @@ def test_disable_offloading(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_disable_onloading(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_disable_onloading(offload_device, onload_device, offload_cache)
 
 
@@ -60,6 +65,7 @@ def test_disable_onloading(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_garbage_collect(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_garbage_collect(offload_device, onload_device, offload_cache)
 
 
@@ -67,6 +73,7 @@ def test_garbage_collect(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_offload(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_offload(offload_device, onload_device, offload_cache)
 
 
@@ -74,6 +81,7 @@ def test_offload(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_onload(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_onload(offload_device, onload_device, offload_cache)
 
 
@@ -81,6 +89,7 @@ def test_onload(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_onloading(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_onloading(offload_device, onload_device, offload_cache)
 
 
@@ -88,6 +97,7 @@ def test_onloading(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_shared_attributes(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_shared_attributes(offload_device, onload_device, offload_cache)
 
 
@@ -95,6 +105,7 @@ def test_shared_attributes(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_tensor_subclass(offload_device, onload_device, offload_cache):
+    init_dist()
     _test_tensor_subclass(offload_device, onload_device, offload_cache)
 
 
@@ -102,6 +113,7 @@ def test_tensor_subclass(offload_device, onload_device, offload_cache):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_distributed_offload(onload_device, tmp_path):
+    init_dist()
     # Broadcast directory path from rank 0 to all ranks
     if dist.get_rank() == 0:
         offload_dir = tmp_path / "offload_dir"
@@ -139,6 +151,7 @@ def test_distributed_offload(onload_device, tmp_path):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_distributed_files(tmp_path):
+    init_dist()
     # Broadcast directory path from rank 0 to all ranks
     if dist.get_rank() == 0:
         offload_dir = tmp_path / "offload_dir"
@@ -200,6 +213,7 @@ def test_distributed_async_update(tmp_path):
     Test that different ranks can update different tensors asynchronously,
     and that values are correct after a barrier.
     """
+    init_dist()
     offload_dir = tmp_path / "offload_dir"
     if dist.get_rank() == 0:
         os.mkdir(offload_dir)

--- a/tests/test_offload/conftest.py
+++ b/tests/test_offload/conftest.py
@@ -80,12 +80,21 @@ def assert_tensor_equal(
 
 def torchrun(world_size: int = 1) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """
-    Test a function within parallel `torchrun` subprocesses, each running with `pytest`
-    ```
-    # (main) -> (torchrun) -
-    #              \\-- (rank 0)
-    #              \\-- (rank 1)
-    ```
+    Pytest decorator to run a test within parallel torchrun subprocesses.
+
+    This decorator automatically spawns torchrun when the test is run with regular
+    pytest.
+    When running under torchrun (detected via TORCHELASTIC_RUN_ID env var), it simply
+    runs the test. The test is responsible for its own distributed initialization.
+
+    Usage:
+        @pytest.mark.unit
+        @requires_gpu(2)
+        @torchrun(world_size=2)
+        def test_distributed_feature():
+            # Test must handle its own distributed setup
+            init_dist()
+            ...
 
     :param world_size: number of ranks to spawn
     """
@@ -93,41 +102,44 @@ def torchrun(world_size: int = 1) -> Callable[[Callable[..., Any]], Callable[...
     def decorator(func: FunctionType):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            # We're running in a torchrun subprocess:
-            # init distributed and run test func
+            # We're running in a torchrun subprocess: just run the test
             if "TORCHELASTIC_RUN_ID" in os.environ:
-                rank = int(os.environ["RANK"])
-                local_rank = int(os.environ["LOCAL_RANK"])
-
-                torch.accelerator.set_device_index(local_rank)
-                accel_type = torch.accelerator.current_accelerator().type
-                dist.init_process_group(
-                    backend=dist.get_default_backend_for_device(
-                        torch.device(accel_type, local_rank)
-                    ),
-                    init_method="env://",
-                    rank=rank,
-                    world_size=world_size,
-                    device_id=local_rank,
-                )
-                dist.barrier()
-
                 return func(*args, **kwargs)
 
             # First time calling in the main process:
             # trigger torchrun with this function as the pytest target
             else:
-                file_path = sys.modules.get(func.__module__).__file__
+                module = sys.modules.get(func.__module__)
+                if module is None:
+                    raise RuntimeError(
+                        f"Can't find module {func.__module__} for func {func.__name__}"
+                    )
+                file_path = module.__file__
+                if file_path is None:
+                    raise RuntimeError(
+                        f"Module {func.__module__} has no __file__ attribute"
+                    )
                 func_name = func.__name__
 
-                cmd = (
-                    f"{sys.executable} "
-                    f"-m torch.distributed.run --nproc_per_node {world_size} "
-                    "--log-dir /tmp/torchrun-logs --tee 3 --role torchrun "
-                    f"-m pytest {file_path}::{func_name} -sx"
-                )
+                cmd = [
+                    sys.executable,
+                    "-m",
+                    "torch.distributed.run",
+                    "--nproc_per_node",
+                    str(world_size),
+                    "--log-dir",
+                    "/tmp/torchrun-logs",
+                    "--tee",
+                    "3",
+                    "--role",
+                    "torchrun",
+                    "-m",
+                    "pytest",
+                    f"{file_path}::{func_name}",
+                    "-sx",
+                ]
 
-                proc = subprocess.run(cmd.split(" "))
+                proc = subprocess.run(cmd)
                 assert proc.returncode == 0
 
         return wrapper

--- a/tests/test_offload/conftest.py
+++ b/tests/test_offload/conftest.py
@@ -77,32 +77,45 @@ def assert_tensor_equal(
         assert torch.equal(tensor_a, tensor_b)
 
 
-def torchrun(world_size: int = 1) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+def torchrun(
+    world_size: int = 1, init_dist: bool = False
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """
     Pytest decorator to run a test within parallel torchrun subprocesses.
 
     This decorator automatically spawns torchrun when the test is run with regular
     pytest.
-    When running under torchrun (detected via TORCHELASTIC_RUN_ID env var), it simply
-    runs the test. The test is responsible for its own distributed initialization.
+    When running under torchrun (detected via TORCHELASTIC_RUN_ID env var), it
+    optionally initializes the distributed process group before running the test.
 
     Usage:
         @pytest.mark.unit
         @requires_gpu(2)
-        @torchrun(world_size=2)
+        @torchrun(world_size=2, init_dist=True)
         def test_distributed_feature():
-            # Test must handle its own distributed setup
+            # Distributed already initialized
+            ...
+
+        @torchrun(world_size=2)  # init_dist=False by default
+        def test_custom_init():
+            # Handle your own distributed setup
+            from compressed_tensors.distributed import init_dist
             init_dist()
             ...
 
     :param world_size: number of ranks to spawn
+    :param init_dist: whether to automatically call init_dist() (default: False)
     """
 
     def decorator(func: FunctionType):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            # We're running in a torchrun subprocess: just run the test
+            # We're running in a torchrun subprocess: optionally init then run the test
             if "TORCHELASTIC_RUN_ID" in os.environ:
+                if init_dist:
+                    from compressed_tensors.distributed import init_dist as _init_dist
+
+                    _init_dist()
                 return func(*args, **kwargs)
 
             # First time calling in the main process:

--- a/tests/test_offload/conftest.py
+++ b/tests/test_offload/conftest.py
@@ -10,7 +10,6 @@ from typing import Any, Callable, Literal, Optional
 
 import pytest
 import torch
-import torch.distributed as dist
 from compressed_tensors.offload.utils import send_tensors
 
 

--- a/tests/test_offload/convert/test_convert.py
+++ b/tests/test_offload/convert/test_convert.py
@@ -5,7 +5,7 @@ import os
 
 import pytest
 import torch
-from compressed_tensors.distributed import init_dist, is_source_process
+from compressed_tensors.distributed import is_source_process
 from compressed_tensors.offload import disable_onloading, from_accelerate, to_accelerate
 from tests.test_offload.conftest import torchrun
 from tests.testing_utils import requires_gpu
@@ -78,7 +78,6 @@ def test_conversion_lifecycle(accel_device, tmp_path):
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_conversion_lifecycle_dist(accel_device, tmp_path):
-    init_dist()
     test_conversion_lifecycle(accel_device, tmp_path)

--- a/tests/test_offload/convert/test_convert.py
+++ b/tests/test_offload/convert/test_convert.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 from compressed_tensors.distributed import is_source_process
 from compressed_tensors.offload import disable_onloading, from_accelerate, to_accelerate
+from compressed_tensors.distributed import init_dist
 from tests.test_offload.conftest import torchrun
 from tests.testing_utils import requires_gpu
 
@@ -80,4 +81,5 @@ def test_conversion_lifecycle(accel_device, tmp_path):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_conversion_lifecycle_dist(accel_device, tmp_path):
+    init_dist()
     test_conversion_lifecycle(accel_device, tmp_path)

--- a/tests/test_offload/convert/test_convert.py
+++ b/tests/test_offload/convert/test_convert.py
@@ -5,9 +5,8 @@ import os
 
 import pytest
 import torch
-from compressed_tensors.distributed import is_source_process
+from compressed_tensors.distributed import init_dist, is_source_process
 from compressed_tensors.offload import disable_onloading, from_accelerate, to_accelerate
-from compressed_tensors.distributed import init_dist
 from tests.test_offload.conftest import torchrun
 from tests.testing_utils import requires_gpu
 

--- a/tests/test_offload/convert/test_from_accelerate.py
+++ b/tests/test_offload/convert/test_from_accelerate.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 import torch
 import torch.distributed as dist
-from compressed_tensors.distributed import init_dist, is_source_process
+from compressed_tensors.distributed import is_source_process
 from compressed_tensors.offload import (
     disable_onloading,
     from_accelerate,
@@ -130,15 +130,14 @@ def test_from_accelerate(accel_device, tmp_path):
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_from_accelerate_dist(accel_device, tmp_path):
-    init_dist()
     test_from_accelerate(accel_device, tmp_path)
 
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 @torch.no_grad()
 def test_dist_disk_safetensors_update(tmp_path):
     offload_folder = tmp_path / "offload_folder"

--- a/tests/test_offload/convert/test_from_accelerate.py
+++ b/tests/test_offload/convert/test_from_accelerate.py
@@ -18,6 +18,7 @@ from compressed_tensors.offload.cache import CPUCache, DeviceCache, DiskCache
 from compressed_tensors.offload.convert.from_accelerate import (
     remove_accelerate_from_module,
 )
+from compressed_tensors.distributed import init_dist
 from tests.test_offload.conftest import torchrun
 from tests.testing_utils import requires_gpu
 from transformers import AutoModelForCausalLM
@@ -132,6 +133,7 @@ def test_from_accelerate(accel_device, tmp_path):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_from_accelerate_dist(accel_device, tmp_path):
+    init_dist()
     test_from_accelerate(accel_device, tmp_path)
 
 

--- a/tests/test_offload/convert/test_from_accelerate.py
+++ b/tests/test_offload/convert/test_from_accelerate.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 import torch
 import torch.distributed as dist
-from compressed_tensors.distributed import is_source_process
+from compressed_tensors.distributed import init_dist, is_source_process
 from compressed_tensors.offload import (
     disable_onloading,
     from_accelerate,
@@ -18,7 +18,6 @@ from compressed_tensors.offload.cache import CPUCache, DeviceCache, DiskCache
 from compressed_tensors.offload.convert.from_accelerate import (
     remove_accelerate_from_module,
 )
-from compressed_tensors.distributed import init_dist
 from tests.test_offload.conftest import torchrun
 from tests.testing_utils import requires_gpu
 from transformers import AutoModelForCausalLM

--- a/tests/test_offload/convert/test_to_accelerate.py
+++ b/tests/test_offload/convert/test_to_accelerate.py
@@ -8,6 +8,7 @@ import torch
 from compressed_tensors.offload import dispatch_with_map, offload_module, to_accelerate
 from compressed_tensors.offload.convert.helpers import norm_device
 from compressed_tensors.offload.convert.to_accelerate import to_accelerate_module
+from compressed_tensors.distributed import init_dist
 from tests.test_offload.conftest import torchrun
 from tests.testing_utils import requires_gpu
 
@@ -80,4 +81,5 @@ def test_to_accelerate(accel_device, tmp_path):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_to_accelerate_dist(accel_device, tmp_path):
+    init_dist()
     test_to_accelerate(accel_device, tmp_path)

--- a/tests/test_offload/convert/test_to_accelerate.py
+++ b/tests/test_offload/convert/test_to_accelerate.py
@@ -5,10 +5,10 @@ import os
 
 import pytest
 import torch
+from compressed_tensors.distributed import init_dist
 from compressed_tensors.offload import dispatch_with_map, offload_module, to_accelerate
 from compressed_tensors.offload.convert.helpers import norm_device
 from compressed_tensors.offload.convert.to_accelerate import to_accelerate_module
-from compressed_tensors.distributed import init_dist
 from tests.test_offload.conftest import torchrun
 from tests.testing_utils import requires_gpu
 

--- a/tests/test_offload/convert/test_to_accelerate.py
+++ b/tests/test_offload/convert/test_to_accelerate.py
@@ -5,7 +5,6 @@ import os
 
 import pytest
 import torch
-from compressed_tensors.distributed import init_dist
 from compressed_tensors.offload import dispatch_with_map, offload_module, to_accelerate
 from compressed_tensors.offload.convert.helpers import norm_device
 from compressed_tensors.offload.convert.to_accelerate import to_accelerate_module
@@ -79,7 +78,6 @@ def test_to_accelerate(accel_device, tmp_path):
 
 @pytest.mark.unit
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_to_accelerate_dist(accel_device, tmp_path):
-    init_dist()
     test_to_accelerate(accel_device, tmp_path)

--- a/tests/test_offload/test_load.py
+++ b/tests/test_offload/test_load.py
@@ -13,6 +13,7 @@ from compressed_tensors.offload import (
 from compressed_tensors.offload.convert import to_accelerate
 from compressed_tensors.offload.convert.from_accelerate import _infer_module_device
 from compressed_tensors.offload.load import load_offloaded_model, patch_from_pretrained
+from compressed_tensors.distributed import init_dist
 from tests.test_offload.conftest import (
     assert_device_equal,
     skip_if_mps_device,
@@ -103,6 +104,7 @@ def test_load(device_map, max_memory, first, second, tmp_path):
 @requires_gpu(2)
 @torchrun(world_size=2)
 def test_load_dist(tmp_path):
+    init_dist()
     for parameters in TEST_PARAMETERS:
         test_load(*parameters, tmp_path=tmp_path)
 

--- a/tests/test_offload/test_load.py
+++ b/tests/test_offload/test_load.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
-from compressed_tensors.distributed import init_dist
 from compressed_tensors.offload import (
     disable_onloading,
     from_accelerate,
@@ -102,9 +101,8 @@ def test_load(device_map, max_memory, first, second, tmp_path):
 
 @pytest.mark.integration
 @requires_gpu(2)
-@torchrun(world_size=2)
+@torchrun(world_size=2, init_dist=True)
 def test_load_dist(tmp_path):
-    init_dist()
     for parameters in TEST_PARAMETERS:
         test_load(*parameters, tmp_path=tmp_path)
 

--- a/tests/test_offload/test_load.py
+++ b/tests/test_offload/test_load.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+from compressed_tensors.distributed import init_dist
 from compressed_tensors.offload import (
     disable_onloading,
     from_accelerate,
@@ -13,7 +14,6 @@ from compressed_tensors.offload import (
 from compressed_tensors.offload.convert import to_accelerate
 from compressed_tensors.offload.convert.from_accelerate import _infer_module_device
 from compressed_tensors.offload.load import load_offloaded_model, patch_from_pretrained
-from compressed_tensors.distributed import init_dist
 from tests.test_offload.conftest import (
     assert_device_equal,
     skip_if_mps_device,


### PR DESCRIPTION
Summary:

adding a similar decorator to llmC in
https://github.com/vllm-project/llm-compressor/pull/2684 which resulted in us making some improvements that i want to reflect over here.

1) move init_dist to out of @torchrun
2) construction is safer, no string splitting, uses a list 
3) error handling

Testing Plan:

```
python tests/test_compressors/distributed/test_distributed_compression.py
python tests/test_compressors/distributed/test_module_parallel.py
python tests/test_compressors/model_compressors/test_model_compressor_distributed.py
python tests/test_offload/cache/test_dist_cpu.py
python tests/test_compressors/distributed/test_module_parallel.py
python tests/test_compressors/model_compressors/test_model_compressor_distributed.py
python tests/test_offload/cache/test_dist_cpu.py
python tests/test_offload/cache/test_dist_device.py
python tests/test_offload/cache/test_dist_disk.py
python tests/test_offload/convert/test_convert.py
python tests/test_offload/convert/test_from_accelerate.py
python tests/test_offload/convert/test_to_accelerate.py
python tests/test_offload/test_load.py
```