### PR TITLE
[Performance] Triton implementation for `cast_to_fp4`

### DIFF
--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -53,29 +53,18 @@ class FP4_E2M1_DATA(FloatArgs):
     min = -6.0
 
     @staticmethod
-    def cast_to_fp4(x):
-        # torch.compile guards on input rank, so rank-varying inputs (dense /
-        # MoE-expert / group-scaled activations) recompile the core once per
-        # rank and exhaust recompile_limit (#734). Flatten to rank-1 so the core
-        # (kept compiled per PR #331) is reused; flatten() keeps a stable 1-D size
-        # symbol that automatic dynamic shapes promotes, whereas reshape(-1)
-        # infers a rank-dependent numel that defeats it.
-        return FP4_E2M1_DATA._cast_to_fp4(x.flatten()).reshape(x.shape)
+    def cast_to_fp4(x: torch.Tensor):
+        """Round float values to the nearest E2M1 representable value.
 
-    @staticmethod
-    @torch.compile
-    def _cast_to_fp4(x):
-        sign = torch.sign(x)
-        x = torch.abs(x)
-        x[(x >= 0.0) & (x <= 0.25)] = 0.0
-        x[(x > 0.25) & (x < 0.75)] = 0.5
-        x[(x >= 0.75) & (x <= 1.25)] = 1.0
-        x[(x > 1.25) & (x < 1.75)] = 1.5
-        x[(x >= 1.75) & (x <= 2.5)] = 2.0
-        x[(x > 2.5) & (x < 3.5)] = 3.0
-        x[(x >= 3.5) & (x <= 5.0)] = 4.0
-        x[x > 5.0] = 6.0
-        return x * sign
+        Uses Triton for GPU tensors and torch.compile for CPU tensors.
+
+        :param x: input tensor to quantize
+        :param tile_size: block size for Triton kernel (default 128K)
+        :return: FP4-quantized tensor with same shape as input
+        """
+        from compressed_tensors.quantization.utils.fp4_utils import cast_to_fp4
+
+        return cast_to_fp4(x)
 
 
 class FP8_E4M3_DATA(FloatArgs):

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -3,7 +3,7 @@
 
 import warnings
 from enum import Enum
-from typing import Any, Optional
+from typing import Any
 
 import torch
 from compressed_tensors.utils import Aliasable

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -3,7 +3,7 @@
 
 import warnings
 from enum import Enum
-from typing import Any
+from typing import Any, Optional
 
 import torch
 from compressed_tensors.utils import Aliasable
@@ -53,18 +53,28 @@ class FP4_E2M1_DATA(FloatArgs):
     min = -6.0
 
     @staticmethod
-    def cast_to_fp4(x: torch.Tensor):
+    def cast_to_fp4(x: torch.Tensor, backend: str = "triton"):
         """Round float values to the nearest E2M1 representable value.
 
         Uses Triton for GPU tensors and torch.compile for CPU tensors.
 
         :param x: input tensor to quantize
-        :param tile_size: block size for Triton kernel (default 128K)
-        :return: FP4-quantized tensor with same shape as input
+        :param backend: "eager" or "triton". CPU/ Meta tensors will always use "eager"
+        :return: input tensor after rounding to fp4 (maintains same dtype)
         """
-        from compressed_tensors.quantization.utils.fp4_utils import cast_to_fp4
+        from compressed_tensors.quantization.utils.fp4_utils import (
+            cast_to_fp4_torch,
+            cast_to_fp4_triton,
+        )
 
-        return cast_to_fp4(x)
+        if backend == "torch" or x.device.type in ("cpu", "meta"):
+            return cast_to_fp4_torch(x)
+
+        elif backend == "triton":
+            return cast_to_fp4_triton(x)
+
+        else:
+            raise ValueError(f"Unknown backend {backend}")
 
 
 class FP8_E4M3_DATA(FloatArgs):

