### PR TITLE
[Bugfix] Validate positive block structure dimensions

### DIFF
--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -257,7 +257,8 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
             return value
 
         error = ValueError(
-            f"Invalid block_structure '{value}'. Must be a list of ints [rows, cols]."
+            f"Invalid block_structure '{value}'. Must be a list of positive ints "
+            "[rows, cols]."
         )
         # For backward compatibility, allow string format "2x4", "8x16", etc.
         if isinstance(value, str):
@@ -266,7 +267,11 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
             except Exception:
                 raise error
         if isinstance(value, (list, tuple)):
-            if len(value) != 2 or not all(isinstance(v, int) for v in value):
+            if (
+                len(value) != 2
+                or not all(isinstance(v, int) for v in value)
+                or not all(v > 0 for v in value)
+            ):
                 raise error
             return list(value)
         raise error

--- a/tests/test_quantization/test_quant_args.py
+++ b/tests/test_quantization/test_quant_args.py
@@ -69,6 +69,15 @@ def test_block_structure_string_non_int():
         QuantizationArgs(strategy="block", block_structure="2xfoo")
 
 
+@pytest.mark.parametrize(
+    "block_structure",
+    ([0, 4], [-1, 4], [4, 0], [4, -1], "0x4", "-1x4", "4x0", "4x-1"),
+)
+def test_block_structure_requires_positive_dimensions(block_structure):
+    with pytest.raises(ValidationError, match="positive"):
+        QuantizationArgs(strategy="block", block_structure=block_structure)
+
+
 def test_infer_strategy():
     args = QuantizationArgs(group_size=128)
     assert args.strategy == QuantizationStrategy.GROUP


### PR DESCRIPTION
## Purpose

`QuantizationArgs` currently accepts zero and negative `block_structure` dimensions. Zero dimensions later cause `ZeroDivisionError` in block padding and initialization, while negative values do not describe valid block sizes.

Fixes #762.

## Changes

- Require both block structure dimensions to be positive integers.
- Apply the same validation to list, tuple, and backward-compatible string inputs.
- Clarify the validation error message.
- Add parameterized regression coverage for zero and negative dimensions in both input formats.

## Testing

```text
pytest -q tests/test_quantization/test_quant_args.py
22 passed

make quality
copyright, black, isort, and flake8 passed
```

## AI assistance

AI assistance was used to inspect the validation code, generate edge-case probes, and draft the test and fix. The bug was reproduced mechanically, the test was run failing before implementation, and all stated checks were run locally.