### PR TITLE
[XPU] Add torch.cuda linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ quality:
 	black --target-version py310 --check $(PYCHECKDIRS);
 	isort --check-only $(PYCHECKDIRS);
 	flake8 $(PYCHECKDIRS);
+	python tools/lint_cuda.py $(PYCHECKDIRS) --fail-on-issues;
 
 # style the code according to accepted standards for the repo
 style:
@@ -18,11 +19,12 @@ style:
 	@echo "Running python styling";
 	black --target-version py310 $(PYCHECKDIRS);
 	isort $(PYCHECKDIRS);
+	python tools/lint_cuda.py $(PYCHECKDIRS) --fix
 
 # run tests for the repo
 test:
 	@echo "Running python tests";
-	pytest -ra tests;
+	pytest -ra tests --ignore tests/test_tools;
 
 # run xpu tests for the repo
 test-xpu: 

--- a/src/compressed_tensors/transform/factory/matrix_multiply.py
+++ b/src/compressed_tensors/transform/factory/matrix_multiply.py
@@ -117,7 +117,7 @@ def high_precision_invert(weight: Tensor) -> Tensor:
     if compute_device.type == "cpu":
         if _cpu_lapack_available is None:
             _cpu_lapack_available = _has_cpu_lapack()
-        if not _cpu_lapack_available and torch.cuda.is_available():
+        if not _cpu_lapack_available and torch.accelerator.is_available():
             compute_device = torch.device("cuda")
 
     result = torch.linalg.inv(weight.to(device=compute_device, dtype=torch.float64))

--- a/tests/test_compressors/test_compress_decompress_module.py
+++ b/tests/test_compressors/test_compress_decompress_module.py
@@ -18,21 +18,20 @@ from compressed_tensors.quantization import (
 )
 from compressed_tensors.quantization.utils import is_module_quantized
 from compressed_tensors.utils import get_direct_state_dict
+from tests.testing_utils import requires_gpu
 
 
+@requires_gpu
 def _run_compress_decompress(
     scheme_name, expected_format, actorder, device, module=None, targets=("Linear",)
 ):
-    if device == "cuda" and not torch.accelerator.is_available():
-        pytest.skip("CUDA not available")
-
     # 1. Initialize module for quantization using a preset scheme.
     # Use 256x256 to avoid degenerate scale shapes (e.g. (N,1) for FP8_BLOCK)
     # that trip up block-vs-channel strategy inference in dequantize.
     # Start in bfloat16 so NVFP4 decompression (which returns bfloat16) preserves dtype.
     if module is None:
         module = nn.Linear(256, 256, bias=False)
-    module = module.to(dtype=torch.bfloat16, device=device)
+    module = module.to(dtype=torch.bfloat16, device="cuda")
     scheme = preset_name_to_scheme(scheme_name, list(targets))
     if actorder is not None:
         scheme.weights.actorder = actorder

--- a/tests/test_compressors/test_compress_decompress_module.py
+++ b/tests/test_compressors/test_compress_decompress_module.py
@@ -23,7 +23,7 @@ from compressed_tensors.utils import get_direct_state_dict
 def _run_compress_decompress(
     scheme_name, expected_format, actorder, device, module=None, targets=("Linear",)
 ):
-    if device == "cuda" and not torch.cuda.is_available():
+    if device == "cuda" and not torch.accelerator.is_available():
         pytest.skip("CUDA not available")
 
     # 1. Initialize module for quantization using a preset scheme.

--- a/tests/test_compressors/test_fp4_optimizations.py
+++ b/tests/test_compressors/test_fp4_optimizations.py
@@ -47,7 +47,7 @@ def reference_pack_fp4_to_uint8(x: torch.Tensor) -> torch.Tensor:
 )
 def test_pack_fp4_to_uint8(device, test_input):
     """Test pack_fp4_to_uint8 matches reference implementation."""
-    if device == "cuda" and not torch.cuda.is_available():
+    if device == "cuda" and not torch.accelerator.is_available():
         pytest.skip("CUDA not available")
 
     from compressed_tensors.compressors.nvfp4.helpers import pack_fp4_to_uint8
@@ -62,7 +62,7 @@ def test_pack_fp4_to_uint8(device, test_input):
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
 def test_pack_fp4_non_contiguous(device):
     """Test pack_fp4_to_uint8 works correctly with non-contiguous input tensors."""