--- a/src/compressed_tensors/quantization/quant_args.py
+++ b/src/compressed_tensors/quantization/quant_args.py
@@ -67,7 +67,7 @@ class FP4_E2M1_DATA(FloatArgs):
             cast_to_fp4_triton,
         )
 
-        if backend == "torch" or x.device.type in ("cpu", "meta"):
+        if backend == "torch" or x.device.type in ("cpu", "meta", "mps"):
             return cast_to_fp4_torch(x)
 
         elif backend == "triton":

--- a/src/compressed_tensors/quantization/utils/__init__.py
+++ b/src/compressed_tensors/quantization/utils/__init__.py
@@ -2,5 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 # flake8: noqa
+from .fp4_utils import *
 from .helpers import *
 from .mxfp_utils import *

--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import torch
+import torch.compiler
 import triton
 import triton.language as tl
 
@@ -49,6 +50,7 @@ def _cast_to_fp4_kernel(
     tl.store(output_ptr + offsets, result, mask=mask)
 
 
+@torch.compile(dynamic=True)
 def _cast_to_fp4_cpu(x):
     """
     CPU implementation for FP4 E2M1 quantization
@@ -97,7 +99,7 @@ def cast_to_fp4(x: torch.Tensor) -> torch.Tensor:
             block_size = 1024
 
             # Use tile_size as BLOCK_SIZE for Triton kernel
-            grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]),)
+            grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]),)  # noqa: E731
             _cast_to_fp4_kernel[grid](x, output, n, BLOCK_SIZE=block_size)
 
             return output.reshape(shape)

--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+import triton
+import triton.language as tl
+
+
+__all__ = ["cast_to_fp4"]
+
+
+@triton.jit
+def _cast_to_fp4_kernel(
+    input_ptr,
+    output_ptr,
+    n,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    Triton kernel for FP4 E2M1 quantization.
+
+    Maps float values to the nearest E2M1 representable value:
+    0.0, ±0.5, ±1.0, ±1.5, ±2.0, ±3.0, ±4.0, ±6.0
+    """
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n
+
+    x = tl.load(input_ptr + offsets, mask=mask, other=0.0)
+
+    # Extract sign and absolute value
+    sign = tl.where(x < 0.0, -1.0, 1.0)
+    abs_x = tl.abs(x)
+
+    # Map absolute values to FP4 representable values
+    # Using sequential tl.where for the quantization mapping
+    result = tl.zeros_like(abs_x)
+    result = tl.where(abs_x > 0.25, 0.5, result)
+    result = tl.where(abs_x >= 0.75, 1.0, result)
+    result = tl.where(abs_x > 1.25, 1.5, result)
+    result = tl.where(abs_x >= 1.75, 2.0, result)
+    result = tl.where(abs_x > 2.5, 3.0, result)
+    result = tl.where(abs_x >= 3.5, 4.0, result)
+    result = tl.where(abs_x > 5.0, 6.0, result)
+
+    # Restore sign
+    result *= sign
+    tl.store(output_ptr + offsets, result, mask=mask)
+
+
+def _cast_to_fp4_cpu(x):
+    """
+    CPU implementation for FP4 E2M1 quantization
+
+    Maps float values to the nearest E2M1 representable value:
+    0.0, ±0.5, ±1.0, ±1.5, ±2.0, ±3.0, ±4.0, ±6.0
+    """
+    sign = torch.where(x < 0.0, -1.0, 1.0)
+    abs_x = torch.abs(x)
+
+    # Map absolute values to FP4 representable values
+    # Using sequential torch.where for readability while maintaining memory efficiency
+    result = torch.zeros_like(abs_x)
+    result = torch.where(abs_x > 0.25, 0.5, result)
+    result = torch.where(abs_x >= 0.75, 1.0, result)
+    result = torch.where(abs_x > 1.25, 1.5, result)
+    result = torch.where(abs_x >= 1.75, 2.0, result)
+    result = torch.where(abs_x > 2.5, 3.0, result)
+    result = torch.where(abs_x >= 3.5, 4.0, result)
+    result = torch.where(abs_x > 5.0, 6.0, result)
+
+    return result * sign
+
+
+def cast_to_fp4(x: torch.Tensor):
+    """Round float values to the nearest E2M1 representable value.
+
+    Uses Triton for GPU tensors and torch.compile for CPU tensors.
+
+    :param x: input tensor to quantize
+    :param tile_size: block size for Triton kernel (default 128K)
+    :return: FP4-quantized tensor with same shape as input
+    """
+    shape = x.shape
+    x = x.flatten()
+
+    match x.device.type:
+        case "cpu" | "meta":
+            return _cast_to_fp4_cpu(x).reshape(shape)
+        
+        case _:
+            output = torch.empty_like(x)
+            n = x.numel()
+            block_size = 1024
+
+            # Use tile_size as BLOCK_SIZE for Triton kernel
+            grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]),)
+
+            _cast_to_fp4_kernel[grid](
+                x,
+                output,
+                n,
+                BLOCK_SIZE=block_size,
+            )
+
+            return output.reshape(shape)

