### PR TITLE
Add Buildkite pipeline for test-check on H100 duo and L4 solo

### DIFF
--- a/.buildkite/test-check/pipeline.yml
+++ b/.buildkite/test-check/pipeline.yml
@@ -1,0 +1,5 @@
+steps:
+  - label: "Upload test pipeline"
+    command: |
+      PIPELINE_FILE="${TEST_RUNNER:-H100duo}"
+      buildkite-agent pipeline upload .buildkite/test-check/test-check-${PIPELINE_FILE}.yml

--- a/.buildkite/test-check/scripts/test-check.sh
+++ b/.buildkite/test-check/scripts/test-check.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# print OS info for debugging
+cat /etc/issue
+
+# fetch full history and tags (setuptools_scm derives version from git tags)
+git fetch --tags --unshallow 2>/dev/null || git fetch --tags
+
+# install system dependencies and uv
+apt-get update && apt-get install -y curl g++ gcc make
+curl -LsSf https://astral.sh/uv/install.sh | env UV_VERSION=0.8.15 sh
+
+# set up GPU and path
+export LD_LIBRARY_PATH=/usr/local/nvidia/lib64
+export PATH="$HOME/.local/bin:/usr/local/nvidia/bin:$PATH"
+nvidia-smi
+
+# create venv and install dependencies
+uv venv testvenv --python 3.12
+source testvenv/bin/activate
+
+export UV_TORCH_BACKEND=cu130
+export HF_HOME=/model-cache
+uv pip install .[dev] --index-strategy unsafe-best-match --extra-index-url https://download.pytorch.org/whl/cu130
+
+# run tests
+make test

--- a/.buildkite/test-check/test-check-H100duo.yml
+++ b/.buildkite/test-check/test-check-H100duo.yml
@@ -1,0 +1,49 @@
+steps:
+  - label: "Compressed-tensors tests on H100 duo"
+    agents:
+      queue: RedHat-H100-WDC
+
+    plugins:
+      - kubernetes:
+          podSpec:
+            serviceAccountName: buildkite-anyuid
+            securityContext:
+              fsGroup: 0
+              runAsUser: 0
+              runAsGroup: 0
+            nodeSelector:
+              vllm.ci/gpu-pool: upstream-ci-h100
+
+            containers:
+              - name: tests
+                image: buildkite/agent:3-ubuntu
+                command:
+                  - chmod +x .buildkite/test-check/scripts/test-check.sh
+                  - .buildkite/test-check/scripts/test-check.sh
+
+                resources:
+                  limits:
+                    nvidia.com/gpu: 2
+
+                volumeMounts:
+                  - name: ci-cache
+                    mountPath: /model-cache
+                    readOnly: false
+                  - name: devshm
+                    mountPath: /dev/shm
+
+                env:
+                  - name: HF_TOKEN
+                    valueFrom:
+                      secretKeyRef:
+                        name: hf-token-secret
+                        key: token
+
+            volumes:
+              - name: ci-cache
+                hostPath:
+                  path: /var/mnt/ci-cache
+                  type: DirectoryOrCreate
+              - name: devshm
+                emptyDir:
+                  medium: Memory

--- a/.buildkite/test-check/test-check-L4solo.yml
+++ b/.buildkite/test-check/test-check-L4solo.yml
@@ -1,0 +1,36 @@
+steps:
+  - label: "Compressed-tensors tests on L4 solo"
+    agents:
+      queue: RedHat-L4-GCP
+
+    plugins:
+      - kubernetes:
+          podSpec:
+            nodeSelector:
+              pool: L4solo
+
+            containers:
+              - name: tests
+                image: buildkite/agent:3-ubuntu
+                command:
+                  - chmod +x .buildkite/test-check/scripts/test-check.sh
+                  - .buildkite/test-check/scripts/test-check.sh
+
+                resources:
+                  limits:
+                    nvidia.com/gpu: 1
+
+                volumeMounts:
+                  - name: model-cache
+                    mountPath: /model-cache
+                    readOnly: false
+                  - name: dshm
+                    mountPath: /dev/shm
+
+            volumes:
+              - name: model-cache
+                persistentVolumeClaim:
+                  claimName: buildkite-podpvc-ssd-blue
+              - name: dshm
+                emptyDir:
+                  medium: Memory


### PR DESCRIPTION
## Summary
- Add Buildkite CI pipeline files to run `test-check` workflow on GPU infrastructure
- H100 duo (WDC) is the default runner, with L4 solo (GCP) available via `TEST_RUNNER` env var override

## Files added
.buildkite/test-check/
├── pipeline.yml                  # entry point, parameterized (default: H100duo)
├── test-check-H100duo.yml        # K8s pod spec: 2x H100 GPU, WDC cluster
├── test-check-L4solo.yml         # K8s pod spec: 1x L4 GPU, GCP cluster
└── scripts/
└── test-check.sh             # shared test runner (uv, Python 3.12, CUDA 13.0)



## Usage
- **Default (H100 duo):** trigger a Buildkite build — no config needed
- **L4 solo:** set `TEST_RUNNER=L4solo` env var when triggering the build

## Reference
- Based on https://github.com/vllm-project/compressed-tensors/pull/717

## Test plan
- [ ] Verify YAML syntax validation passes
- [ ] Verify shell script syntax validation passes
- [ ] Trigger Buildkite build — confirm pipeline uploads successfully
- [ ] Confirm pod schedules on H100 node pool and `nvidia-smi` shows 2x H100
- [ ] Confirm `make test` passes on H100 duo