-    if device == "cuda" and not torch.cuda.is_available():
+    if device == "cuda" and not torch.accelerator.is_available():
         pytest.skip("CUDA not available")
 
     from compressed_tensors.compressors.nvfp4.helpers import pack_fp4_to_uint8

--- a/tests/test_tools/README.md
+++ b/tests/test_tools/README.md
@@ -1,0 +1,1 @@
+This directory contains tests for files in the `tools` folder. The tests in this folder do not run as part of any CI, are meant only to be used by local developers

--- a/tests/test_tools/test_lint_cuda.py
+++ b/tests/test_tools/test_lint_cuda.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""
+Test suite for the torch.cuda linter.
+
+This module contains tests to verify the linter correctly detects
+torch.cuda usage and suggests torch.accelerator alternatives.
+"""
+
+import ast
+import sys
+import tempfile
+from pathlib import Path
+
+from tools.lint_cuda import TorchCudaLinter, apply_fixes, lint_file
+
+
+def test_detect_torch_cuda_is_available():
+    """Test detection of torch.cuda.is_available()."""
+    code = """
+import torch
+
+if torch.cuda.is_available():
+    print("CUDA available")
+"""
+    tree = ast.parse(code)
+    linter = TorchCudaLinter("test.py")
+    linter.visit(tree)
+
+    assert len(linter.issues) == 1
+    line, col, usage, suggestion = linter.issues[0]
+    assert usage == "torch.cuda.is_available"
+    assert suggestion == "torch.accelerator.is_available"
+    print("✓ test_detect_torch_cuda_is_available passed")
+
+
+def test_detect_torch_cuda_stream():
+    """Test detection of torch.cuda.Stream."""
+    code = """
+import torch
+
+stream = torch.cuda.Stream()
+"""
+    tree = ast.parse(code)
+    linter = TorchCudaLinter("test.py")
+    linter.visit(tree)
+
+    assert len(linter.issues) == 1
+    line, col, usage, suggestion = linter.issues[0]
+    assert usage == "torch.cuda.Stream"
+    assert suggestion == "torch.Stream"
+    print("✓ test_detect_torch_cuda_stream passed")
+
+
+def test_detect_torch_cuda_event():
+    """Test detection of torch.cuda.Event."""
+    code = """
+import torch
+
+event = torch.cuda.Event()
+"""
+    tree = ast.parse(code)
+    linter = TorchCudaLinter("test.py")
+    linter.visit(tree)
+
+    assert len(linter.issues) == 1
+    line, col, usage, suggestion = linter.issues[0]
+    assert usage == "torch.cuda.Event"
+    assert suggestion == "torch.Event"
+    print("✓ test_detect_torch_cuda_event passed")
+
+
+def test_detect_torch_cuda_context_manager():
+    """Test detection of torch.cuda.stream context manager."""
+    code = """
+import torch
+
+with torch.cuda.stream(stream):
+    x = torch.randn(10)
+"""
+    tree = ast.parse(code)
+    linter = TorchCudaLinter("test.py")
+    linter.visit(tree)
+
+    assert len(linter.issues) == 1
+    line, col, usage, suggestion = linter.issues[0]
+    assert usage == "torch.cuda.stream"
+    # Generic replacement since torch.cuda.stream is not in the specific suggestions
+    assert suggestion == "torch.Stream"
+    print("✓ test_detect_torch_cuda_context_manager passed")
+
+
+def test_detect_memory_functions():
+    """Test detection of memory-related CUDA functions."""
+    code = """
+import torch
+
+allocated = torch.cuda.memory_allocated()
+reserved = torch.cuda.memory_reserved()
+torch.cuda.empty_cache()
+"""
+    tree = ast.parse(code)
+    linter = TorchCudaLinter("test.py")
+    linter.visit(tree)
+
+    assert len(linter.issues) == 3
+    usages = [usage for _, _, usage, _ in linter.issues]
+    assert "torch.cuda.memory_allocated" in usages
+    assert "torch.cuda.memory_reserved" in usages
+    assert "torch.cuda.empty_cache" in usages
+    print("✓ test_detect_memory_functions passed")
+
+
+def test_detect_from_import():
+    """Test detection of 'from torch.cuda import ...' statements."""
+    code = """
+from torch.cuda import Stream, Event
+"""
+    tree = ast.parse(code)
+    linter = TorchCudaLinter("test.py")
+    linter.visit(tree)
+
+    assert len(linter.issues) == 2
+    print("✓ test_detect_from_import passed")
+
+
+def test_ignore_non_cuda_torch():
+    """Test that non-CUDA torch calls are not flagged."""
+    code = """
+import torch
+
+x = torch.randn(10)
+y = torch.tensor([1, 2, 3])
+device = torch.device("cpu")
+"""
+    tree = ast.parse(code)
+    linter = TorchCudaLinter("test.py")
+    linter.visit(tree)
+
+    assert len(linter.issues) == 0
+    print("✓ test_ignore_non_cuda_torch passed")
+
+
+def test_complex_usage():
+    """Test detection in complex code with multiple CUDA calls."""
+    code = """
+import torch
+
+def setup_cuda():
+    if torch.cuda.is_available():
+        device_count = torch.cuda.device_count()
+        torch.cuda.set_device(0)
+        stream = torch.cuda.Stream()
+        with torch.cuda.stream(stream):
+            torch.cuda.synchronize()
+"""
+    tree = ast.parse(code)
+    linter = TorchCudaLinter("test.py")
+    linter.visit(tree)
+
+    assert len(linter.issues) == 6
+    print("✓ test_complex_usage passed")
+
+
+def test_lint_file_integration():
+    """Test the lint_file function with a temporary file."""
+    code = """
+import torch
+
+if torch.cuda.is_available():
+    stream = torch.cuda.Stream()
+"""
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(code)
+        temp_path = Path(f.name)
+
+    try:
+        issues = lint_file(temp_path)
+        assert len(issues) == 2
+        print("✓ test_lint_file_integration passed")
+    finally:
+        temp_path.unlink()
+
+
+def test_no_duplicate_reports():
+    """Test that the same position is not reported multiple times."""
+    code = """
+import torch
+
+if torch.cuda.is_available():
+    pass
+"""
+    tree = ast.parse(code)
+    linter = TorchCudaLinter("test.py")
+    linter.visit(tree)
+
+    # Should only report once, not for both torch.cuda and torch.cuda.is_available
+    # at overlapping positions
+    positions = [(line, col) for line, col, _, _ in linter.issues]
+    assert len(positions) == len(set(positions)), "Duplicate positions found"
+    print("✓ test_no_duplicate_reports passed")
+
+
+def test_apply_fixes():
+    """Test that apply_fixes correctly replaces torch.cuda with torch.accelerator."""
+    code = """import torch
+
+def check_device():
+    if torch.cuda.is_available():
+        device_count = torch.cuda.device_count()
+        current = torch.cuda.current_device()
+        torch.cuda.synchronize()
+        return True
+    return False
+"""
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(code)
+        temp_path = Path(f.name)
+
+    try:
+        # First lint to get issues
+        issues = lint_file(temp_path)
+        assert len(issues) > 0, "Should find issues"
+
+        # Apply fixes
+        result = apply_fixes(temp_path, issues)
+        assert result is True, "Fixes should be applied"
+
+        # Read the fixed content
+        with open(temp_path, "r") as f:
+            fixed_code = f.read()
+
+        # Verify torch.cuda is replaced with torch.accelerator
+        assert "torch.cuda" not in fixed_code, "torch.cuda should be replaced"
+        assert "torch.accelerator" in fixed_code, "torch.accelerator should be present"
+
+        # Verify no more issues after fix
+        issues_after = lint_file(temp_path)
+        assert len(issues_after) == 0, "Should have no issues after fix"
+
+        print("✓ test_apply_fixes passed")
+    finally:
+        temp_path.unlink()
+
+
+def run_all_tests():
+    """Run all test functions."""
+    print("Running torch.cuda linter tests...\n")
+
+    tests = [
+        test_detect_torch_cuda_is_available,
+        test_detect_torch_cuda_stream,
+        test_detect_torch_cuda_event,
+        test_detect_torch_cuda_context_manager,
+        test_detect_memory_functions,
+        test_detect_from_import,
+        test_ignore_non_cuda_torch,
+        test_complex_usage,
+        test_lint_file_integration,
+        test_no_duplicate_reports,
+        test_apply_fixes,
+    ]
+
+    failed = []
+    for test in tests:
+        try:
+            test()
+        except AssertionError as e:
+            print(f"✗ {test.__name__} failed: {e}")
+            failed.append(test.__name__)
+        except Exception as e:
+            print(f"✗ {test.__name__} errored: {e}")
+            failed.append(test.__name__)
+
+    print(f"\n{'='*60}")
+    print(f"Tests passed: {len(tests) - len(failed)}/{len(tests)}")
+    if failed:
+        print(f"Failed tests: {', '.join(failed)}")
+        sys.exit(1)
+    else:
+        print("All tests passed! ✓")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    run_all_tests()

--- a/tests/test_tools/test_lint_cuda.py
+++ b/tests/test_tools/test_lint_cuda.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 """
 Test suite for the torch.cuda linter.
 
