### PR TITLE
[Offload] Skip device-map entries with no local module in dispatch_with_map

### DIFF
--- a/src/compressed_tensors/offload/dispatch.py
+++ b/src/compressed_tensors/offload/dispatch.py
@@ -92,7 +92,17 @@ def dispatch_with_map(
     for name, (onload_device, offload_device) in tqdm(
         list(device_map.items()), desc="Dispatching model", disable=(not show_progress)
     ):
-        module = model.get_submodule(name)
+        try:
+            module = model.get_submodule(name)
+        except AttributeError:
+            # The device map is authored from the source rank's view of the
+            # module tree. On other ranks, sharded structures -- e.g. an
+            # nn.ModuleList of routed MoE experts where slots the rank does
+            # not own are None placeholders -- legitimately lack some of
+            # these submodules. Skip map entries with no local module rather
+            # than crashing the dispatch.
+            logger.debug(f"Skipping '{name}' from device map: not present locally")
+            continue
 
         if offload_device == "disk":
             offload_module(

--- a/tests/test_offload/test_dispatch.py
+++ b/tests/test_offload/test_dispatch.py
@@ -8,6 +8,7 @@ import torch
 from compressed_tensors.offload.cache import CPUCache, OffloadCache
 from compressed_tensors.offload.dispatch import (
     dispatch_model,
+    dispatch_with_map,
     get_device_memory,
     set_onload_device,
 )
@@ -73,6 +74,40 @@ def has_memory_requirements(device_memory: dict[torch.device, int]):
             return False
 
     return True
+
+
+@pytest.mark.unit
+def test_dispatch_with_map_skips_missing_local_modules():
+    # Sharded-MoE pattern: a device map is authored from the source rank's
+    # view of the model, then broadcast to every rank (see from_accelerate).
+    # On ranks that do not own a given routed expert, that ModuleList slot is
+    # a None placeholder, so dispatch_with_map must skip the map entry rather
+    # than crash in model.get_submodule (issue #711).
+    class MoEModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.experts = torch.nn.ModuleList(
+                [None, torch.nn.Linear(5, 5), None, torch.nn.Linear(5, 5)]
+            )
+
+    model = MoEModel()
+    cpu = torch.device("cpu")
+    device_map = {
+        "experts.0": (cpu, cpu),  # None placeholder on this rank
+        "experts.1": (cpu, cpu),
+        "experts.2": (cpu, cpu),  # None placeholder on this rank
+        "experts.3": (cpu, cpu),
+    }
+
+    with patch("compressed_tensors.offload.dispatch.offload_module") as mock_offload:
+        # must not raise AttributeError("`0` is not an nn.Module")
+        dispatch_with_map(model, device_map, show_progress=False)
+
+    dispatched = [call.args[0] for call in mock_offload.call_args_list]
+    # only the locally-present experts are dispatched; None slots are skipped
+    assert mock_offload.call_count == 2
+    assert model.experts[1] in dispatched
+    assert model.experts[3] in dispatched
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
Fixes #711. `dispatch_with_map` crashes with ``AttributeError: `0` is not an nn.Module`` on ranks that don't own every routed expert of a contiguously-sharded MoE model.

## Root cause
`from_accelerate` builds a device map from the **source rank's** view of the module tree, `dist.broadcast_object_list`s it to every rank, then calls `dispatch_with_map`, which does `model.get_submodule(name)` for every entry (`dispatch.py:95`). With contiguous expert sharding the local model has `None` placeholders in its `nn.ModuleList` for non-owned experts (`experts = ModuleList([Expert(...) if owned else None ...])`). `get_submodule("experts.0")` hits that `None` slot and torch raises ``AttributeError("`0` is not an nn.Module")``, so the unconditional post-save `from_accelerate` round-trip crashes on ranks that don't own slot 0 (the source rank, which does, is fine). The device map is authoritative for the source rank's view, not for every rank's view.

## Fix
Wrap the lookup in `try/except AttributeError` and skip (debug-log) map entries with no corresponding local module — there is nothing to dispatch for them. The happy path never raises, so behavior is unchanged when every module is present. This is the smaller of the two fixes the issue describes; building a per-rank intersected device map would be a larger, separate refactor.

## Reproduction (CPU only — no GPU or distributed launch needed)
```python
import torch, torch.nn as nn
from compressed_tensors.offload.dispatch import dispatch_with_map

class M(nn.Module):
    def __init__(self):
        super().__init__()
        # contiguous sharded MoE: slots 0 and 2 are None placeholders on this rank
        self.experts = nn.ModuleList([None, nn.Linear(8, 8), None, nn.Linear(8, 8)])

cpu = torch.device("cpu")
device_map = {f"experts.{i}": (cpu, None) for i in range(4)}
dispatch_with_map(M(), device_map, show_progress=False)
```
- **Before:** ``AttributeError: `0` is not an nn.Module``
- **After:** skips `experts.0` / `experts.2` (debug log), completes cleanly.

## Test
Added `tests/test_offload/test_dispatch.py::test_dispatch_with_map_skips_missing_local_modules` (GPU-free; mocks `offload_module`): asserts the call no longer raises and that only the locally-present experts are dispatched.
```
PYTHONPATH=src python -m pytest \
  tests/test_offload/test_dispatch.py::test_dispatch_with_map_skips_missing_local_modules
```
- WITH fix: `1 passed`
- WITHOUT fix (revert `dispatch.py` only): ``FAILED ... AttributeError: `0` is not an nn.Module``

## Dup-check
No open PR touches `dispatch_with_map` / `get_submodule` (checked the open offload PRs #731/#729/#709/#703 and `git log` history of `dispatch.py` + `from_accelerate.py`). #711 is unassigned with no linked PR.

---
AI-assisted (Claude); every line human-reviewed. DCO signed off.
