### PR TITLE
[Offload] Explicit model class patching for `load_offloaded_model`

### DIFF
--- a/src/compressed_tensors/offload/README.md
+++ b/src/compressed_tensors/offload/README.md
@@ -347,18 +347,10 @@ A context manager that patches `from_pretrained` on transformers model classes. 
 ```python
 from transformers import AutoModelForCausalLM
 
-# Option 1: Automatic patching (patches all model classes in caller's scope)
 with load_offloaded_model():
     model = AutoModelForCausalLM.from_pretrained(
         "meta-llama/Llama-3-8B",
         device_map="auto_offload",  # CT-specific: only cpu/disk, no GPU
-    )
-
-# Option 2: Explicit class patching (more targeted, recommended)
-with load_offloaded_model(model_class=AutoModelForCausalLM):
-    model = AutoModelForCausalLM.from_pretrained(
-        "meta-llama/Llama-3-8B",
-        device_map="auto_offload",
     )
 ```
 

--- a/src/compressed_tensors/offload/README.md
+++ b/src/compressed_tensors/offload/README.md
@@ -336,9 +336,9 @@ Returns a mapping of all available CUDA devices to their total memory (in bytes)
 
 ### `load.py` — Loading with Offloading
 
-#### `load_offloaded_model(extra_cpu_mem=5e9)` *(context manager)*
+#### `load_offloaded_model(model_class=None, extra_cpu_mem=5e9)` *(context manager)*
 
-A context manager that patches `from_pretrained` on any `transformers` model class or `PreTrainedModel` subclass visible in the caller's global scope. Within the context, calling `from_pretrained` will:
+A context manager that patches `from_pretrained` on transformers model classes. Within the context, calling `from_pretrained` will:
 
 1. On rank 0: load the model using `accelerate`'s device offloading.
 2. On other ranks: load the model on the meta device (no actual weights).
@@ -347,10 +347,18 @@ A context manager that patches `from_pretrained` on any `transformers` model cla
 ```python
 from transformers import AutoModelForCausalLM
 
+# Option 1: Automatic patching (patches all model classes in caller's scope)
 with load_offloaded_model():
     model = AutoModelForCausalLM.from_pretrained(
         "meta-llama/Llama-3-8B",
         device_map="auto_offload",  # CT-specific: only cpu/disk, no GPU
+    )
+
+# Option 2: Explicit class patching (more targeted, recommended)
+with load_offloaded_model(model_class=AutoModelForCausalLM):
+    model = AutoModelForCausalLM.from_pretrained(
+        "meta-llama/Llama-3-8B",
+        device_map="auto_offload",
     )
 ```
 
@@ -359,6 +367,7 @@ with load_offloaded_model():
 In addition to standard `device_map` options (`"auto"`, `"cpu"`, etc.), `load_offloaded_model` supports `device_map="auto_offload"`. This restricts accelerate's auto-mapping to only use CPU and disk (no GPU VRAM), which is useful when you want the GPU to be fully available for activations during inference.
 
 **Parameters:**
+- `model_class`: explicit class to patch (e.g., `AutoModelForCausalLM`). If `None`, patches all `transformers` model classes or `PreTrainedModel` subclasses visible in the caller's global scope. Providing an explicit class is more efficient and recommended when the target class is known.
 - `extra_cpu_mem`: bytes to reserve in CPU RAM for non-weight operations (default 5 GB). Memory estimates are automatically computed for both distributed and non-distributed setups.
 
 **When to use:** the recommended entry point for loading offloaded models from pretrained checkpoints. Handles distributed loading correctly, sharing weights across ranks with minimal memory overhead.
@@ -596,13 +605,22 @@ Copies the subclass, `__dict__`, and `requires_grad` from `src` into `dst`. Used
 from transformers import AutoModelForCausalLM
 from compressed_tensors.offload import load_offloaded_model
 
-with load_offloaded_model():
+# Recommended: explicit class patching
+with load_offloaded_model(model_class=AutoModelForCausalLM):
     model = AutoModelForCausalLM.from_pretrained(
         "meta-llama/Llama-3.1-70B",
         device_map="auto",      # or "auto_offload" to restrict to cpu/disk only
         torch_dtype="bfloat16",
     )
 # model is now using compressed-tensors offloading
+
+# Alternative: automatic patching (patches all model classes in scope)
+with load_offloaded_model():
+    model = AutoModelForCausalLM.from_pretrained(
+        "meta-llama/Llama-3.1-70B",
+        device_map="auto",
+        torch_dtype="bfloat16",
+    )
 ```
 
 ### 2. Multi-GPU Dispatch
@@ -623,7 +641,7 @@ from compressed_tensors.offload import init_dist, load_offloaded_model
 
 init_dist()  # initialize NCCL
 
-with load_offloaded_model():
+with load_offloaded_model(model_class=AutoModelForCausalLM):
     model = AutoModelForCausalLM.from_pretrained(
         "meta-llama/Llama-3.1-70B",
         device_map="auto",

--- a/src/compressed_tensors/offload/load.py
+++ b/src/compressed_tensors/offload/load.py
@@ -24,7 +24,9 @@ cls_to_patch = _BaseAutoModelClass | PreTrainedModel
 
 
 @contextlib.contextmanager
-def load_offloaded_model(extra_cpu_mem: int = 5e9):
+def load_offloaded_model(
+    model_class: type[cls_to_patch] | None = None, extra_cpu_mem: int = 5e9
+):
     """
     Context manager used to load a transformers model with offloading implemented by
     compressed-tensors.
@@ -38,15 +40,21 @@ def load_offloaded_model(extra_cpu_mem: int = 5e9):
     `device_map="auto_offload"`, which means that the model will load as many parameters
     can fit onto the cpu, and any extra parameters will be loaded on disk.
 
+    :param model_class: explicit class to patch. If None, patches all classes in the
+        caller's frame that are subclasses of _BaseAutoModelClass or PreTrainedModel.
     :param extra_cpu_mem: extra cpu memory to reserve for any operations not related to
         model loading (bytes). Defaults to 5Gb.
     """
-    frame = _get_caller_frame()
-
     with contextlib.ExitStack() as stack:
-        for obj in frame.f_globals.values():
-            if isinstance(obj, type) and issubclass(obj, cls_to_patch):
-                stack.enter_context(patch_from_pretrained(obj, extra_cpu_mem))
+        if model_class is not None:
+            # Explicit class provided, patch only that class
+            stack.enter_context(patch_from_pretrained(model_class, extra_cpu_mem))
+        else:
+            # No class provided, use frame-based patching
+            frame = _get_caller_frame()
+            for obj in frame.f_globals.values():
+                if isinstance(obj, type) and issubclass(obj, cls_to_patch):
+                    stack.enter_context(patch_from_pretrained(obj, extra_cpu_mem))
 
         yield
 


### PR DESCRIPTION
## Purpose ##
* Support passing explicit model classes when patching for `load_offloaded_model`
* This enables cases where the model class being used is a local var, not a global var
* It's also better to be explicit where possible
```python3
model_class = getattr(transformers, model_class)  # local var, not global to frame
with load_offloaded_model(model_class):
  model = model_class(...)
```

## Changes ##
* Add `model_class` arg to `load_offloaded_model`

## Testing ##
* Tested that the above code example works locally