### PR TITLE
Support compress/decompress for Embedding layers

### DIFF
--- a/src/compressed_tensors/compressors/base.py
+++ b/src/compressed_tensors/compressors/base.py
@@ -16,7 +16,19 @@ from compressed_tensors.utils import (
 )
 
 
-__all__ = ["BaseCompressor", "compress_module", "decompress_module"]
+__all__ = [
+    "BaseCompressor",
+    "compress_module",
+    "decompress_module",
+    "COMPRESSIBLE_MODULE_TYPES",
+]
+
+
+# Module types whose weights can be compressed/decompressed. Compression operates
+# on a per-module weight state dict and is agnostic to the module's forward, so any
+# module that stores a quantizable 2D `weight` works. Quantization of these types is
+# initialized in `initialize_module_for_quantization`.
+COMPRESSIBLE_MODULE_TYPES = (torch.nn.Linear, torch.nn.Embedding)
 
 
 class BaseCompressor(RegistryMixin, ABC):

--- a/src/compressed_tensors/compressors/mxfp4/base.py
+++ b/src/compressed_tensors/compressors/mxfp4/base.py
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import torch
-from compressed_tensors.compressors.base import BaseCompressor
+from compressed_tensors.compressors.base import (
+    COMPRESSIBLE_MODULE_TYPES,
+    BaseCompressor,
+)
 from compressed_tensors.compressors.mx_utils import (
     compress_mx_scale,
     decompress_mx_scale,
@@ -42,7 +45,7 @@ class MXFP4PackedCompressor(NVFP4PackedCompressor):
     def can_compress(cls, module_type: type, scheme: QuantizationScheme) -> bool:
         """MXFP4 matches FP4 with group_size=32."""
         return (
-            module_type == torch.nn.Linear
+            module_type in COMPRESSIBLE_MODULE_TYPES
             and scheme.weights is not None
             and scheme.weights.num_bits == 4
             and scheme.weights.type == QuantizationType.FLOAT.value

--- a/src/compressed_tensors/compressors/mxfp8/base.py
+++ b/src/compressed_tensors/compressors/mxfp8/base.py
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import torch
-from compressed_tensors.compressors.base import BaseCompressor
+from compressed_tensors.compressors.base import (
+    COMPRESSIBLE_MODULE_TYPES,
+    BaseCompressor,
+)
 from compressed_tensors.compressors.mx_utils import (
     compress_mx_scale,
     decompress_mx_scale,
@@ -92,7 +95,7 @@ class MXFP8QuantizationCompressor(NaiveQuantizationCompressor):
     def can_compress(cls, module_type: type, scheme: QuantizationScheme) -> bool:
         """MXFP8 matches FP8 with group_size=32 and uint8 scale_dtype."""
         return (
-            module_type == torch.nn.Linear
+            module_type in COMPRESSIBLE_MODULE_TYPES
             and scheme.weights is not None
             and scheme.weights.num_bits == 8
             and scheme.weights.type == QuantizationType.FLOAT.value

--- a/src/compressed_tensors/compressors/naive_quantized/base.py
+++ b/src/compressed_tensors/compressors/naive_quantized/base.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import torch
-from compressed_tensors.compressors.base import BaseCompressor
+from compressed_tensors.compressors.base import (
+    COMPRESSIBLE_MODULE_TYPES,
+    BaseCompressor,
+)
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization import (
     ActivationOrdering,
@@ -129,7 +131,7 @@ class NaiveQuantizationCompressor(BaseCompressor):
         Naive quantization is the fallback compressor - it matches any quantized
         scheme that doesn't match a more specific compressor.
         """
-        return module_type == torch.nn.Linear and scheme.weights is not None
+        return module_type in COMPRESSIBLE_MODULE_TYPES and scheme.weights is not None
 
 
 @BaseCompressor.register(name=CompressionFormat.int_quantized.value)
@@ -140,7 +142,7 @@ class IntQuantizationCompressor(NaiveQuantizationCompressor):
     def can_compress(cls, module_type: type, scheme: QuantizationScheme) -> bool:
         """Int quantized matches w8a8 int quantization."""
         return (
-            module_type == torch.nn.Linear
+            module_type in COMPRESSIBLE_MODULE_TYPES
             and scheme.input_activations is not None
             and scheme.weights is not None
             and scheme.weights.type == QuantizationType.INT.value
@@ -155,7 +157,7 @@ class FloatQuantizationCompressor(NaiveQuantizationCompressor):
     def can_compress(cls, module_type: type, scheme: QuantizationScheme) -> bool:
         """Float quantized matches w8a8 float quantization."""
         return (
-            module_type == torch.nn.Linear
+            module_type in COMPRESSIBLE_MODULE_TYPES
             and scheme.input_activations is not None
             and scheme.weights is not None
             and scheme.weights.type == QuantizationType.FLOAT.value

--- a/src/compressed_tensors/compressors/nvfp4/base.py
+++ b/src/compressed_tensors/compressors/nvfp4/base.py
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import torch
-from compressed_tensors.compressors.base import BaseCompressor
+from compressed_tensors.compressors.base import (
+    COMPRESSIBLE_MODULE_TYPES,
+    BaseCompressor,
+)
 from compressed_tensors.compressors.nvfp4.helpers import (
     pack_fp4_to_uint8,
     unpack_fp4_from_uint8,
@@ -132,7 +135,7 @@ class NVFP4PackedCompressor(BaseCompressor):
     def can_compress(cls, module_type: type, scheme: QuantizationScheme) -> bool:
         """NVFP4 matches FP4 with group_size != 32 (or None)."""
         return (
-            module_type == torch.nn.Linear
+            module_type in COMPRESSIBLE_MODULE_TYPES
             and scheme.weights is not None
             and scheme.weights.num_bits == 4
             and scheme.weights.type == QuantizationType.FLOAT.value

--- a/src/compressed_tensors/compressors/pack_quantized/base.py
+++ b/src/compressed_tensors/compressors/pack_quantized/base.py
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import torch
-from compressed_tensors.compressors.base import BaseCompressor
+from compressed_tensors.compressors.base import (
+    COMPRESSIBLE_MODULE_TYPES,
+    BaseCompressor,
+)
 from compressed_tensors.compressors.pack_quantized.helpers import (
     pack_to_int32,
     unpack_from_int32,
@@ -142,7 +145,7 @@ class PackedQuantizationCompressor(BaseCompressor):
     def can_compress(cls, module_type: type, scheme: QuantizationScheme) -> bool:
         """Pack quantized matches weight-only INT quantization with 1..8 bits."""
         return (
-            module_type == torch.nn.Linear
+            module_type in COMPRESSIBLE_MODULE_TYPES
             and scheme.weights is not None
             and scheme.input_activations is None
             and 1 <= scheme.weights.num_bits <= 8

--- a/tests/test_compressors/test_compress_decompress_module.py
+++ b/tests/test_compressors/test_compress_decompress_module.py
@@ -4,17 +4,25 @@
 import pytest
 import torch
 import torch.nn as nn
+from compressed_tensors.compressors import ModelCompressor
 from compressed_tensors.compressors.base import compress_module, decompress_module
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization import (
     ActivationOrdering,
+    QuantizationArgs,
+    QuantizationConfig,
+    QuantizationScheme,
+    apply_quantization_config,
     initialize_module_for_quantization,
     preset_name_to_scheme,
 )
+from compressed_tensors.quantization.utils import is_module_quantized
 from compressed_tensors.utils import get_direct_state_dict
 
 
-def _run_compress_decompress(scheme_name, expected_format, actorder, device):
+def _run_compress_decompress(
+    scheme_name, expected_format, actorder, device, module=None, targets=("Linear",)
+):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
 
@@ -22,8 +30,10 @@ def _run_compress_decompress(scheme_name, expected_format, actorder, device):
     # Use 256x256 to avoid degenerate scale shapes (e.g. (N,1) for FP8_BLOCK)
     # that trip up block-vs-channel strategy inference in dequantize.
     # Start in bfloat16 so NVFP4 decompression (which returns bfloat16) preserves dtype.
-    module = nn.Linear(256, 256, bias=False).to(dtype=torch.bfloat16, device=device)
-    scheme = preset_name_to_scheme(scheme_name, ["Linear"])
+    if module is None:
+        module = nn.Linear(256, 256, bias=False)
+    module = module.to(dtype=torch.bfloat16, device=device)
+    scheme = preset_name_to_scheme(scheme_name, list(targets))
     if actorder is not None:
         scheme.weights.actorder = actorder
     initialize_module_for_quantization(module, scheme)
@@ -89,3 +99,73 @@ def test_compress_decompress_module(scheme_name, expected_format, actorder, devi
 @pytest.mark.parametrize("device", ["cpu", "meta", "cuda"])
 def test_compress_decompress_module_mxfp4(scheme_name, expected_format, device):
     _run_compress_decompress(scheme_name, expected_format, None, device)
+
+
+@pytest.mark.parametrize(
+    "scheme_name,expected_format,actorder",
+    [
+        ("UNQUANTIZED", CompressionFormat.dense, None),
+        ("W8A16", CompressionFormat.pack_quantized, None),
+        ("W4A16", CompressionFormat.pack_quantized, None),
+        ("W4A16", CompressionFormat.pack_quantized, ActivationOrdering.GROUP),
+        ("W4A16_ASYM", CompressionFormat.pack_quantized, None),
+        ("NVFP4A16", CompressionFormat.nvfp4_pack_quantized, None),
+        ("MXFP4A16", CompressionFormat.mxfp4_pack_quantized, None),
+    ],
+)
+@pytest.mark.parametrize("device", ["cpu", "meta", "cuda"])
+def test_compress_decompress_embedding(scheme_name, expected_format, actorder, device):
+    # Embeddings are compressed the same way as Linear weights: weight-only
+    # (weight-and-activation schemes don't apply since embeddings consume indices).
+    module = nn.Embedding(256, 256)
+    _run_compress_decompress(
+        scheme_name,
+        expected_format,
+        actorder,
+        device,
+        module=module,
+        targets=("Embedding",),
+    )
+
+
+def test_linear_only_config_leaves_embedding_untouched():
+    # Embedding compression is opt-in: a module is only compressed if it has a
+    # quantization_scheme attached, which apply_quantization_config does only for
+    # matched targets. A Linear-only config must leave embeddings fully untouched.
+    class TinyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed = nn.Embedding(64, 128)
+            self.proj = nn.Linear(128, 64, bias=False)
+
+    model = TinyModel()
+    embed_weight_before = model.embed.weight.detach().clone()
+
+    config = QuantizationConfig(
+        config_groups={
+            "group_0": QuantizationScheme(
+                targets=["Linear"],
+                weights=QuantizationArgs(num_bits=4, symmetric=True),
+            )
+        }
+    )
+    apply_quantization_config(model, config)
+
+    # Only the Linear is targeted; the Embedding gets no scheme.
+    assert is_module_quantized(model.proj)
+    assert not is_module_quantized(model.embed)
+    assert not hasattr(model.embed, "quantization_scheme")
+
+    ModelCompressor.from_pretrained_model(model).compress_model(model)
+
+    # Linear is compressed (weight replaced by packed params)...
+    proj_keys = set(get_direct_state_dict(model.proj).keys())
+    assert "weight_packed" in proj_keys
+    assert "weight" not in proj_keys
+
+    # ...but the Embedding is byte-for-byte unchanged: no packed params, no
+    # status attribute, original weight preserved.
+    embed_keys = set(get_direct_state_dict(model.embed).keys())
+    assert embed_keys == {"weight"}
+    assert not hasattr(model.embed, "quantization_status")
+    assert torch.equal(model.embed.weight, embed_weight_before)


### PR DESCRIPTION
Compression operates on a per-module weight state dict and is agnostic to the module forward, so the only thing gating Embedding support was the `module_type == torch.nn.Linear` check in each compressor `can_compress`. This adds a shared `COMPRESSIBLE_MODULE_TYPES = (Linear, Embedding)` and switches the checks to it. QDQ and quantization initialization already supported Embedding.

This stays opt-in. A module is only compressed if it has a `quantization_scheme`, which `apply_quantization_config` attaches only to matched targets. A Linear-only config produces identical output to before. The only behavioral delta is that embeddings explicitly targeted for quantization now actually compress instead of silently falling back to dense.

Tests added: Embedding compress/decompress round-trips across pack/naive/nvfp4/mxfp4 weight-only formats, and a guard test confirming a Linear-only config leaves embeddings byte-for-byte untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)