--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import torch
-import torch.compiler
 import triton
 import triton.language as tl
 
@@ -23,13 +22,11 @@ def _cast_to_fp4_kernel(
     mask = offsets < n
 
     x = tl.load(input_ptr + offsets, mask=mask, other=0.0)
+    x = x.to(tl.bfloat16)
 
-    # Extract sign and absolute value
-    sign = tl.where(x < 0.0, -1.0, 1.0)
+    sign_bit = x.to(tl.int16, bitcast=True) & (-32768)
     abs_x = tl.abs(x)
 
-    # Map absolute values to FP4 representable values
-    # Using sequential tl.where for the quantization mapping
     result = tl.zeros_like(abs_x)
     result = tl.where(abs_x > 0.25, 0.5, result)
     result = tl.where(abs_x >= 0.75, 1.0, result)
@@ -39,8 +36,9 @@ def _cast_to_fp4_kernel(
     result = tl.where(abs_x >= 3.5, 4.0, result)
     result = tl.where(abs_x > 5.0, 6.0, result)
 
-    # Restore sign
-    result *= sign
+    result = (result.to(tl.int16, bitcast=True) | sign_bit).to(
+        tl.bfloat16, bitcast=True
+    )
     tl.store(output_ptr + offsets, result, mask=mask)
 
 
@@ -52,7 +50,7 @@ def cast_to_fp4_triton(x: torch.Tensor) -> torch.Tensor:
     0.0, ±0.5, ±1.0, ±1.5, ±2.0, ±3.0, ±4.0, ±6.0
     """
     shape = x.shape
-    x = x.flatten()
+    x = x.contiguous().flatten()
     output = torch.empty_like(x)
     n = x.numel()
     block_size = 1024
@@ -65,21 +63,11 @@ def cast_to_fp4_triton(x: torch.Tensor) -> torch.Tensor:
 
 
 @torch.compile(dynamic=True)
-def cast_to_fp4_torch(x):
-    """
-    CPU implementation for FP4 E2M1 quantization
-
-    Maps float values to the nearest E2M1 representable value:
-    0.0, ±0.5, ±1.0, ±1.5, ±2.0, ±3.0, ±4.0, ±6.0
-    """
-    sign = torch.empty_like(x)
-    torch.sign(x, out=sign)
+def _cast_to_fp4_torch_impl(x):
+    sign = torch.sign(x)
     abs_x = torch.abs(x)
 
-    # Map absolute values to FP4 representable values
-    # Using sequential torch.where for readability while maintaining memory efficiency
-    result = torch.empty_like(x)
-    result = torch.where(abs_x <= 0.25, 0.0, result)
+    result = torch.where(abs_x <= 0.25, 0.0, torch.empty_like(x))
     result = torch.where(abs_x > 0.25, 0.5, result)
     result = torch.where(abs_x >= 0.75, 1.0, result)
     result = torch.where(abs_x > 1.25, 1.5, result)
@@ -88,4 +76,15 @@ def cast_to_fp4_torch(x):
     result = torch.where(abs_x >= 3.5, 4.0, result)
     result = torch.where(abs_x > 5.0, 6.0, result)
 
-    return result * sign.to(result)
+    return result * sign
+
+
+def cast_to_fp4_torch(x):
+    """
+    CPU implementation for FP4 E2M1 quantization
+
+    Maps float values to the nearest E2M1 representable value:
+    0.0, ±0.5, ±1.0, ±1.5, ±2.0, ±3.0, ±4.0, ±6.0
+    """
+    orig_dtype = x.dtype
+    return _cast_to_fp4_torch_impl(x.to(torch.bfloat16)).to(orig_dtype)

--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -7,7 +7,7 @@ import triton
 import triton.language as tl
 
 
-__all__ = ["cast_to_fp4"]
+__all__ = ["cast_to_fp4_triton", "cast_to_fp4_torch"]
 
 
 @triton.jit
@@ -17,12 +17,6 @@ def _cast_to_fp4_kernel(
     n,
     BLOCK_SIZE: tl.constexpr,
 ):
-    """
-    Triton kernel for FP4 E2M1 quantization.
-
-    Maps float values to the nearest E2M1 representable value:
-    0.0, ±0.5, ±1.0, ±1.5, ±2.0, ±3.0, ±4.0, ±6.0
-    """
     pid = tl.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
     offsets = block_start + tl.arange(0, BLOCK_SIZE)
@@ -50,8 +44,28 @@ def _cast_to_fp4_kernel(
     tl.store(output_ptr + offsets, result, mask=mask)
 
 
+def cast_to_fp4_triton(x: torch.Tensor) -> torch.Tensor:
+    """
+    Triton implementation for FP4 E2M1 quantization
+
+    Maps float values to the nearest E2M1 representable value:
+    0.0, ±0.5, ±1.0, ±1.5, ±2.0, ±3.0, ±4.0, ±6.0
+    """
+    shape = x.shape
+    x = x.flatten()
+    output = torch.empty_like(x)
+    n = x.numel()
+    block_size = 1024
+
+    # Use tile_size as BLOCK_SIZE for Triton kernel
+    grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]),)  # noqa: E731
+    _cast_to_fp4_kernel[grid](x, output, n, BLOCK_SIZE=block_size)
+
+    return output.reshape(shape)
+
+
 @torch.compile(dynamic=True)
-def _cast_to_fp4_cpu(x):
+def cast_to_fp4_torch(x):
     """
     CPU implementation for FP4 E2M1 quantization
 
@@ -75,31 +89,3 @@ def _cast_to_fp4_cpu(x):
     result = torch.where(abs_x > 5.0, 6.0, result)
 
     return result * sign.to(result)
-
-
-def cast_to_fp4(x: torch.Tensor) -> torch.Tensor:
-    """Round float values to the nearest E2M1 representable value.
-
-    Uses Triton for GPU tensors and torch.compile for CPU tensors.
-
-    :param x: input tensor to quantize
-    :param tile_size: block size for Triton kernel (default 128K)
-    :return: FP4-quantized tensor with same shape as input
-    """
-    shape = x.shape
-    x = x.flatten()
-
-    match x.device.type:
-        case "cpu" | "meta":
-            return _cast_to_fp4_cpu(x).reshape(shape)
-
-        case _:
-            output = torch.empty_like(x)
-            n = x.numel()
-            block_size = 1024
-
-            # Use tile_size as BLOCK_SIZE for Triton kernel
-            grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]),)  # noqa: E731
-            _cast_to_fp4_kernel[grid](x, output, n, BLOCK_SIZE=block_size)
-
-            return output.reshape(shape)

