### PR TITLE
[Bugfix] Remove unreachable GROUP+dynamic branch in QuantizationScheme

### DIFF
--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -57,14 +57,6 @@ class QuantizationScheme(BaseModel, use_enum_values=True):
                 QuantizationStrategy.TENSOR_GROUP,
                 QuantizationStrategy.ATTN_HEAD,
             ):
-                if (
-                    inputs.strategy == QuantizationStrategy.GROUP
-                    and inputs.dynamic is True
-                ):
-                    raise NotImplementedError(
-                        "Static and local group-wise activation "
-                        "quantization is not supported"
-                    )
 
                 raise NotImplementedError(
                     f"Using {inputs.strategy} strategy is not supported for "


### PR DESCRIPTION
## Purpose

Removes dead code in `QuantizationScheme.validate_model_after`. The inner
`inputs.strategy == QuantizationStrategy.GROUP and inputs.dynamic is True`
check is unreachable: the enclosing `if inputs.strategy not in (...)` block
lists `GROUP` among the allowed strategies, so inside it the strategy can
never be `GROUP`.

As confirmed in #<issue-number>, group dynamic activation quantization is a
supported configuration (used by the `MXFP4`, `MXFP8`, and `FP8_BLOCK`
presets), so the guard is obsolete leftover from #450.

Fixes #758

## Changes

- Remove the unreachable `GROUP + dynamic` branch and its
  `NotImplementedError`.

## Testing

- `make quality` passes.
- Verified a `GROUP` + `dynamic=True` input-activation scheme is still
  accepted, and unsupported activation strategies still raise
  `NotImplementedError`.
- `pytest tests/test_quantization/ -k scheme` passes.