@@ -273,7 +277,7 @@ def run_all_tests():
             print(f"✗ {test.__name__} errored: {e}")
             failed.append(test.__name__)
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Tests passed: {len(tests) - len(failed)}/{len(tests)}")
     if failed:
         print(f"Failed tests: {', '.join(failed)}")

--- a/tools/lint_cuda.py
+++ b/tools/lint_cuda.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""
+Linter to detect torch.cuda usage and suggest torch.accelerator API instead.
+
+This linter scans Python files for direct torch.cuda API calls and recommends
+using the torch.accelerator API for better device abstraction and portability.
+"""
+
+import ast
+import argparse
+import sys
+import warnings
+from pathlib import Path
+from typing import List, Tuple, Optional
+
+
+class TorchCudaLinter(ast.NodeVisitor):
+    """AST visitor to detect torch.cuda usage."""
+
+    def __init__(self, filename: str):
+        self.filename = filename
+        self.issues: List[Tuple[int, int, str, str]] = []
+        self.reported_positions = set()  # Track (line, col) to avoid duplicates
+        self.torch_cuda_suggestions = {
+            "torch.cuda.is_available": "torch.accelerator.is_available",
+            "torch.cuda.device_count": "torch.accelerator.device_count",
+            "torch.cuda.current_device": "torch.accelerator.current_device_index",
+            "torch.cuda.current_stream": "torch.accelerator.current_stream",
+            "torch.cuda.set_device": "torch.accelerator.set_device_index",
+            "torch.cuda.synchronize": "torch.accelerator.synchronize",
+            "torch.cuda.Stream": "torch.Stream",
+            "torch.cuda.stream": "torch.Stream",
+            "torch.cuda.Event": "torch.Event",
+            "torch.cuda.memory_allocated": "torch.accelerator.memory_allocated",
+            "torch.cuda.memory_reserved": "torch.accelerator.memory_reserved",
+            "torch.cuda.empty_cache": "torch.accelerator.empty_cache",
+            "torch.cuda.max_memory_allocated": "torch.accelerator.max_memory_allocated",
+            "torch.cuda.reset_peak_memory_stats": "torch.accelerator.reset_peak_memory_stats",
+        }
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        """Visit attribute access nodes (e.g., torch.cuda.is_available)."""
+        # Build the full attribute chain
+        full_attr = self._get_full_attribute(node)
+
+        # Only report the outermost torch.cuda usage to avoid duplicates
+        if full_attr and full_attr.startswith("torch.cuda"):
+            position = (node.lineno, node.col_offset)
+            if position not in self.reported_positions:
+                suggestion = self._get_suggestion(full_attr)
+                self.issues.append((
+                    node.lineno,
+                    node.col_offset,
+                    full_attr,
+                    suggestion
+                ))
+                self.reported_positions.add(position)
+
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        """Visit 'from torch.cuda import ...' statements."""
+        if node.module and node.module.startswith("torch.cuda"):
+            for alias in node.names:
+                imported_name = alias.name
+                self.issues.append((
+                    node.lineno,
+                    node.col_offset,
+                    f"from {node.module} import {imported_name}",
+                    f"Consider using 'from torch.accelerator import {imported_name}' instead"
+                ))
+
+        self.generic_visit(node)
+
+    def _get_full_attribute(self, node: ast.AST) -> Optional[str]:
+        """Recursively build the full attribute chain (e.g., torch.cuda.is_available)."""
+        if isinstance(node, ast.Name):
+            return node.id
+        elif isinstance(node, ast.Attribute):
+            parent = self._get_full_attribute(node.value)
+            if parent:
+                return f"{parent}.{node.attr}"
+        return None
+
+    def _get_suggestion(self, cuda_call: str) -> str:
+        """Get the appropriate torch.accelerator suggestion for a torch.cuda call."""
+        # Check for partial matches (e.g., torch.cuda.foo.bar)
+        for cuda_api, suggestion in self.torch_cuda_suggestions.items():
+            if cuda_call.startswith(cuda_api):
+                return suggestion
+
+        # Generic suggestion
+        return cuda_call.replace("torch.cuda", "torch.get_device_module()")
+
+
+def apply_fixes(filepath: Path, issues: List[Tuple[int, int, str, str]], verbose: bool = False) -> bool:
+    """
+    Apply automatic fixes to a file using the suggested replacements.
+
+    Args:
+        filepath: Path to the Python file to fix
+        issues: List of issues to fix (line, col, usage, suggestion)
+        verbose: Whether to print verbose output
+
+    Returns:
+        True if fixes were applied, False otherwise
+    """
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+
+        # Group issues by line to handle multiple issues on the same line
+        issues_by_line = {}
+        for line_num, col_offset, usage, suggestion in issues:
+            if line_num not in issues_by_line:
+                issues_by_line[line_num] = []
+            issues_by_line[line_num].append((col_offset, usage, suggestion))
+
+        modified = False
+        changes_made = []  # Track what actually changed for warning message
+
+        # Process lines in reverse order to maintain positions
+        for line_num in sorted(issues_by_line.keys(), reverse=True):
+            if line_num > len(lines):
+                continue
+
+            line_idx = line_num - 1
+            original_line = lines[line_idx]
+            new_line = original_line
+
+            # Apply each suggested fix on this line
+            # Sort by column offset in reverse to maintain positions during replacement
+            sorted_issues = sorted(issues_by_line[line_num], key=lambda x: x[0], reverse=True)
+
+            for col_offset, usage, suggestion in sorted_issues:
+                # Apply the suggested replacement
+                if usage in new_line:
+                    new_line = new_line.replace(usage, suggestion, 1)
+                    if verbose:
+                        print(f"  Fixed line {line_num}: {usage} → {suggestion}")
+
+            if new_line != original_line:
+                lines[line_idx] = new_line
+                modified = True
+                # Track unique changes for the summary
+                for _, usage, suggestion in sorted_issues:
+                    change = (usage, suggestion)
+                    if change not in changes_made:
+                        changes_made.append(change)
+
+        if modified:
+            with open(filepath, "w", encoding="utf-8") as f:
+                f.writelines(lines)
+
+            # Print warning about what changed
+            print(f"\n⚠️  Applied fixes to {filepath}:")
+            for usage, suggestion in changes_made:
+                print(f"   {usage} → {suggestion}")
+            print()
+
+            return True
+        return False
+
+    except Exception as e:
+        if verbose:
+            print(f"Error applying fixes to {filepath}: {e}", file=sys.stderr)
+        return False
+
+
+def lint_file(filepath: Path, verbose: bool = False) -> List[Tuple[int, int, str, str]]:
+    """
+    Lint a single Python file for torch.cuda usage.
+
+    Args:
+        filepath: Path to the Python file to lint
+        verbose: Whether to print verbose output
+
+    Returns:
+        List of issues found (line, col, usage, suggestion)
+    """
+    try:
+        with open(filepath, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Suppress SyntaxWarnings (e.g., invalid escape sequences) from parsed files
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=SyntaxWarning)
+            tree = ast.parse(content, filename=str(filepath))
+
+        linter = TorchCudaLinter(str(filepath))
+        linter.visit(tree)
+
+        return linter.issues
+    except SyntaxError as e:
+        if verbose:
+            print(f"Syntax error in {filepath}: {e}", file=sys.stderr)
+        return []
+    except Exception as e:
+        if verbose:
+            print(f"Error processing {filepath}: {e}", file=sys.stderr)
+        return []
+
+
+def lint_directory(directory: Path, verbose: bool = False) -> dict:
+    """
+    Recursively lint all Python files in a directory.
+
+    Args:
+        directory: Path to directory to lint
+        verbose: Whether to print verbose output
+
+    Returns:
+        Dictionary mapping filenames to lists of issues
+    """
+    all_issues = {}
+
+    for py_file in directory.rglob("*.py"):
+        issues = lint_file(py_file, verbose=verbose)
+        if issues:
+            all_issues[str(py_file)] = issues
+
+    return all_issues
+
+
+def print_issues(all_issues: dict, verbose: bool = False) -> int:
+    """
+    Print linting issues in a readable format.
+
+    Args:
+        all_issues: Dictionary mapping filenames to lists of issues
+        verbose: Whether to print in verbose mode
+
+    Returns:
+        Number of total issues found
+    """
+    total_issues = 0
+
+    for filename, issues in sorted(all_issues.items()):
+        print(f"\n{filename}")
+        for line, col, usage, suggestion in issues:
+            total_issues += 1
+            print(f"  Line {line}, Col {col}: {usage}")
+            print(f"    → Suggestion: Use '{suggestion}' instead")
+            if verbose:
+                print(f"    → Reason: torch.accelerator provides better device abstraction")
+
+    return total_issues
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Lint Python files for torch.cuda usage and suggest torch.accelerator alternatives"
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        type=Path,
+        help="Files or directories to lint"
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Verbose output"
+    )
+    parser.add_argument(
+        "--fail-on-issues",
+        action="store_true",
+        help="Exit with non-zero status if issues are found"
+    )
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Automatically apply fixes by replacing torch.cuda with torch.accelerator"
+    )
+
+    args = parser.parse_args()
+
+    all_issues = {}
+
+    for path in args.paths:
+        if not path.exists():
+            print(f"Error: Path '{path}' does not exist", file=sys.stderr)
+            continue
+
+        if path.is_file():
+            if path.suffix == ".py":
+                issues = lint_file(path, verbose=args.verbose)
+                if issues:
+                    all_issues[str(path)] = issues
+        elif path.is_dir():
+            dir_issues = lint_directory(path, verbose=args.verbose)
+            all_issues.update(dir_issues)
+
+    if all_issues:
+        if args.fix:
+            # Fix mode: apply automatic fixes
+            fixed_files = 0
+            total_issues = 0
+
+            print(f"{'='*70}")
+            print("Fixing `torch.cuda` to `torch.accelerator`...")
+            print(f"{'='*70}\n")
+
+            for filename, issues in sorted(all_issues.items()):
+                total_issues += len(issues)
+                if apply_fixes(Path(filename), issues, verbose=args.verbose):
+                    fixed_files += 1
+
+            print(f"{'='*70}")
+            print(f"✓ Fixed {total_issues} issue(s) across {fixed_files} file(s)")
+            print(
+                "  Please check that the applied changes "
+                "do not break device-specific functionality"
+            )
+            print(f"{'='*70}")
+
+        else:
+            # Check mode: just report issues
+            total_issues = print_issues(all_issues, verbose=args.verbose)
+            print()
+            print(f"{'='*70}")
+            print("\nℹ️  torch.accelerator provides better device abstraction and portability")
+            print("   compared to direct torch.cuda calls. It supports multiple backends")
+            print("   (CUDA, XPU, MPS, etc.) with a unified API.")
+            print()
+            print(f"{'='*70}")
+
+            if args.fail_on_issues:
+                sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose ##
* Ensure that code in compressed-tensors is compliant with the `torch.accelerator` api, which is superior to `torch.cuda` due to it being compatible with the XPU interface

## Example ##
```
$ make quality
Running copyright checks
...
Running python quality checks
black --target-version py310 --check src tests;
All done! ✨ 🍰 ✨
isort --check-only src tests;
flake8 src tests;
python tools/lint_cuda.py src tests --fail-on-issues;

src/compressed_tensors/transform/factory/matrix_multiply.py
  Line 120, Col 41: torch.cuda.is_available
    → Suggestion: Use 'torch.accelerator.is_available' instead

======================================================================

ℹ️  torch.accelerator provides better device abstraction and portability
   compared to direct torch.cuda calls. It supports multiple backends
   (CUDA, XPU, MPS, etc.) with a unified API.

======================================================================
```
```
$ make style
Running copyright checks
...
Running python styling
black --target-version py310 src tests;
All done! ✨ 🍰 ✨
isort src tests;
python tools/lint_cuda.py src tests --fix
======================================================================
Fixing `torch.cuda` to `torch.accelerator`...
======================================================================


⚠️  Applied fixes to src/compressed_tensors/transform/factory/matrix_multiply.py:
   torch.cuda.is_available → torch.accelerator.is_available

======================================================================
✓ Fixed 1 issue(s) across 1 file(s)
  Please check that the applied changes do not break device-specific functionality
======================================================================
```