--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -56,12 +56,14 @@ def _cast_to_fp4_cpu(x):
     Maps float values to the nearest E2M1 representable value:
     0.0, ±0.5, ±1.0, ±1.5, ±2.0, ±3.0, ±4.0, ±6.0
     """
-    sign = torch.where(x < 0.0, -1.0, 1.0)
+    sign = torch.empty_like(x)
+    torch.sign(x, out=sign)
     abs_x = torch.abs(x)
 
     # Map absolute values to FP4 representable values
     # Using sequential torch.where for readability while maintaining memory efficiency
-    result = torch.zeros_like(abs_x)
+    result = torch.empty_like(x)
+    result = torch.where(abs_x <= 0.25, 0.0, result)
     result = torch.where(abs_x > 0.25, 0.5, result)
     result = torch.where(abs_x >= 0.75, 1.0, result)
     result = torch.where(abs_x > 1.25, 1.5, result)
@@ -70,10 +72,10 @@ def _cast_to_fp4_cpu(x):
     result = torch.where(abs_x >= 3.5, 4.0, result)
     result = torch.where(abs_x > 5.0, 6.0, result)
 
-    return result * sign
+    return result * sign.to(result)
 
 
-def cast_to_fp4(x: torch.Tensor):
+def cast_to_fp4(x: torch.Tensor) -> torch.Tensor:
     """Round float values to the nearest E2M1 representable value.
 
     Uses Triton for GPU tensors and torch.compile for CPU tensors.
