### PR TITLE
Add `force_local_cache` context manager for independent per-rank model loading

### DIFF
--- a/src/compressed_tensors/offload/__init__.py
+++ b/src/compressed_tensors/offload/__init__.py
@@ -53,6 +53,7 @@ __all__ = [
     # control movement
     "disable_onloading",
     "disable_offloading",
+    "force_local_cache",
     # manipulate parameters
     "update_offload_parameter",
     "get_execution_device",
@@ -108,6 +109,24 @@ def disable_onloading():
     """
     with OffloadCache.disable_onloading():
         yield
+
+
+def force_local_cache():
+    """
+    Context under which ``OffloadCache.cls_from_device`` always returns
+    non-distributed caches (``CPUCache``, ``DeviceCache``, ``DiskCache``)
+    even when ``torch.distributed`` is initialized.
+
+    Use when each DDP rank loads the model independently — all ranks
+    already have local parameters, so distributed broadcast is unnecessary.
+
+    Supports nesting.
+    """
+    from compressed_tensors.offload.cache.base import (
+        force_local_cache as _force_local_cache,
+    )
+
+    return _force_local_cache()
 
 
 def update_offload_parameter(module: torch.nn.Module, name: str, data: torch.Tensor):

--- a/src/compressed_tensors/offload/cache/base.py
+++ b/src/compressed_tensors/offload/cache/base.py
@@ -10,6 +10,36 @@ import torch
 import torch.distributed as dist
 from compressed_tensors.utils import is_accelerator_type
 
+# Depth counter: supports nested force_local_cache() contexts.
+# > 0 means cls_from_device returns non-distributed caches.
+_force_local_cache_depth = 0
+
+
+@contextlib.contextmanager
+def force_local_cache():
+    """Context under which :meth:`OffloadCache.cls_from_device` returns
+    non-distributed caches.
+
+    Increments a module-level depth counter; while the counter is > 0,
+    ``cls_from_device`` returns ``CPUCache`` / ``DeviceCache`` /
+    ``DiskCache`` instead of their distributed counterparts, even when
+    ``torch.distributed`` is initialized.
+
+    Use when each DDP rank loads the model independently (e.g. safetensors
+    mmap on CPU).  All ranks already have local parameters, so
+    ``DistributedCPUCache``'s per-parameter broadcast is unnecessary
+    overhead.
+
+    Supports nesting — the counter stays incremented until the outermost
+    context exits.
+    """
+    global _force_local_cache_depth
+    _force_local_cache_depth += 1
+    try:
+        yield
+    finally:
+        _force_local_cache_depth -= 1
+
 
 class OffloadCache(MutableMapping, ABC):
     """
@@ -65,7 +95,11 @@ class OffloadCache(MutableMapping, ABC):
         from compressed_tensors.offload.cache.dist_disk import DistributedDiskCache
 
         device_type = torch.device(device).type if device != "disk" else "disk"
-        distributed = dist.is_available() and dist.is_initialized()
+        distributed = (
+            dist.is_available()
+            and dist.is_initialized()
+            and _force_local_cache_depth == 0
+        )
 
         match (device_type, distributed):
             case ("cpu", False):

--- a/src/compressed_tensors/offload/cache/base.py
+++ b/src/compressed_tensors/offload/cache/base.py
@@ -10,6 +10,7 @@ import torch
 import torch.distributed as dist
 from compressed_tensors.utils import is_accelerator_type
 
+
 # Depth counter: supports nested force_local_cache() contexts.
 # > 0 means cls_from_device returns non-distributed caches.
 _force_local_cache_depth = 0

--- a/tests/test_offload/cache/test_force_local_cache.py
+++ b/tests/test_offload/cache/test_force_local_cache.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch.distributed as dist
+from compressed_tensors.offload.cache.base import (
+    OffloadCache,
+    force_local_cache,
+)
+from tests.test_offload.conftest import torchrun
+from tests.testing_utils import requires_gpu
+
+
+def _cache_name(device):
+    return OffloadCache.cls_from_device(device).__name__
+
+
+def _is_distributed_cache(device):
+    return "Distributed" in _cache_name(device)
+
+
+def _is_local_cache(device):
+    return "Distributed" not in _cache_name(device)
+
+
+@pytest.mark.unit
+@torchrun(world_size=2, init_dist=True)
+def test_force_local_cache_cpu():
+    assert _is_distributed_cache("cpu")
+    with force_local_cache():
+        assert _is_local_cache("cpu")
+    assert _is_distributed_cache("cpu")
+
+
+@pytest.mark.unit
+@requires_gpu(2)
+@torchrun(world_size=2, init_dist=True)
+def test_force_local_cache_device():
+    device = torch.device("cuda", torch.cuda.current_device())
+    assert _is_distributed_cache(device)
+    with force_local_cache():
+        assert _is_local_cache(device)
+    assert _is_distributed_cache(device)
+
+
+@pytest.mark.unit
+@torchrun(world_size=2, init_dist=True)
+def test_force_local_cache_not_distributed():
+    assert dist.is_initialized()
+    assert _is_distributed_cache("cpu")
+    with force_local_cache():
+        assert _is_local_cache("cpu")
+
+
+@pytest.mark.unit
+@torchrun(world_size=2, init_dist=True)
+def test_force_local_cache_nesting():
+    assert _is_distributed_cache("cpu")
+    with force_local_cache():
+        assert _is_local_cache("cpu")
+        with force_local_cache():
+            assert _is_local_cache("cpu")
+        assert _is_local_cache("cpu")
+    assert _is_distributed_cache("cpu")
+
+
+@pytest.mark.unit
+@torchrun(world_size=2, init_dist=True)
+def test_force_local_cache_restores_after_exception():
+    try:
+        with force_local_cache():
+            assert _is_local_cache("cpu")
+            raise RuntimeError("test")
+    except RuntimeError:
+        pass
+    assert _is_distributed_cache("cpu")

--- a/tests/test_offload/cache/test_force_local_cache.py
+++ b/tests/test_offload/cache/test_force_local_cache.py
@@ -4,10 +4,7 @@
 import pytest
 import torch
 import torch.distributed as dist
-from compressed_tensors.offload.cache.base import (
-    OffloadCache,
-    force_local_cache,
-)
+from compressed_tensors.offload.cache.base import OffloadCache, force_local_cache
 from tests.test_offload.conftest import torchrun
 from tests.testing_utils import requires_gpu
 


### PR DESCRIPTION
## Summary

Add `force_local_cache()` context manager to `compressed_tensors.offload`. When active, `OffloadCache.cls_from_device` returns local caches (`CPUCache`, `DeviceCache`, `DiskCache`) instead of distributed variants, even when `torch.distributed` is initialized.

## Background

When running DDP quantization on large models (e.g., Qwen3-235B), each rank loads the full model independently from disk via safetensors mmap. All ranks already have all parameters locally — there is no meta-device rank that needs data broadcast from rank 0. However, `OffloadCache.cls_from_device("cpu")` unconditionally returns `DistributedCPUCache` whenever `dist.is_initialized()`, causing per-parameter `broadcast + barrier` operations (~218ms each × 45K+ params = hours of overhead).

`load_offloaded_model()` + `device_map="auto"` also fails for large models in DDP: OOMs on a single GPU per rank, and `device_map="auto_offload"` hangs on `dist.broadcast_object_list([61K-entry device_map])`.

The alternative — independent per-rank CPU loading — works but needs a way to suppress the distributed cache selection.

## Change

```python
with force_local_cache():
    oneshot(model=model, dataset=ds, recipe=recipe, ...)
```