### PR TITLE
[Bugfix] Remove unreachable GROUP+dynamic activation validation branch

### DIFF
--- a/src/compressed_tensors/quantization/quant_scheme.py
+++ b/src/compressed_tensors/quantization/quant_scheme.py
@@ -57,15 +57,6 @@ class QuantizationScheme(BaseModel, use_enum_values=True):
                 QuantizationStrategy.TENSOR_GROUP,
                 QuantizationStrategy.ATTN_HEAD,
             ):
-                if (
-                    inputs.strategy == QuantizationStrategy.GROUP
-                    and inputs.dynamic is True
-                ):
-                    raise NotImplementedError(
-                        "Static and local group-wise activation "
-                        "quantization is not supported"
-                    )
-
                 raise NotImplementedError(
                     f"Using {inputs.strategy} strategy is not supported for "
                     "activation quantization"

--- a/tests/test_quantization/test_quant_scheme.py
+++ b/tests/test_quantization/test_quant_scheme.py
@@ -2,7 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
-from compressed_tensors.quantization import QuantizationArgs, QuantizationScheme
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationScheme,
+    QuantizationStrategy,
+)
 from pydantic import ValidationError
 
 
@@ -36,6 +40,36 @@ def test_full_scheme():
     assert scheme.input_activations == input_activations
     assert scheme.output_activations == output_activations
     assert scheme.format == "float-quantized"
+
+
+def test_group_dynamic_input_activations_supported():
+    # GROUP strategy dynamic input activations are handled by
+    # compute_dynamic_scales_and_zp, so scheme validation must accept them
+    # rather than rejecting with a "not supported" error (#758).
+    input_activations = QuantizationArgs(
+        num_bits=8,
+        strategy=QuantizationStrategy.GROUP,
+        group_size=128,
+        dynamic=True,
+    )
+    scheme = QuantizationScheme(
+        targets=["Linear"],
+        weights=QuantizationArgs(num_bits=4, group_size=128),
+        input_activations=input_activations,
+    )
+    assert scheme.input_activations.strategy == QuantizationStrategy.GROUP
+    assert scheme.input_activations.dynamic is True
+
+
+def test_unsupported_activation_strategy_still_rejected():
+    # activation strategies outside the supported set remain rejected
+    with pytest.raises(NotImplementedError):
+        QuantizationScheme(
+            targets=["Linear"],
+            input_activations=QuantizationArgs(
+                num_bits=8, strategy=QuantizationStrategy.CHANNEL
+            ),
+        )
 
 
 def test_needs_targets():


### PR DESCRIPTION
## Purpose

Fixes #758. `QuantizationScheme.validate_model_after` has an inner check that raises `"Static and local group-wise activation quantization is not supported"` for GROUP + dynamic input activations:

```python
if inputs.strategy not in (TOKEN, TENSOR, GROUP, TENSOR_GROUP, ATTN_HEAD):
    if inputs.strategy == QuantizationStrategy.GROUP and inputs.dynamic is True:
        raise NotImplementedError("Static and local group-wise activation ...")
    raise NotImplementedError(f"Using {inputs.strategy} strategy is not supported ...")
```

`GROUP` is in the allowed set of the outer `not in (...)`, so the inner branch is unreachable dead code. It is also incorrect: GROUP strategy dynamic activations are handled by `compute_dynamic_scales_and_zp` (`quantization/utils/helpers.py`), which reshapes into groups for both `GROUP` and `TENSOR_GROUP`. This removes the dead, misleading branch. The outer check that rejects genuinely unsupported activation strategies (e.g. `channel`) is unchanged.

## Test Plan / Test Result

`pytest tests/test_quantization/test_quant_scheme.py` passes (7 tests, 2 added):

```
tests/test_quantization/test_quant_scheme.py .......  [100%]  7 passed
```

- `test_group_dynamic_input_activations_supported`: a GROUP + `dynamic=True` input-activation scheme validates.
- `test_unsupported_activation_strategy_still_rejected`: a `channel` input-activation strategy still raises `NotImplementedError`.

Built with an AI-assisted engineering workflow (Claude) under my direction: I specified the design, reviewed each iteration, and validated the profiling and test results. Co-authored-by trailer on the commit.