@@ -88,7 +90,7 @@ def cast_to_fp4(x: torch.Tensor):
     match x.device.type:
         case "cpu" | "meta":
             return _cast_to_fp4_cpu(x).reshape(shape)
-        
+
         case _:
             output = torch.empty_like(x)
             n = x.numel()
@@ -96,12 +98,6 @@ def cast_to_fp4(x: torch.Tensor):
 
             # Use tile_size as BLOCK_SIZE for Triton kernel
             grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]),)
-
-            _cast_to_fp4_kernel[grid](
-                x,
-                output,
-                n,
-                BLOCK_SIZE=block_size,
-            )
+            _cast_to_fp4_kernel[grid](x, output, n, BLOCK_SIZE=block_size)
 
             return output.reshape(shape)

--- a/tests/test_quantization/test_quant_args.py
+++ b/tests/test_quantization/test_quant_args.py
@@ -2,17 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import pytest
-import torch
-import torch._dynamo
 from compressed_tensors.quantization import (
     ActivationOrdering,
     QuantizationArgs,
     QuantizationStrategy,
     QuantizationType,
 )
-from compressed_tensors.quantization.quant_args import FP4_E2M1_DATA
 from pydantic import ValidationError
-from torch._dynamo.utils import counters
 
 
 def test_defaults():

--- a/tests/test_quantization/test_quant_args.py
+++ b/tests/test_quantization/test_quant_args.py
@@ -182,38 +182,3 @@ def test_serialize_args():
     # Deserialize from dict
     reloaded = QuantizationArgs.model_validate(args_dict)
     assert reloaded == args
