### PR TITLE
fix model chkpt name mismatch for ignore

### DIFF
--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -25,6 +25,31 @@ __all__ = [
 ]
 
 
+def _map_to_checkpoint_names(model: Module, ignore_list: list[str]) -> list[str]:
+    """Translate ignore list entries from HF module names to checkpoint names.
+
+    Transformers v5 may rename weight keys on load (e.g. vision_embedder ->
+    embed_vision).  The ignore list is built from ``model.named_modules()``
+    which uses HF names, but safetensors keys use checkpoint names.  This
+    applies the same reverse mapping that ``save_pretrained`` uses for weights.
+    """
+    weight_conversions = getattr(model, "_weight_conversions", None)
+    if not weight_conversions:
+        return ignore_list
+
+    inverted = [conv.reverse_transform() for conv in reversed(weight_conversions)]
+
+    result = []
+    for name in ignore_list:
+        for rev in inverted:
+            renamed, matched = rev.rename_source_key(name)
+            if matched is not None:
+                name = renamed
+        result.append(name)
+
+    return result
+
+
 class QuantizationStatus(str, Enum):
     """
     Enum storing the different states a quantized layer can be in
@@ -230,6 +255,8 @@ class QuantizationConfig(BaseModel):
                 consolidated_ignore += ignore_names
             # else we leave it off the ignore list, doesn't fall under any of the
             # existing quantization schemes so it won't be quantized
+
+        consolidated_ignore = _map_to_checkpoint_names(model, consolidated_ignore)
 
         # create config groups from all unique schemes
         config_groups = {}

--- a/tests/test_quantization/test_quant_config.py
+++ b/tests/test_quantization/test_quant_config.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
+import torch
 from compressed_tensors.quantization import (
     DEFAULT_QUANTIZATION_FORMAT,
     DEFAULT_QUANTIZATION_METHOD,
@@ -9,7 +10,9 @@ from compressed_tensors.quantization import (
     QuantizationScheme,
     QuantizationStatus,
 )
+from compressed_tensors.quantization.quant_config import _map_to_checkpoint_names
 from pydantic import ValidationError
+from transformers import AutoModelForImageTextToText
 
 
 def test_basic_config():
@@ -94,3 +97,64 @@ def test_to_dict():
     # Deserialize from dict
     reloaded = QuantizationConfig.model_validate(config_dict)
     assert config == reloaded
+
+
+@pytest.mark.parametrize(
+    "model_id,hf_ignores,checkpoint_ignores",
+    [
+        pytest.param(
+            "llava-hf/llava-interleave-qwen-0.5b-hf",
+            [
+                "lm_head",
+                "model.vision_tower.encoder.layers.0.self_attn.q_proj",
+                "model.multi_modal_projector.linear_1",
+            ],
+            [
+                "lm_head",
+                "vision_tower.vision_model.encoder.layers.0.self_attn.q_proj",
+                "multi_modal_projector.linear_1",
+            ],
+            id="llava",
+        ),
+        pytest.param(
+            "google/gemma-4-12b-it",
+            [
+                "lm_head",
+                "model.embed_vision.patch_dense",
+                "model.embed_vision.multimodal_embedder.embedding_projection",
+            ],
+            [
+                "lm_head",
+                "model.vision_embedder.patch_dense",
+                "model.embed_vision.embedding_projection",
+            ],
+            id="gemma4",
+        ),
+        pytest.param(
+            "Qwen/Qwen2-VL-2B-Instruct",
+            [
+                "lm_head",
+                "model.visual.merger.mlp.0",
+            ],
+            [
+                "lm_head",
+                "visual.merger.mlp.0",
+            ],
+            id="qwen2_vl",
+        ),
+    ],
+)
+def test_map_to_checkpoint_names(model_id, hf_ignores, checkpoint_ignores):
+    """Load a real model and verify that HF module names in the ignore list
+    are reverse-mapped to checkpoint key names.
+
+    Uses ``device_map="meta"`` so no weights are materialised -- only the
+    model structure and its ``_weight_conversions`` are needed.
+    """
+    model = AutoModelForImageTextToText.from_pretrained(
+        model_id, dtype=torch.float16, device_map="meta"
+    )
+
+    result = _map_to_checkpoint_names(model, hf_ignores)
+
+    assert result == checkpoint_ignores


### PR DESCRIPTION
certain models have different safetensor and model checkpoint name conventions. 

when doing quantization if you ignore the model module name, it would put that in the ignore list and then when vllm would load it, it might not be in the ignore list and so vllm would think it was quantized.

using the name mapping to update the ignore list solves this issue.

test plan:

https://github.com/vllm-project/llm-compressor/pull/2816
