### PR TITLE
Validate positive block structures

### DIFF
--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -257,7 +257,8 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
             return value
 
         error = ValueError(
-            f"Invalid block_structure '{value}'. Must be a list of ints [rows, cols]."
+            f"Invalid block_structure '{value}'. Must be a list of positive ints "
+            "[rows, cols]."
         )
         # For backward compatibility, allow string format "2x4", "8x16", etc.
         if isinstance(value, str):
@@ -266,7 +267,11 @@ class QuantizationArgs(BaseModel, use_enum_values=True):
             except Exception:
                 raise error
         if isinstance(value, (list, tuple)):
-            if len(value) != 2 or not all(isinstance(v, int) for v in value):
+            if (
+                len(value) != 2
+                or not all(isinstance(v, int) for v in value)
+                or not all(v > 0 for v in value)
+            ):
                 raise error
             return list(value)
         raise error

--- a/tests/test_quantization/test_quant_args.py
+++ b/tests/test_quantization/test_quant_args.py
@@ -69,6 +69,17 @@ def test_block_structure_string_non_int():
         QuantizationArgs(strategy="block", block_structure="2xfoo")
 
 
+def test_block_structure_requires_positive_dims():
+    with pytest.raises(ValidationError):
+        QuantizationArgs(strategy="block", block_structure=[0, 4])
+    with pytest.raises(ValidationError):
+        QuantizationArgs(strategy="block", block_structure=[-1, 4])
+    with pytest.raises(ValidationError):
+        QuantizationArgs(strategy="block", block_structure="0x4")
+    with pytest.raises(ValidationError):
+        QuantizationArgs(strategy="block", block_structure="-1x4")
+
+
 def test_infer_strategy():
     args = QuantizationArgs(group_size=128)
     assert args.strategy == QuantizationStrategy.GROUP


### PR DESCRIPTION
Fixes #762 by rejecting zero and negative dimensions in QuantizationArgs.block_structure.

Validation:
- python3 -m py_compile src/compressed_tensors/quantization/quant_args.py tests/test_quantization/test_quant_args.py
- pytest could not be run in this environment because the local package dependencies are not installed (missing loguru, then other runtime deps).