### PR TITLE
Support arbitrary 1-8 bit INT weight packing in pack-quantized

### DIFF
--- a/src/compressed_tensors/compressors/pack_quantized/base.py
+++ b/src/compressed_tensors/compressors/pack_quantized/base.py
@@ -30,7 +30,9 @@ PACK_ZP_STRATS = [
 @BaseCompressor.register(name=CompressionFormat.pack_quantized.value)
 class PackedQuantizationCompressor(BaseCompressor):
     """
-    Compresses a quantized model by packing every eight 4-bit weights into an int32.
+    Compresses a quantized weight by packing multiple sub-8-bit INT values into an
+    int32. Supports num_bits in [1, 8]; each int32 holds ``pack_factor = 32 // num_bits``
+    values, with any unused high bits left as zero.
     """
 
     @classmethod
@@ -138,11 +140,11 @@ class PackedQuantizationCompressor(BaseCompressor):
 
     @classmethod
     def can_compress(cls, module_type: type, scheme: QuantizationScheme) -> bool:
-        """Pack quantized matches weight-only INT quantization with 4 or 8 bits."""
+        """Pack quantized matches weight-only INT quantization with 1..8 bits."""
         return (
             module_type == torch.nn.Linear
             and scheme.weights is not None
             and scheme.input_activations is None
-            and scheme.weights.num_bits in (4, 8)
+            and 1 <= scheme.weights.num_bits <= 8
             and scheme.weights.type == QuantizationType.INT.value
         )

--- a/src/compressed_tensors/compressors/pack_quantized/base.py
+++ b/src/compressed_tensors/compressors/pack_quantized/base.py
@@ -31,8 +31,8 @@ PACK_ZP_STRATS = [
 class PackedQuantizationCompressor(BaseCompressor):
     """
     Compresses a quantized weight by packing multiple sub-8-bit INT values into an
-    int32. Supports num_bits in [1, 8]; each int32 holds ``pack_factor = 32 // num_bits``
-    values, with any unused high bits left as zero.
+    int32. Supports num_bits in [1, 8]; each int32 holds
+    ``pack_factor = 32 // num_bits`` values, with any unused high bits left as zero.
     """
 
     @classmethod

--- a/src/compressed_tensors/compressors/pack_quantized/helpers.py
+++ b/src/compressed_tensors/compressors/pack_quantized/helpers.py
@@ -44,11 +44,8 @@ def pack_to_int32(
     if value.dtype is not torch.int8:
         raise ValueError("Tensor must be quantized to torch.int8 before packing")
 
-    if num_bits > 8:
-        raise ValueError("Packing is only supported for less than 8 bits")
-
-    if num_bits < 1:
-        raise ValueError(f"num_bits must be at least 1, got {num_bits}")
+    if not 1 <= num_bits <= 8:
+        raise ValueError(f"Packing is only supported for num_bits in [1, 8], got {num_bits}")
 
     # Handle N-dimensional tensors (e.g. MoE 3D weights) by packing each 2D slice
     if value.ndim > 2:
@@ -111,8 +108,8 @@ def unpack_from_int32(
             f"Expected {torch.int32} but got {value.dtype}, Aborting unpack."
         )
 
-    if num_bits > 8:
-        raise ValueError("Unpacking is only supported for less than 8 bits")
+    if not 1 <= num_bits <= 8:
+        raise ValueError(f"Unpacking is only supported for num_bits in [1, 8], got {num_bits}")
 
     # Handle N-dimensional tensors (e.g. MoE 3D weights) by unpacking each 2D slice
     if value.ndim > 2:

--- a/src/compressed_tensors/compressors/pack_quantized/helpers.py
+++ b/src/compressed_tensors/compressors/pack_quantized/helpers.py
@@ -45,7 +45,9 @@ def pack_to_int32(
         raise ValueError("Tensor must be quantized to torch.int8 before packing")
 
     if not 1 <= num_bits <= 8:
-        raise ValueError(f"Packing is only supported for num_bits in [1, 8], got {num_bits}")
+        raise ValueError(
+            f"Packing is only supported for num_bits in [1, 8], got {num_bits}"
+        )
 
     # Handle N-dimensional tensors (e.g. MoE 3D weights) by packing each 2D slice
     if value.ndim > 2:
@@ -109,7 +111,9 @@ def unpack_from_int32(
         )
 
     if not 1 <= num_bits <= 8:
-        raise ValueError(f"Unpacking is only supported for num_bits in [1, 8], got {num_bits}")
+        raise ValueError(
+            f"Unpacking is only supported for num_bits in [1, 8], got {num_bits}"
+        )
 
     # Handle N-dimensional tensors (e.g. MoE 3D weights) by unpacking each 2D slice
     if value.ndim > 2:

--- a/tests/test_compressors/test_pack_quant.py
+++ b/tests/test_compressors/test_pack_quant.py
@@ -405,8 +405,8 @@ def test_pack_to_int32(num_bits, values, expected_values):
 )
 def test_unpack_from_int32(num_bits, values, expected_tensor):
     unpacked_tensor = unpack_from_int32(values, num_bits, expected_tensor.shape)
-    assert torch.equal(unpacked_tensor, unpacked_tensor)
-    assert unpacked_tensor.dtype == unpacked_tensor.dtype
+    assert torch.equal(unpacked_tensor, expected_tensor)
+    assert unpacked_tensor.dtype == expected_tensor.dtype
 
 
 @pytest.mark.parametrize(

--- a/tests/test_compressors/test_pack_quant.py
+++ b/tests/test_compressors/test_pack_quant.py
@@ -125,7 +125,24 @@ def test_repack_8bit(value):
     assert torch.equal(value, unpacked)
 
 
-@pytest.mark.parametrize("num_bits", [4, 8])
+@pytest.mark.parametrize("num_bits", [1, 2, 3, 4, 5, 6, 7, 8])
+@pytest.mark.parametrize("shape", [(256, 1024), (512, 100), (128, 33)])
+def test_pack_unpack_roundtrip(num_bits, shape):
+    """Pack/unpack roundtrip preserves values for all supported bit widths."""
+    lo, hi = -(1 << (num_bits - 1)), (1 << (num_bits - 1)) - 1
+    value = torch.randint(lo, hi + 1, shape, dtype=torch.int8)
+
+    packed = pack_to_int32(value, num_bits)
+    assert packed.dtype == torch.int32
+
+    pack_factor = 32 // num_bits
+    assert packed.shape == (shape[0], math.ceil(shape[1] / pack_factor))
+
+    unpacked = unpack_from_int32(packed, num_bits, torch.Size(shape))
+    assert torch.equal(unpacked, value)
+
+
+@pytest.mark.parametrize("num_bits", [1, 2, 3, 4, 5, 6, 7, 8])
 def test_compress_decompress_match(num_bits):
     """Round-trip compress → decompress in memory."""
     module_sd = {


### PR DESCRIPTION
Relaxes `PackedQuantizationCompressor.can_compress` from num_bits in (4, 8) to 1 <= num_bits <= 8 for INT, weight-only schemes. The pack_to_int32 / unpack_from_int32 helpers already use pack_factor = 32 // num_bits, so no
deeper changes were needed. Packing odd bit widths (3, 5, 6, 7) just leaves the high bits of each int32 zero, matching the layout:

```
┌──────────┬──────────────────┬─────────────┐
│ num_bits │ values per int32 │ wasted bits │
├──────────┼──────────────────┼─────────────┤
│ 1        │ 32               │ 0           │
├──────────┼──────────────────┼─────────────┤
│ 2        │ 16               │ 0           │
├──────────┼──────────────────┼─────────────┤
│ 3        │ 10               │ 2           │
├──────────┼──────────────────┼─────────────┤
│ 4        │ 8                │ 0           │
├──────────┼──────────────────┼─────────────┤
│ 5        │ 6                │ 2           │
├──────────┼──────────────────┼─────────────┤
│ 6        │ 5                │ 2           │
├──────────┼──────────────────┼─────────────┤
│ 7        │ 4                │ 4           │
├──────────┼──────────────────┼─────────────┤
│ 8        │ 4                │ 0           │
└──────────┴──────────────────┴─────────────┘
```