### PR TITLE
Add runner selection dropdown for manual Buildkite triggers

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,16 @@
 steps:
   # Test check pipeline
-  - label: "Compressed-Tensors Smoke, Sanity and Regression"
+  - label: ":gear: Compressed-Tensors Smoke, Sanity and Regression"
     command: |
-      PIPELINE_FILE="$${TEST_RUNNER:-H100duo}"
-      buildkite-agent pipeline upload .buildkite/test-check/test-check-$${PIPELINE_FILE}.yml
+      RUNNER=$$(buildkite-agent meta-data get "test-runner" --default "L4solo")
+      echo "╔══════════════════════════════════════════╗"
+      echo "║          BUILD SUMMARY                   ║"
+      echo "╠══════════════════════════════════════════╣"
+      echo "║ Triggered by : $${BUILDKITE_BUILD_CREATOR}"
+      echo "║ Source        : $${BUILDKITE_SOURCE}"
+      echo "║ Branch        : $${BUILDKITE_BRANCH}"
+      echo "║ Commit        : $${BUILDKITE_COMMIT:0:8}"
+      echo "║ PR            : $${BUILDKITE_PULL_REQUEST:-none}"
+      echo "║ GPU Runner    : $${RUNNER}"
+      echo "╚══════════════════════════════════════════╝"
+      buildkite-agent pipeline upload .buildkite/test-check/test-check-$${RUNNER}.yml


### PR DESCRIPTION
## Summary
- Add build summary banner and meta-data based runner selection to pipeline.yml
- Works with Buildkite UI input step to allow manual runner override
- Temporarily switch default GPU runner from H100duo (WDC) to L4solo (GCP) due to H100 cluster issue

## Reason
H100 nodes on WDC cluster have NVIDIA driver failures.

## What changed
- `.buildkite/pipeline.yml` — added build summary banner, meta-data based runner selection, changed default runner from H100duo to L4solo

## Usage
- **Default (L4solo):** trigger a Buildkite build — no config needed
- **H100duo:** select "H100 Duo (WDC)" from the GPU Runner dropdown when triggering manually from Buildkite UI

## Revert
Once the H100 cluster issue is resolved, revert this change by switching the default back to H100duo in `.buildkite/pipeline.yml`.

## Reference
- Follows the same pattern used in the Speculators repo