-
-
-def test_cast_to_fp4_no_recompile_across_ranks():
-    # https://github.com/vllm-project/compressed-tensors/issues/734
-    # rank-varying inputs must not recompile the compiled fp4 rounding core
-    torch._dynamo.reset()
-    counters.clear()
-
-    for shape in [(16,), (4, 16), (2, 4, 16), (2, 2, 4, 16), (2, 2, 2, 4, 16)]:
-        FP4_E2M1_DATA.cast_to_fp4(torch.randn(*shape))
-
-    # must not grow one graph per rank: pre-fix this hit 5 (one per distinct
-    # rank) and exhausted recompile_limit; the fix keeps it bounded. Lower
-    # bound guards against a vacuous pass if the compiled core never runs.
-    assert 1 <= counters["stats"]["unique_graphs"] < 5
-
-
-def test_cast_to_fp4_boundary_values():
-    x = torch.tensor(
-        [0.0, 0.25, 0.5, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0, 7.0, -0.75, -3.5]
-    )
-    expected = torch.tensor(
-        [0.0, 0.0, 0.5, 1.0, 1.0, 2.0, 2.0, 4.0, 4.0, 6.0, -1.0, -4.0]
-    )
-    assert torch.equal(FP4_E2M1_DATA.cast_to_fp4(x), expected)
-
-    x = torch.randn(2, 3, 4, 5)
-    assert FP4_E2M1_DATA.cast_to_fp4(x).shape == x.shape
-
-
-def test_cast_to_fp4_degenerate_shapes():
-    # MoE experts can receive zero routed tokens -> numel 0 activations
-    for t in [torch.randn(0), torch.randn(1), torch.tensor(3.0), torch.randn(1, 0, 4)]:
-        out = FP4_E2M1_DATA.cast_to_fp4(t)
-        assert out.shape == t.shape

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -3,7 +3,10 @@
 
 import pytest
 import torch
-from compressed_tensors.quantization.utils.fp4_utils import cast_to_fp4
+from compressed_tensors.quantization.utils.fp4_utils import (
+    cast_to_fp4_torch,
+    cast_to_fp4_triton,
+)
 from tests.testing_utils import requires_gpu
 
 
@@ -16,13 +19,14 @@ def test_cast_to_fp4_cpu_gpu_match(size, dtype):
     x_gpu = x_cpu.cuda()
 
     # Quantize on CPU and GPU
-    result_cpu = cast_to_fp4(x_cpu)
-    result_gpu = cast_to_fp4(x_gpu)
+    result_cpu = cast_to_fp4_torch(x_cpu)
+    result_gpu = cast_to_fp4_triton(x_gpu)
 
     # Compare outputs (convert to same dtype for comparison)
     assert torch.allclose(result_cpu.cuda(), result_gpu, atol=1e-6)
 
 
+@requires_gpu
 def test_cast_to_fp4_boundary_values():
     input_values = torch.tensor(
         [
@@ -74,7 +78,8 @@ def test_cast_to_fp4_boundary_values():
             -2.7,
             -4.5,
             -7.0,
-        ]
+        ],
+        device="cuda",
     )
 
     expected_output = torch.tensor(
@@ -127,10 +132,11 @@ def test_cast_to_fp4_boundary_values():
             -3.0,
             -4.0,
             -6.0,
-        ]
+        ],
+        device="cuda",
     )
 
-    result = cast_to_fp4(input_values)
+    result = cast_to_fp4_triton(input_values)
     assert torch.allclose(result, expected_output, atol=1e-6)
 
 
@@ -153,7 +159,7 @@ def test_cast_to_fp4_memory_usage(size):
     baseline_memory = torch.cuda.memory_allocated()
 
     # Perform quantization
-    result = cast_to_fp4(x)
+    result = cast_to_fp4_triton(x)
     output_memory = result.element_size() * result.numel()
 
     # Check peak memory usage

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -39,6 +39,7 @@ def test_cast_to_fp4_boundary_values():
             3.0,
             4.0,
             6.0,
+            -0.0,
             -0.5,
             -1.0,
             -1.5,
@@ -93,6 +94,7 @@ def test_cast_to_fp4_boundary_values():
             3.0,
             4.0,
             6.0,
+            -0.0,
             -0.5,
             -1.0,
             -1.5,
@@ -137,7 +139,8 @@ def test_cast_to_fp4_boundary_values():
     )
 
     result = cast_to_fp4_triton(input_values)
-    assert torch.allclose(result, expected_output, atol=1e-6)
+    assert torch.equal(result, expected_output)
+    assert torch.signbit(result[8]).item(), "cast_to_fp4 should preserve -0.0 sign bit"
 
 
 @requires_gpu

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -1,7 +1,179 @@
-import torch
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 import pytest
-
+import torch
 from compressed_tensors.quantization.quant_args import FP4_E2M1_DATA
