### PR TITLE
[Offload] Use explicit class patching for `load_offloaded_model`

### DIFF
--- a/src/compressed_tensors/offload/load.py
+++ b/src/compressed_tensors/offload/load.py
@@ -2,16 +2,15 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import contextlib
-import inspect
 import os
 import shutil
 from functools import wraps
-from types import FrameType
 
 import psutil
 import torch
 from compressed_tensors.distributed import is_distributed, is_source_process
 from compressed_tensors.offload.convert import from_accelerate
+from compressed_tensors.utils import patch_attr
 from loguru import logger
 from transformers import PreTrainedModel
 from transformers.models.auto.modeling_auto import _BaseAutoModelClass
@@ -24,9 +23,7 @@ cls_to_patch = _BaseAutoModelClass | PreTrainedModel
 
 
 @contextlib.contextmanager
-def load_offloaded_model(
-    model_class: type[cls_to_patch] | None = None, extra_cpu_mem: int = 5e9
-):
+def load_offloaded_model(model_class: type[cls_to_patch], extra_cpu_mem: int = 5e9):
     """
     Context manager used to load a transformers model with offloading implemented by
     compressed-tensors.
@@ -40,31 +37,19 @@ def load_offloaded_model(
     `device_map="auto_offload"`, which means that the model will load as many parameters
     can fit onto the cpu, and any extra parameters will be loaded on disk.
 
-    :param model_class: explicit class to patch. If None, patches all classes in the
-        caller's frame that are subclasses of _BaseAutoModelClass or PreTrainedModel.
+    :param model_class: model class to patch
     :param extra_cpu_mem: extra cpu memory to reserve for any operations not related to
         model loading (bytes). Defaults to 5Gb.
     """
-    with contextlib.ExitStack() as stack:
-        if model_class is not None:
-            # Explicit class provided, patch only that class
-            stack.enter_context(patch_from_pretrained(model_class, extra_cpu_mem))
-        else:
-            # No class provided, use frame-based patching
-            frame = _get_caller_frame()
-            for obj in frame.f_globals.values():
-                if isinstance(obj, type) and issubclass(obj, cls_to_patch):
-                    stack.enter_context(patch_from_pretrained(obj, extra_cpu_mem))
+    original_from_pretrained = model_class.from_pretrained
+    patched_fn_called = False
 
-        yield
+    @classmethod
+    @wraps(original_from_pretrained)
+    def patched(cls, *args, **kwargs):
+        nonlocal patched_fn_called
+        patched_fn_called = True
 
-
-@contextlib.contextmanager
-def patch_from_pretrained(obj: cls_to_patch, extra_cpu_mem: int):
-    original_func = obj.from_pretrained.__func__
-
-    @wraps(original_func)
-    def from_pretrained(cls, *args, **kwargs):
         kwargs.setdefault("device_map", None)
 
         # Rank 0 does loading, other ranks init on meta device
@@ -86,16 +71,22 @@ def patch_from_pretrained(obj: cls_to_patch, extra_cpu_mem: int):
         elif "max_memory" not in kwargs:
             kwargs["max_memory"] = _get_device_memory() | _get_cpu_memory(extra_cpu_mem)
 
-        model = original_func(cls, *args, **kwargs)
+        model = original_from_pretrained(*args, **kwargs)
         from_accelerate(model)  # rank 0 shares weights with ranks via offload/broadcast
 
         return model
 
-    try:
-        obj.from_pretrained = from_pretrained.__get__(obj)
-        yield
-    finally:
-        obj.from_pretrained = original_func.__get__(obj)
+    with patch_attr(model_class, "from_pretrained", patched):
+        try:
+            yield
+        finally:
+            if not patched_fn_called:
+                logger.warning(
+                    f"`{model_class.__name__}.from_pretrained` was never called. If "
+                    "you are loading with a model class other than "
+                    f"{model_class.__name__}, please pass as argument to "
+                    "`load_offloaded_model`"
+                )
 
 
 def _get_device_memory() -> dict[int, int]:
@@ -127,15 +118,3 @@ def _get_shared_memory() -> int:
             "Could not find shared memory at `/dev/shm`. Please add platform suppport"
         )
         return psutil.virtual_memory().available
-
-
-def _get_caller_frame() -> FrameType:
-    frame = inspect.currentframe()
-    frame = frame.f_back.f_back  # skip this function's caller's frame
-    while frame is not None and "contextlib" in frame.f_code.co_filename:
-        frame = frame.f_back  # skip contextlib frames
-
-    if frame is None:
-        raise RuntimeError("Could not find caller frame")
-
-    return frame

--- a/src/compressed_tensors/offload/load.py
+++ b/src/compressed_tensors/offload/load.py
@@ -12,18 +12,16 @@ from compressed_tensors.distributed import is_distributed, is_source_process
 from compressed_tensors.offload.convert import from_accelerate
 from compressed_tensors.utils import patch_attr
 from loguru import logger
-from transformers import PreTrainedModel
-from transformers.models.auto.modeling_auto import _BaseAutoModelClass
+from transformers import AutoModelForCausalLM, PreTrainedModel
 
 
 __all__ = ["load_offloaded_model"]
 
 
