### PR TITLE
[Quantization] Only apply quantization schemes to Linear, Embedding, and Attention layers

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -153,7 +153,7 @@ def apply_quantization_config(
             module.quantization_status = config.quantization_status
 
         # linear quantization
-        elif isinstance(module, torch.nn.Linear):
+        elif isinstance(module, (torch.nn.Linear, torch.nn.Embedding)):
             module.quantization_scheme = scheme
             initialize_module_for_quantization(
                 module, force_zero_point=force_zero_point

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -150,6 +150,9 @@ def apply_quantization_config(
         if is_attention_module(module) and is_narrow_match(model, scheme.targets, name):
             module.quantization_scheme = scheme
             initialize_hooked_attention(model, module)
+            initialize_module_for_quantization(
+                module, force_zero_point=force_zero_point
+            )
             module.quantization_status = config.quantization_status
 
         # linear quantization

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -137,25 +137,28 @@ def apply_quantization_config(
         match_named_modules(model, target_to_scheme, config.ignore, warn_on_fail=True)
     )
 
-    for name, submodule in tqdm(
+    for name, module in tqdm(
         matched_modules,
         desc="Applying quantization config",
         disable=not show_progress,
     ):
-        # mark modules to be quantized by adding
-        # quant scheme to the matching layers
-        matched_targets = match_targets(name, submodule, target_to_scheme)
+        # a module may match multiple scheme targets
+        matched_targets = match_targets(name, module, target_to_scheme)
         scheme = _scheme_from_targets(target_to_scheme, matched_targets, name)
-        # target matched - add layer and scheme to target list
-        submodule.quantization_scheme = scheme
 
-        if is_attention_module(submodule) and is_narrow_match(
-            model, scheme.targets, name
-        ):
-            initialize_hooked_attention(model, submodule)
+        # attention quantization
+        if is_attention_module(module) and is_narrow_match(model, scheme.targets, name):
+            module.quantization_scheme = scheme
+            initialize_hooked_attention(model, module)
+            module.quantization_status = config.quantization_status
 
-        initialize_module_for_quantization(submodule, force_zero_point=force_zero_point)
-        submodule.quantization_status = config.quantization_status
+        # linear quantization
+        elif isinstance(module, torch.nn.Linear):
+            module.quantization_scheme = scheme
+            initialize_module_for_quantization(
+                module, force_zero_point=force_zero_point
+            )
+            module.quantization_status = config.quantization_status
 
 
 def _apply_kv_cache_scheme(

--- a/src/compressed_tensors/utils/match.py
+++ b/src/compressed_tensors/utils/match.py
@@ -390,6 +390,7 @@ def is_narrow_match(
     """
     Checks if any of the targets narrowly match the module. A target narrowly matches
     a module if the target matches the module, but does not match the module's parent
+    or any of the module's children.
 
     :param model: model containing both module and its parent
     :param targets: target strings, potentially containing "re:" prefixes
@@ -403,8 +404,17 @@ def is_narrow_match(
     parent_name = name.rsplit(".", 1)[0]
     parent = model.get_submodule(parent_name)
 
+    def _matches_any_child(target: str) -> bool:
+        return any(
+            is_match(f"{name}.{child_name}", child_module, target)
+            for child_name, child_module in module.named_modules()
+            if child_name  # skip the module itself (empty string key)
+        )
+
     return any(
-        is_match(name, module, target) and not is_match(parent_name, parent, target)
+        is_match(name, module, target)
+        and not is_match(parent_name, parent, target)
+        and not _matches_any_child(target)
         for target in targets
     )
 

--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -491,3 +491,108 @@ def test_apply_attention():
         assert hasattr(layer.self_attn, "q_scale")
         assert hasattr(layer.self_attn, "k_scale")
         assert hasattr(layer.self_attn, "v_scale")
+
+
+linear_scheme = QuantizationScheme(targets=["Linear"])
+attention_scheme = QuantizationScheme(targets=["LlamaAttention"])
+attention_linears = QuantizationScheme(targets=[r"re:.*self_attn\..*"])
+mlp_linears = QuantizationScheme(targets=[r"re:.*mlp\..*"])
+down_proj_scheme = QuantizationScheme(targets=["re:.*down_proj"])
+
+
+@pytest.mark.parametrize(
+    "config, expected_schemes",
+    [
+        # all linears
+        (
+            QuantizationConfig(config_groups={"group_0": linear_scheme}),
+            {
+                p: linear_scheme
+                for p in [
+                    f"model.layers.{i}.self_attn.{k}_proj"
+                    for i in range(6)
+                    for k in "qkvo"
+                ]
+                + [
+                    f"model.layers.{i}.mlp.{k}_proj"
+                    for i in range(6)
+                    for k in ["gate", "up", "down"]
+                ]
+                + ["lm_head"]
+            },
+        ),
+        # only attention
+        (
+            QuantizationConfig(config_groups={"group_0": attention_scheme}),
+            {f"model.layers.{i}.self_attn": attention_scheme for i in range(6)},
+        ),
+        # linear and attention
+        (
+            QuantizationConfig(
+                config_groups={"attention": attention_scheme, "linear": linear_scheme},
+            ),
+            {
+                **{f"model.layers.{i}.self_attn": attention_scheme for i in range(6)},
+                **{
+                    p: linear_scheme
+                    for p in [
+                        f"model.layers.{i}.self_attn.{k}_proj"
+                        for i in range(6)
+                        for k in "qkvo"
+                    ]
+                    + [
+                        f"model.layers.{i}.mlp.{k}_proj"
+                        for i in range(6)
+                        for k in ["gate", "up", "down"]
+                    ]
+                    + ["lm_head"]
+                },
+            },
+        ),
+        # only down proj
+        (
+            QuantizationConfig(config_groups={"group_0": down_proj_scheme}),
+            {f"model.layers.{i}.mlp.down_proj": down_proj_scheme for i in range(6)},
+        ),
+        # attention linears and mlp linears as separate groups
+        (
+            QuantizationConfig(
+                config_groups={
+                    "attention_linears": attention_linears,
+                    "mlp_linears": mlp_linears,
+                },
+            ),
+            {
+                **{
+                    f"model.layers.{i}.self_attn.{k}_proj": attention_linears
+                    for i in range(6)
+                    for k in "qkvo"
+                },
+                **{
+                    f"model.layers.{i}.mlp.{k}_proj": mlp_linears
+                    for i in range(6)
+                    for k in ["gate", "up", "down"]
+                },
+            },
+        ),
+    ],
+)
+def test_apply_model(config, expected_schemes):
+    model = AutoModelForCausalLM.from_pretrained(
+        "nm-testing/tinysmokellama-3.2",
+        cache_dir="test-apply-model-cache",
+    )
+    apply_quantization_config(model, config)
+
+    for name, module in model.named_modules():
+        if name in expected_schemes:
+            assert hasattr(
+                module, "quantization_scheme"
+            ), f"{name} should have quantization_scheme"
+            assert (
+                module.quantization_scheme == expected_schemes[name]
+            ), f"{name} has wrong scheme"
+        else:
+            assert not hasattr(
+                module, "quantization_scheme"
+            ), f"{name} should not have quantization_scheme"

--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -494,7 +494,10 @@ def test_apply_attention():
 
 
 linear_scheme = QuantizationScheme(targets=["Linear"])
-attention_scheme = QuantizationScheme(targets=["LlamaAttention"])
+attention_scheme = QuantizationScheme(
+    targets=["LlamaAttention"],
+    input_activations=QuantizationArgs(num_bits=8, type="float", strategy="tensor"),
+)
 attention_linears = QuantizationScheme(targets=[r"re:.*self_attn\..*"])
 mlp_linears = QuantizationScheme(targets=[r"re:.*mlp\..*"])
 down_proj_scheme = QuantizationScheme(targets=["re:.*down_proj"])


### PR DESCRIPTION
## Purpose ##
* Make it easier to create mixed-precision quantization configs
  * Right now, it's extremely annoying/pedantic to create valid quantization configs which target different parts of the model
  * If you attempt to use a common sense target like `.*mlp.*`, you see an error which complains about parent modules (DecoderLayer, etc) being targeted with quantization. In reality, the only modules which can be quantized are attention and linears

## Changes ##
* Only apply quantization config to attention and linear layers

## Testing ##
* Added targeting test