### PR TITLE
[Bugfix] Fix ignore list for linearized MoE layers

### DIFF
--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 from enum import Enum
 from typing import Annotated, Any
 
-import torch
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization.quant_args import DynamicType, QuantizationArgs
 from compressed_tensors.quantization.quant_scheme import (
@@ -215,7 +214,7 @@ class QuantizationConfig(BaseModel):
         kv_cache_scheme: QuantizationArgs | None = None
 
         for name, submodule in model.named_modules():
-            layer_type: str = get_vllm_module_type(submodule)
+            layer_type: str = get_vllm_module_type(type(submodule).__name__)
 
             # add config group if quantized non-attention or attention quant
             has_config_group = is_module_quantized(submodule) and (
@@ -305,16 +304,16 @@ class QuantizationConfig(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
 
-def get_vllm_module_type(module: torch.nn.Module) -> str:
+def get_vllm_module_type(module_type: str) -> str:
     """
     Returns a string representing the module type used when loading in vLLM.
     This is typically going to be the same as the `torch.nn.Module` type,
     however specific cases like MoE gate layers need to be treated like "Linear"
     layers for the purposes of config matching.
     """
-
-    module_type = type(module).__name__
-    if "Router" in module_type or "Gate" in module_type or "Gating" in module_type:
+    if "ExpertMLP" not in module_type and (
+        "Router" in module_type or "Gate" in module_type or "Gating" in module_type
+    ):
         module_type = "Linear"
 
     return module_type

--- a/tests/test_quantization/test_quant_config.py
+++ b/tests/test_quantization/test_quant_config.py
@@ -10,7 +10,10 @@ from compressed_tensors.quantization import (
     QuantizationScheme,
     QuantizationStatus,
 )
-from compressed_tensors.quantization.quant_config import _map_to_checkpoint_names
+from compressed_tensors.quantization.quant_config import (
+    _map_to_checkpoint_names,
+    get_vllm_module_type,
+)
 from pydantic import ValidationError
 from transformers import AutoModelForImageTextToText
 
@@ -158,3 +161,15 @@ def test_map_to_checkpoint_names(model_id, hf_ignores, checkpoint_ignores):
     result = _map_to_checkpoint_names(model, hf_ignores)
 
     assert result == checkpoint_ignores
+
+
+def test_get_vllm_module_type():
+    assert get_vllm_module_type("ExpertMLP") == "ExpertMLP"
+    assert get_vllm_module_type("ExpertMLPWithGate") == "ExpertMLPWithGate"
+    assert get_vllm_module_type("ExpertMLPWithoutGate") == "ExpertMLPWithoutGate"
+    assert get_vllm_module_type("Linear") == "Linear"
+    assert get_vllm_module_type("DeepseekV4TopKRouter") == "Linear"
+    assert get_vllm_module_type("DeepseekV4HashRouter") == "Linear"
+    assert get_vllm_module_type("JetMoeTopKGating") == "Linear"
+    assert get_vllm_module_type("Qwen3NextGatedDeltaNet") == "Linear"
+    assert get_vllm_module_type("JetMoeTopKGating") == "Linear"


### PR DESCRIPTION
## Purpose ##
* Fix bug where `model.layers.*.experts` would end up in ignore list
  * This was due to `test_get_vllm_module_type` falsely thinking that `"ExpertMLPWithGate"` was a router gating class, and therefore attempting to put it in the ignore list.

## Changes ##
* Explicitly treat modules with `ExpertMLP` in the name as regular classes, rather than router gating classes

## Postrequisite  ##
* https://github.com/vllm-project/llm-compressor/pull/2886