-cls_to_patch = _BaseAutoModelClass | PreTrainedModel
-
-
 @contextlib.contextmanager
-def load_offloaded_model(model_class: type[cls_to_patch], extra_cpu_mem: int = 5e9):
+def load_offloaded_model(
+    model_class: type[PreTrainedModel] = AutoModelForCausalLM, extra_cpu_mem: int = 5e9
+):
     """
     Context manager used to load a transformers model with offloading implemented by
     compressed-tensors.

--- a/tests/test_offload/convert/test_from_accelerate.py
+++ b/tests/test_offload/convert/test_from_accelerate.py
@@ -143,7 +143,7 @@ def test_dist_disk_safetensors_update(tmp_path):
     offload_folder = tmp_path / "offload_folder"
     os.makedirs(offload_folder, exist_ok=True)
 
-    with load_offloaded_model(AutoModelForCausalLM):
+    with load_offloaded_model():
         model = AutoModelForCausalLM.from_pretrained(
             "Qwen/Qwen3-0.6B",
             dtype="auto",

--- a/tests/test_offload/convert/test_from_accelerate.py
+++ b/tests/test_offload/convert/test_from_accelerate.py
@@ -143,7 +143,7 @@ def test_dist_disk_safetensors_update(tmp_path):
     offload_folder = tmp_path / "offload_folder"
     os.makedirs(offload_folder, exist_ok=True)
 
-    with load_offloaded_model():
+    with load_offloaded_model(AutoModelForCausalLM):
         model = AutoModelForCausalLM.from_pretrained(
             "Qwen/Qwen3-0.6B",
             dtype="auto",

--- a/tests/test_offload/test_load.py
+++ b/tests/test_offload/test_load.py
@@ -12,7 +12,7 @@ from compressed_tensors.offload import (
 )
 from compressed_tensors.offload.convert import to_accelerate
 from compressed_tensors.offload.convert.from_accelerate import _infer_module_device
-from compressed_tensors.offload.load import load_offloaded_model, patch_from_pretrained
+from compressed_tensors.offload.load import load_offloaded_model
 from tests.test_offload.conftest import (
     assert_device_equal,
     skip_if_mps_device,
@@ -58,7 +58,7 @@ TEST_PARAMETERS = [
 @requires_gpu
 @pytest.mark.parametrize("device_map,max_memory,first,second", TEST_PARAMETERS)
 def test_load(device_map, max_memory, first, second, tmp_path):
-    with load_offloaded_model():
+    with load_offloaded_model(AutoModelForCausalLM):
         model = AutoModelForCausalLM.from_pretrained(
             "Qwen/Qwen3-0.6B",
             device_map=device_map,
@@ -131,7 +131,7 @@ def test_patch_forwards_positional_args(mock_from_accelerate):
             received["kwargs"] = kwargs
             return MagicMock()
 
-    with patch_from_pretrained(FakeModel, extra_cpu_mem=0):
+    with load_offloaded_model(FakeModel, extra_cpu_mem=0):
         FakeModel.from_pretrained("org/model", device_map="cpu", torch_dtype="auto")
 
     assert received["cls"] is FakeModel


### PR DESCRIPTION
## Purpose ##
* Resolve issues where users import and patch model classes in the same script as they use `load_offloaded_model`

For example, a script like this raises an error which is very difficult to debug.

```python3
from transformers import AutoModelForCausalLM, AutoTokenizer
from transformers.models.deepseek_v4.modeling_deepseek_v4 import (
    DeepseekV4PreTrainedModel,
)
from compressed_tensors.offload import load_offloaded_model

# Upstream BUG: norms should be loaded in float32, but usually aren't due to the base
# model having a quant_config which overrides this. Loading in float32 actually
# breaks the model definition (it expects bfloat16). Let's force load in bfloat16.
DeepseekV4PreTrainedModel._keep_in_fp32_modules_strict = set()

with load_offloaded_model():
    model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
```
```
  File "/home/kylesayrs/transformers/src/transformers/quantizers/base.py", line 45, in get_keys_to_not_convert
    if len(model.all_tied_weights_keys) > 0:
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kylesayrs/llm-compressor/env/lib64/python3.12/site-packages/torch/nn/modules/module.py", line 1967, in __getattr__
    raise AttributeError(
AttributeError: 'DeepseekV4PreTrainedModel' object has no attribute 'all_tied_weights_keys'. Did you mean: '_tied_weights_keys'?
```

In this case, I believe the error is caused by the following:
* Transformers `AutoModelForCausalLM.from_pretrained` normally figures out the model class, then calls `model_class.from_pretrained`. `model_class.from_pretrained` is a bound classmethod, meaning that it is called with `cls = DeepseekV4PreTrainedModel`
* However, `load_offloaded_model` calls `model = original_func(cls, *args, **kwargs)`, meaning that it calls it with the passed class (not the bound class), ie `AutoModelForCausalLM`, so the model never actually initializes with `DeepseekV4PreTrainedModel`. It initializes with `AutoModelForCausalLM`, ie a model with no parameters.

## Changes ##
* Instead of inspecting the frame and patching every class that is in the frame (leading to double patches), instead just patch the passed class once upon entering (defaults to `AutoModelForCausalLM`

## Testing ##
* Issue above is fixed
* Tests are updated