### PR TITLE
Treat imatrix weight observer as calibration data dependent

### DIFF
--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -291,6 +291,9 @@ class QuantizationConfig(BaseModel):
             return True
 
         for _, scheme in self.config_groups.items():
+            if scheme.weights is not None:
+                if scheme.weights.observer == "imatrix_mse":
+                    return True
             if scheme.input_activations is not None:
                 if scheme.input_activations.dynamic in (False, DynamicType.LOCAL):
                     return True

--- a/tests/test_quantization/test_quant_config.py
+++ b/tests/test_quantization/test_quant_config.py
@@ -173,3 +173,33 @@ def test_get_vllm_module_type():
     assert get_vllm_module_type("JetMoeTopKGating") == "Linear"
     assert get_vllm_module_type("Qwen3NextGatedDeltaNet") == "Linear"
     assert get_vllm_module_type("JetMoeTopKGating") == "Linear"
+
+
+def test_imatrix_mse_weight_observer_requires_calibration_data():
+    from compressed_tensors.quantization import QuantizationArgs
+
+    config = QuantizationConfig(
+        config_groups={
+            "group_1": QuantizationScheme(
+                targets=["Linear"],
+                weights=QuantizationArgs(observer="imatrix_mse"),
+            )
+        }
+    )
+
+    assert config.requires_calibration_data()
+
+
+def test_default_weight_observer_does_not_require_calibration_data():
+    from compressed_tensors.quantization import QuantizationArgs
+
+    config = QuantizationConfig(
+        config_groups={
+            "group_1": QuantizationScheme(
+                targets=["Linear"],
+                weights=QuantizationArgs(),
+            )
+        }
+    )
+
+    assert not config.requires_calibration_data()


### PR DESCRIPTION
## Summary
- make `QuantizationConfig.requires_calibration_data()` return `True` when a weight scheme uses the `imatrix_mse` observer
- add focused tests covering the new iMatrix case and the existing default weight-only behavior

This supports vllm-project/llm-compressor#2716, where `imatrix_mse` no longer uses a separate gatherer modifier and should request calibration through the quantization config.

## Test Plan
- `PYTHONPATH=src /Users/shaneduncan/vLLM/llm-compressor/.venv/bin/python -m pytest tests/test_quantization/test_quant_config.py`
- `PYTHONPATH=src /Users/shaneduncan/vLLM/llm-compressor/.venv/bin/ruff check src/compressed_tensors/quantization/quant_config.py tests/test_quantization/test_quant_config.py`

Note: this local checkout did not have generated `src/compressed_tensors/version.py`; I used a temporary local version stub for the pytest run and removed it before committing.