### PR TITLE
Fix MTP tensor copy from indexed checkpoints

### DIFF
--- a/src/compressed_tensors/utils/safetensors_load.py
+++ b/src/compressed_tensors/utils/safetensors_load.py
@@ -555,12 +555,17 @@ def _fetch_and_save_prefix_tensors(
     :return: dict mapping tensor key to tensor
 
     """
-    source_dir = get_safetensors_folder(source_model)
-    weight_mappings = get_weight_mappings(source_dir)
+    model_files = get_checkpoint_files(source_model)
+    weight_map = get_weight_map(model_files)
 
     tensors = {}
-    for key, filepath in weight_mappings.items():
+    for key, weight_shard_name in weight_map.items():
         if key.startswith(prefix):
+            if weight_shard_name not in model_files:
+                raise ValueError(
+                    f"Could not find shard {weight_shard_name} for tensor {key}"
+                )
+            filepath = model_files[weight_shard_name]
             with safe_open(filepath, framework="pt", device="cpu") as f:
                 tensors[key] = f.get_tensor(key)
 

--- a/tests/test_utils/test_save_mtp_tensors.py
+++ b/tests/test_utils/test_save_mtp_tensors.py
@@ -139,6 +139,37 @@ class TestSaveMtpTensorsToCheckpoint:
             assert torch.equal(saved[key], expected[key])
         assert all(k.startswith("mtp") for k in saved)
 
+    def test_mtp_tensors_saved_from_checkpoint_with_existing_mtp_shard(
+        self, dest_dir_with_index, tmp_path
+    ):
+        """
+        Verify that a checkpoint produced by save_mtp_tensors_to_checkpoint can
+        itself be used as a source for copying MTP tensors into another checkpoint.
+        """
+        src = tmp_path / "src_with_mtp_shard"
+        src.mkdir()
+
+        model_tensors = {"model.layer0.weight": torch.randn(4, 4)}
+        mtp_tensors = {"mtp.layer0.weight": torch.randn(3, 3)}
+        _make_safetensors(str(src / SAFE_WEIGHTS_NAME), model_tensors)
+        _make_safetensors(str(src / "model_mtp.safetensors"), mtp_tensors)
+
+        index = {
+            "metadata": {},
+            "weight_map": {
+                "model.layer0.weight": SAFE_WEIGHTS_NAME,
+                "mtp.layer0.weight": "model_mtp.safetensors",
+            },
+        }
+        with open(src / SAFE_WEIGHTS_INDEX_NAME, "w") as f:
+            json.dump(index, f)
+
+        save_mtp_tensors_to_checkpoint(str(src), str(dest_dir_with_index))
+
+        saved = _read_safetensors(str(dest_dir_with_index / "model_mtp.safetensors"))
+        assert set(saved.keys()) == {"mtp.layer0.weight"}
+        assert torch.equal(saved["mtp.layer0.weight"], mtp_tensors["mtp.layer0.weight"])
+
     def test_index_updated(self, source_dir, dest_dir_with_index):
         """
         Verify that after the call the destination index file contains MTP keys


### PR DESCRIPTION
Currently, when using save_mtp_tensors_to_checkpoint to save the MTP from model A to B, you cannot reuse save_mtp_tensors_to_checkpoint to save from B to another model C. Which means that it is required to download A again, even though everything necessary is already in B.

This PR aims to give the possibility to copy the MTP from A to B (as is currently being done) and also B to C.

Use the checkpoint file map and safetensors weight map when fetching prefix-matched tensors, so sources with both model.safetensors and a safetensors index correctly resolve sidecar shards such as model_mtp.safetensors.

Add regression coverage for copying MTP tensors from a checkpoint that was itself produced by save_mtp_tensors_to_checkpoint.