### PR TITLE
[Bugfix] Enforce block_structure length validation for string format

### DIFF
--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -245,25 +245,21 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
     def validate_block_structure(cls, value) -> list[int] | None:
         if value is None:
             return value
+
+        error = ValueError(
+            f"Invalid block_structure '{value}'. Must be a list of ints [rows, cols]."
+        )
         # For backward compatibility, allow string format "2x4", "8x16", etc.
         if isinstance(value, str):
             try:
-                return [int(x) for x in value.split("x")]
+                value = [int(x) for x in value.split("x")]
             except Exception:
-                raise ValueError(
-                    f"Invalid block_structure '{value}'. Must be a list of ints "
-                    "[rows, cols]."
-                )
+                raise error
         if isinstance(value, (list, tuple)):
             if len(value) != 2 or not all(isinstance(v, int) for v in value):
-                raise ValueError(
-                    f"Invalid block_structure '{value}'. Must be a list of ints "
-                    "[rows, cols]."
-                )
+                raise error
             return list(value)
-        raise ValueError(
-            f"Invalid block_structure '{value}'. Must be a list of ints [rows, cols]."
-        )
+        raise error
 
     @field_validator("strategy", mode="before")
     def validate_strategy(cls, value) -> QuantizationStrategy | None:

--- a/tests/test_quantization/test_quant_args.py
+++ b/tests/test_quantization/test_quant_args.py
@@ -52,6 +52,19 @@ def test_block():
     assert block.block_structure != kwargs["block_structure"]  # "2x4" != [2, 4]
 
 
+def test_block_structure_string_length_validation():
+    # string and list forms must enforce the same [rows, cols] contract
+    with pytest.raises(ValidationError):
+        QuantizationArgs(strategy="block", block_structure="2x4x8")
+    with pytest.raises(ValidationError):
+        QuantizationArgs(strategy="block", block_structure=[2, 4, 8])
+
+
+def test_block_structure_string_non_int():
+    with pytest.raises(ValidationError):
+        QuantizationArgs(strategy="block", block_structure="2xfoo")
+
+
 def test_infer_strategy():
     args = QuantizationArgs(group_size=128)
     assert args.strategy == QuantizationStrategy.GROUP


### PR DESCRIPTION
## Purpose

`QuantizationArgs.validate_block_structure` enforced the two-element `[rows, cols]` contract for the list/tuple form but not for the backward-compatible string form. As a result `"2x4x8"` was silently accepted as `[2, 4, 8]`, while the equivalent list `[2, 4, 8]` was correctly rejected — the same field behaved differently depending on input format.

Fixes #754

## Changes

- Route the string branch through the existing length/all-int check instead of returning early.
- Collapse the three duplicated `ValueError` messages into a single `error` to keep the validation paths consistent.
- Add regression tests covering the string length and non-int cases.

## Testing

pytest tests/test_quantization/test_quant_args.py

All tests pass, including the new cases:
- `test_block_structure_string_length_validation`
- `test_block_structure_string_non_int`