### PR TITLE
Ignore non-linear MoE gate layers

### DIFF
--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -5,13 +5,14 @@ from collections import defaultdict
 from enum import Enum
 from typing import Annotated, Any
 
+import torch
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization.quant_args import DynamicType, QuantizationArgs
 from compressed_tensors.quantization.quant_scheme import (
     QuantizationScheme,
     preset_name_to_scheme,
 )
-from compressed_tensors.quantization.utils import is_module_quantized, module_type
+from compressed_tensors.quantization.utils import is_module_quantized
 from pydantic import BaseModel, ConfigDict, Field
 from torch.nn import Module
 
@@ -189,7 +190,7 @@ class QuantizationConfig(BaseModel):
         kv_cache_scheme: QuantizationArgs | None = None
 
         for name, submodule in model.named_modules():
-            layer_type: str = module_type(submodule)
+            layer_type: str = get_vllm_module_type(submodule)
 
             # add config group if quantized non-attention or attention quant
             has_config_group = is_module_quantized(submodule) and (
@@ -275,3 +276,18 @@ class QuantizationConfig(BaseModel):
 
     # TODO set `extra="forbid"` when upstream transformers is compatible
     model_config = ConfigDict(extra="ignore")
+
+
+def get_vllm_module_type(module: torch.nn.Module) -> str:
+    """
+    Returns a string representing the module type used when loading in vLLM.
+    This is typically going to be the same as the `torch.nn.Module` type,
+    however specific cases like MoE gate layers need to be treated like "Linear"
+    layers for the purposes of config matching.
+    """
+
+    module_type = type(module).__name__
+    if "Gate" in module_type or "Router" in module_type:
+        module_type = "Linear"
+
+    return module_type

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -287,7 +287,7 @@ def get_vllm_module_type(module: torch.nn.Module) -> str:
     """
 
     module_type = type(module).__name__
-    if "Gate" in module_type or "Router" in module_type:
+    if "Router" in module_type or "Gate" in module_type or "Gating" in module_type:
         module_type = "Linear"
 
     return module_type


### PR DESCRIPTION
## Background ##
In transformers v4, moe gate modules were just linear modules, and these linear modules would be picked up by ct to be added to the ignore list.

In transformers v5 however, moe gate modules are now [custom classes](https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py#L279C21-L279C39), and are therefore not being picked up into the ignore list by [this logic](https://github.com/vllm-project/compressed-tensors/blob/main/src/compressed_tensors/quantization/quant_config.py#L158).

## Purpose ##
* Properly ignore gating layers to enable proper gate ignoring by vLLM

## Changes ##
* Treat router modules as Linear layers when computing the ignore list
  * This treatment matches how vLLM treats router layers when matching
  * According to [router module names scraped by claude](https://github.com/user-attachments/files/28847593/moe_gate_classes.txt), "Router", "Gate", and "Gating" should cover all cases.

## Testing ##
* E2E MoE tests now pass

```
================= vLLM GENERATION =================

PROMPT:
The capital of France is
GENERATED TEXT:
 Paris. The capital of the United Kingdom is London. The capital of the United

PROMPT:
The creator of the theory of relativity was Albert
GENERATED TEXT:
 Einstein, who was born in 1879 and died in 1

PROMPT:
The classic game is called rock, paper,
GENERATED TEXT:
 scissors. The rules are simple: rock beats scissors, scissors beats paper, and
```