-
+from compressed_tensors.quantization.utils.fp4_utils import cast_to_fp4
 from tests.testing_utils import requires_gpu
 
+
+@requires_gpu
+@pytest.mark.parametrize("size", [1, 10, 100, 1000])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_cast_to_fp4_cpu_gpu_match(size, dtype):
+    """Test that CPU and GPU implementations produce identical results for small tensors."""
+    # Create random tensor
+    x_cpu = torch.randn(size, dtype=dtype)
+    x_gpu = x_cpu.cuda()
+
+    # Quantize on CPU and GPU
+    result_cpu = cast_to_fp4(x_cpu)
+    result_gpu = cast_to_fp4(x_gpu)
+
+    # Compare outputs (convert to same dtype for comparison)
+    assert torch.allclose(result_cpu.cuda(), result_gpu, atol=1e-6)
+
+
+def test_cast_to_fp4_boundary_values():
+    input_values = torch.tensor(
+        [
+            # Exact FP4 values
+            0.0,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            6.0,
+            -0.5,
+            -1.0,
+            -1.5,
+            -2.0,
+            -3.0,
+            -4.0,
+            -6.0,
+            # Values at boundaries
+            0.25,
+            0.75,
+            1.25,
+            1.75,
+            2.5,
+            3.5,
+            5.0,
+            -0.25,
+            -0.75,
+            -1.25,
+            -1.75,
+            -2.5,
+            -3.5,
+            -5.0,
+            # Values between boundaries
+            0.3,
+            0.6,
+            0.9,
+            1.3,
+            1.8,
+            2.7,
+            4.5,
+            7.0,
+            -0.3,
+            -0.6,
+            -0.9,
+            -1.3,
+            -1.8,
+            -2.7,
+            -4.5,
+            -7.0,
+        ]
+    )
+
+    expected_output = torch.tensor(
+        [
+            # Exact FP4 values
+            0.0,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            6.0,
+            -0.5,
+            -1.0,
+            -1.5,
+            -2.0,
+            -3.0,
+            -4.0,
+            -6.0,
+            # Values at boundaries (based on >= vs > conditions in implementation)
+            0.0,
+            1.0,
+            1.0,
+            2.0,
+            2.0,
+            4.0,
+            4.0,
+            -0.0,
+            -1.0,
+            -1.0,
+            -2.0,
+            -2.0,
+            -4.0,
+            -4.0,
+            # Values between boundaries
+            0.5,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            6.0,
+            -0.5,
+            -0.5,
+            -1.0,
+            -1.5,
+            -2.0,
+            -3.0,
+            -4.0,
+            -6.0,
+        ]
+    )
+
+    result = cast_to_fp4(input_values)
+    assert torch.allclose(result, expected_output, atol=1e-6)
+
+
+@requires_gpu
+@pytest.mark.parametrize("size", [1024, 10240, 102400, 1024000])
+def test_cast_to_fp4_memory_usage(size):
+    """Test that peak memory usage is reasonable for large tensors.
+
+    The implementation should not create excessive intermediate tensors.
+    Expected memory usage should be roughly: input + output + small overhead.
+    """
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+
+    # Create input tensor
+    x = torch.randn(size, dtype=torch.float32, device="cuda")
+    input_memory = x.element_size() * x.numel()
+
+    # Record baseline memory after input creation
+    baseline_memory = torch.cuda.memory_allocated()
+
+    # Perform quantization
+    result = cast_to_fp4(x)
+    output_memory = result.element_size() * result.numel()
+
+    # Check peak memory usage
+    peak_memory = torch.cuda.max_memory_allocated()
+    actual_overhead = peak_memory - baseline_memory - output_memory
+
+    # Expected overhead: allow up to 20% extra for intermediate computations
+    # This is generous to account for Triton kernel overhead
+    max_allowed_overhead = 0.2 * (input_memory + output_memory)
+
+    assert actual_overhead <= max_allowed_overhead, (
+        f"Memory overhead too high for size {size}. "
+        f"Input: {input_memory / 1024**2:.2f} MB, "
+        f"Output: {output_memory / 1024**2:.2f} MB, "
+        f"Actual overhead: {actual_overhead / 1024**2:.2f} MB, "
+        f"Max allowed overhead: {max_allowed_overhead / 1024**2:.2f} MB"
+    )
+
+    # Clean up
+    del x, result
+    torch.cuda.empty_cache()

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -1,0 +1,7 @@
+import torch
+import pytest
+
+from compressed_tensors.quantization.quant_args import FP4_E2M1_DATA
+
+from tests.testing_utils import requires_gpu
+

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -148,22 +148,22 @@ def test_cast_to_fp4_memory_usage(size):
     The implementation should not create excessive intermediate tensors.
     Expected memory usage should be roughly: input + output + small overhead.
     """
-    torch.cuda.empty_cache()
-    torch.cuda.reset_peak_memory_stats()
+    torch.accelerator.empty_cache()
+    torch.accelerator.reset_peak_memory_stats()
 
     # Create input tensor
     x = torch.randn(size, dtype=torch.float32, device="cuda")
     input_memory = x.element_size() * x.numel()
 
     # Record baseline memory after input creation
-    baseline_memory = torch.cuda.memory_allocated()
+    baseline_memory = torch.accelerator.memory_allocated()
 
     # Perform quantization
     result = cast_to_fp4_triton(x)
     output_memory = result.element_size() * result.numel()
 
     # Check peak memory usage
-    peak_memory = torch.cuda.max_memory_allocated()
+    peak_memory = torch.accelerator.max_memory_allocated()
     actual_overhead = peak_memory - baseline_memory - output_memory
 
     # Expected overhead: allow up to 20% extra for intermediate computations
@@ -180,4 +180,4 @@ def test_cast_to_fp4_memory_usage(size):
 
     # Clean up
     del x, result
-    torch.cuda.empty_cache()
+    torch.accelerator.empty_cache()

--- a/tests/test_quantization/test_utils/test_fp4_utils.py
+++ b/tests/test_quantization/test_utils/test_fp4_utils.py
@@ -3,7 +3,6 @@
 
 import pytest
 import torch
-from compressed_tensors.quantization.quant_args import FP4_E2M1_DATA
 from compressed_tensors.quantization.utils.fp4_utils import cast_to_fp4
 from tests.testing_utils import requires_gpu
 
@@ -12,7 +11,6 @@ from tests.testing_utils import requires_gpu
 @pytest.mark.parametrize("size", [1, 10, 100, 1000])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 def test_cast_to_fp4_cpu_gpu_match(size, dtype):
-    """Test that CPU and GPU implementations produce identical results for small tensors."""
     # Create random tensor
     x_cpu = torch.randn(size, dtype=dtype)
     x_gpu = x_cpu.cuda()
@@ -97,7 +95,7 @@ def test_cast_to_fp4_boundary_values():
             -3.0,
             -4.0,
             -6.0,
-            # Values at boundaries (based on >= vs > conditions in implementation)
+            # Values at boundaries
             0.0,
             1.0,
             1.0,


### PR DESCRIPTION
## Benchmarking ##
```
GPU Average:
  Speedup: 1.58x
  Memory Reduction: 0% compared to torch.compile, -50% w.r.t. no torch compile

CPU Average:
  Speedup: 1.07x
  Memory Reduction: -32.93%
```

## Theoretical Speedups ##
- The old implementation with torch compile had ~1250 GB/s memory bandwidth
- The new implementation with triton has ~1490 GB/s
- The peak memory bandwidth on A100 is ~2000 GB/s
