### PR TITLE
Triton implementation for quantize kernel in forward helpers

### DIFF
--- a/benchmarks/benchmark_quantize_triton.py
+++ b/benchmarks/benchmark_quantize_triton.py
@@ -62,17 +62,13 @@ def benchmark_cuda(func, x, scale, zero_point, q_min, q_max, args, name, warmup=
         torch.cuda.empty_cache()
         gc.collect()
         torch.cuda.synchronize()
-        print(f"  Warmup complete, starting benchmark...")
+        print("  Warmup complete, starting benchmark...")
 
     times = []
-    peaks = []
 
     for _ in range(N_RUNS):
         torch.cuda.empty_cache()
         gc.collect()
-        torch.cuda.reset_peak_memory_stats()
-
-        baseline_mem = torch.cuda.memory_allocated(0)
 
         torch.cuda.synchronize()
         start = time.time()
@@ -80,19 +76,15 @@ def benchmark_cuda(func, x, scale, zero_point, q_min, q_max, args, name, warmup=
         torch.cuda.synchronize()
         elapsed = time.time() - start
 
-        peak = (torch.cuda.max_memory_allocated(0) - baseline_mem) / 1e9
-
         times.append(elapsed)
-        peaks.append(peak)
 
         del result
         torch.cuda.empty_cache()
         gc.collect()
 
     avg_time = sum(times) / N_RUNS
-    avg_peak = sum(peaks) / N_RUNS
 
-    return avg_time, avg_peak
+    return avg_time
 
 
 def run_config(quant_type, num_bits, rows, cols):
@@ -111,21 +103,19 @@ def run_config(quant_type, num_bits, rows, cols):
 
     # PyTorch reference on CUDA (no Triton kernel, just PyTorch ops)
     print("\nRunning PyTorch reference (CUDA, no Triton)...")
-    time_pytorch, peak_pytorch = benchmark_cuda(
+    time_pytorch = benchmark_cuda(
         pytorch_quantize_cuda, x_cuda, scale_cuda, zp_cuda, q_min_cuda, q_max_cuda, args, "pytorch_cuda", warmup=True
     )
-    print(f"PyTorch (CUDA):")
+    print("PyTorch (CUDA):")
     print(f"  Time: {time_pytorch*1000:.2f}ms")
-    print(f"  Peak: {peak_pytorch:.3f} GB")
 
     # Triton kernel (CUDA path in _quantize)
     print("\nRunning Triton kernel (CUDA)...")
-    time_triton, peak_triton = benchmark_cuda(
+    time_triton = benchmark_cuda(
         _quantize, x_cuda, scale_cuda, zp_cuda, q_min_cuda, q_max_cuda, args, "triton", warmup=True
     )
-    print(f"Triton (CUDA):")
+    print("Triton (CUDA):")
     print(f"  Time: {time_triton*1000:.2f}ms")
-    print(f"  Peak: {peak_triton:.3f} GB")
 
     # Verify correctness - compare Triton kernel vs PyTorch ops on same CUDA data
     x_test = torch.randn(512, 1024, dtype=torch.float32, device=device)
@@ -185,7 +175,6 @@ def run_config(quant_type, num_bits, rows, cols):
         "cols": cols,
         "pytorch_ms": time_pytorch * 1000,
         "triton_ms": time_triton * 1000,
-        "triton_peak": peak_triton,
         "speedup": time_pytorch / time_triton if time_triton > 0 else 0,
         "correct": correct,
     }
@@ -196,7 +185,7 @@ def main():
         print("CUDA not available, Triton requires GPU")
         return
 
-    print(f"Benchmarking _quantize from forward_helpers.py")
+    print("Benchmarking _quantize from forward_helpers.py")
     print(f"Device: {torch.cuda.get_device_name(device)}")
     print(f"N_RUNS: {N_RUNS}")
 

--- a/benchmarks/benchmark_quantize_triton.py
+++ b/benchmarks/benchmark_quantize_triton.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Benchmark script for _quantize Triton implementation in forward_helpers.py.
+
+Compares Triton kernel vs PyTorch ops, both on CUDA (apples to apples).
+"""
+
+import gc
+import time
+import torch
+
+from compressed_tensors.quantization.lifecycle.forward_helpers import _quantize
+from compressed_tensors.quantization.quant_args import (
+    QuantizationArgs,
+    QuantizationType,
+    QuantizationStrategy,
+)
+from compressed_tensors.quantization.utils.helpers import calculate_range
+
+SIZE = 4096 * 4096  # ~16.7M elements
+device = "cuda:0" if torch.cuda.is_available() else "cpu"
+N_RUNS = 200
+
+
+def create_test_data(rows, cols, quant_type, num_bits, target_device):
+    """Create test data and quantization parameters."""
+    args = QuantizationArgs(
+        num_bits=num_bits,
+        type=quant_type,
+        symmetric=True,
+        strategy=QuantizationStrategy.TENSOR,
+    )
+    q_min, q_max = calculate_range(args, torch.device(target_device))
+
+    x = torch.randn(rows, cols, dtype=torch.float32, device=target_device)
+    scale = (torch.rand(1) * 0.01 + 0.001).to(target_device)
+    zero_point = None  # symmetric quantization
+
+    return x, scale, zero_point, q_min, q_max, args
+
+
+def pytorch_quantize_cuda(x, scale, zero_point, q_min, q_max, args):
+    """PyTorch reference implementation on CUDA (no Triton)."""
+    from compressed_tensors.quantization.quant_args import round_to_quantized_type_args
+    scaled = x / scale
+    if zero_point is not None:
+        scaled = scaled + zero_point.to(x.dtype)
+    return round_to_quantized_type_args(tensor=scaled, args=args, min=q_min, max=q_max)
+
+
+def benchmark_cuda(func, x, scale, zero_point, q_min, q_max, args, name, warmup=False):
+    """Benchmark a quantization function on CUDA."""
+    x = x.clone()
+    if warmup:
+        print(f"  Warming up {name}...")
+        for _ in range(10):
+            _ = func(x, scale, zero_point, q_min, q_max, args)
+        torch.cuda.empty_cache()
+        gc.collect()
+        torch.cuda.synchronize()
+        print(f"  Warmup complete, starting benchmark...")
+
+    times = []
+    peaks = []
+
+    for _ in range(N_RUNS):
+        torch.cuda.empty_cache()
+        gc.collect()
+        torch.cuda.reset_peak_memory_stats()
+
+        baseline_mem = torch.cuda.memory_allocated(0)
+
+        torch.cuda.synchronize()
+        start = time.time()
+        result = func(x, scale, zero_point, q_min, q_max, args)
+        torch.cuda.synchronize()
+        elapsed = time.time() - start
+
+        peak = (torch.cuda.max_memory_allocated(0) - baseline_mem) / 1e9
+
+        times.append(elapsed)
+        peaks.append(peak)
+
+        del result
+        torch.cuda.empty_cache()
+        gc.collect()
+
+    avg_time = sum(times) / N_RUNS
+    avg_peak = sum(peaks) / N_RUNS
+
+    return avg_time, avg_peak
+
+
+def run_config(quant_type, num_bits, rows, cols):
+    """Run benchmarks for a specific configuration."""
+    type_str = "int" if quant_type == QuantizationType.INT else "fp"
+    config_name = f"{type_str}{num_bits}"
+
+    print(f"\n{'='*80}")
+    print(f"Benchmarking {config_name} quantization ({rows}x{cols} = {rows*cols/1e6:.1f}M elements)")
+    print("=" * 80)
+
+    # Create CUDA test data - both paths run on CUDA for fair comparison
+    x_cuda, scale_cuda, zp_cuda, q_min_cuda, q_max_cuda, args = create_test_data(
+        rows, cols, quant_type, num_bits, device
+    )
+
+    # PyTorch reference on CUDA (no Triton kernel, just PyTorch ops)
+    print("\nRunning PyTorch reference (CUDA, no Triton)...")
+    time_pytorch, peak_pytorch = benchmark_cuda(
+        pytorch_quantize_cuda, x_cuda, scale_cuda, zp_cuda, q_min_cuda, q_max_cuda, args, "pytorch_cuda", warmup=True
+    )
+    print(f"PyTorch (CUDA):")
+    print(f"  Time: {time_pytorch*1000:.2f}ms")
+    print(f"  Peak: {peak_pytorch:.3f} GB")
+
+    # Triton kernel (CUDA path in _quantize)
+    print("\nRunning Triton kernel (CUDA)...")
+    time_triton, peak_triton = benchmark_cuda(
+        _quantize, x_cuda, scale_cuda, zp_cuda, q_min_cuda, q_max_cuda, args, "triton", warmup=True
+    )
+    print(f"Triton (CUDA):")
+    print(f"  Time: {time_triton*1000:.2f}ms")
+    print(f"  Peak: {peak_triton:.3f} GB")
+
+    # Verify correctness - compare Triton kernel vs PyTorch ops on same CUDA data
+    x_test = torch.randn(512, 1024, dtype=torch.float32, device=device)
+    scale_test = (torch.rand(1) * 0.01 + 0.001).to(device)
+
+    # PyTorch reference on CUDA
+    pytorch_out = pytorch_quantize_cuda(
+        x=x_test.clone(),
+        scale=scale_test.clone(),
+        zero_point=None,
+        q_min=q_min_cuda.clone(),
+        q_max=q_max_cuda.clone(),
+        args=args,
+    )
+
+    # Triton kernel on CUDA
+    triton_out = _quantize(
+        x=x_test.clone(),
+        scale=scale_test.clone(),
+        zero_point=None,
+        q_min=q_min_cuda.clone(),
+        q_max=q_max_cuda.clone(),
+        args=args,
+    )
+
+    # Tolerance depends on quantization type (matching test_quantize_dequantize_matches_sequential)
+    if quant_type == QuantizationType.INT:
+        atol = 1.0  # Allow 1 unit difference due to rounding at boundaries
+    else:
+        atol = 0.5  # FP4/FP8 may have boundary differences
+
+    diff = (pytorch_out - triton_out).abs()
+    max_diff = diff.max().item()
+    correct = max_diff <= atol
+
+    if not correct:
+        max_idx = diff.argmax()
+        row_idx = max_idx // 1024
+        col_idx = max_idx % 1024
+        scaled_val = x_test[row_idx, col_idx].item() / scale_test.item()
+        print(f"\nWarning: outputs differ, max_diff={max_diff:.6f} (atol={atol})")
+        print(f"  At index [{row_idx}, {col_idx}]:")
+        print(f"    input={x_test[row_idx, col_idx].item():.15f}")
+        print(f"    scale={scale_test.item():.15f}")
+        print(f"    scaled={scaled_val:.15f}")
+        print(f"    pytorch={pytorch_out[row_idx, col_idx].item():.6f}")
+        print(f"    triton={triton_out[row_idx, col_idx].item():.6f}")
+
+    del x_cuda, scale_cuda, q_min_cuda, q_max_cuda
+    del x_test, scale_test, pytorch_out, triton_out
+    torch.cuda.empty_cache()
+    gc.collect()
+
+    return {
+        "config": config_name,
+        "rows": rows,
+        "cols": cols,
+        "pytorch_ms": time_pytorch * 1000,
+        "triton_ms": time_triton * 1000,
+        "triton_peak": peak_triton,
+        "speedup": time_pytorch / time_triton if time_triton > 0 else 0,
+        "correct": correct,
+    }
+
+
+def main():
+    if not torch.cuda.is_available():
+        print("CUDA not available, Triton requires GPU")
+        return
+
+    print(f"Benchmarking _quantize from forward_helpers.py")
+    print(f"Device: {torch.cuda.get_device_name(device)}")
+    print(f"N_RUNS: {N_RUNS}")
+
+    # Configurations to benchmark
+    configs = [
+        (QuantizationType.INT, 4),
+        (QuantizationType.INT, 8),
+        (QuantizationType.FLOAT, 4),
+        (QuantizationType.FLOAT, 8),
+    ]
+
+    # Tensor sizes
+    sizes = [
+        (4096, 4096),
+        (4096, 11008),  # LLaMA MLP
+        (8192, 8192),
+    ]
+
+    results = []
+
+    for quant_type, num_bits in configs:
+        for rows, cols in sizes:
+            result = run_config(quant_type, num_bits, rows, cols)
+            results.append(result)
+
+    # Print summary
+    print("\n" + "=" * 100)
+    print("SUMMARY (both on CUDA - apples to apples)")
+    print("=" * 100)
+    print(f"{'Config':<8} {'Size':<15} {'PyTorch/CUDA (ms)':<18} "
+          f"{'Triton/CUDA (ms)':<18} {'Speedup':<10} {'Correct':<8}")
+    print("-" * 100)
+
+    for r in results:
+        size_str = f"{r['rows']}x{r['cols']}"
+        correct_str = "Yes" if r["correct"] else "NO"
+        print(f"{r['config']:<8} {size_str:<15} {r['pytorch_ms']:>14.2f} ms  "
+              f"{r['triton_ms']:>14.2f} ms  "
+              f"{r['speedup']:>6.2f}x    {correct_str:<8}")
+
+
+if __name__ == "__main__":
+    main()
+
+
+"""
+Example output:
+
+====================================================================================================
+SUMMARY (both on CUDA - apples to apples)
+====================================================================================================
+Config   Size            PyTorch/CUDA (ms)  Triton/CUDA (ms)   Speedup    Correct 
+----------------------------------------------------------------------------------------------------
+int4     4096x4096              X.XX ms           X.XX ms    X.XXx    Yes     
+int4     4096x11008             X.XX ms           X.XX ms    X.XXx    Yes     
+int8     4096x4096              X.XX ms           X.XX ms    X.XXx    Yes     
+fp4      4096x4096              X.XX ms           X.XX ms    X.XXx    Yes     
+...
+"""

--- a/benchmarks/benchmark_quantize_triton.py
+++ b/benchmarks/benchmark_quantize_triton.py
@@ -5,6 +5,8 @@
 Benchmark script for _quantize Triton implementation in forward_helpers.py.
 
 Compares Triton kernel vs PyTorch ops, both on CUDA (apples to apples).
+
+Based on https://github.com/vllm-project/compressed-tensors/blob/6186e34ac31e93298386568ee0ef6416289a6bda/benchmark_pack_fp4_triton.py
 """
 
 import gc

--- a/benchmarks/benchmark_quantize_triton.py
+++ b/benchmarks/benchmark_quantize_triton.py
@@ -13,7 +13,10 @@ import gc
 import time
 import torch
 
-from compressed_tensors.quantization.lifecycle.forward_helpers import _quantize
+from compressed_tensors.quantization.lifecycle.forward_helpers import (
+    _quantize,
+    adapt_scale_and_zp_for_triton,
+)
 from compressed_tensors.quantization.quant_args import (
     QuantizationArgs,
     QuantizationType,
@@ -50,6 +53,21 @@ def pytorch_quantize_cuda(x, scale, zero_point, q_min, q_max, args):
     if zero_point is not None:
         scaled = scaled + zero_point.to(x.dtype)
     return round_to_quantized_type_args(tensor=scaled, args=args, min=q_min, max=q_max)
+
+
+def triton_quantize_cuda(x, scale, zero_point, q_min, q_max, args):
+    """Triton kernel wrapper that adapts scale/zp and enables Triton."""
+    num_rows = x.shape[0]
+    scale_adapted, zp_adapted = adapt_scale_and_zp_for_triton(scale, zero_point, num_rows)
+    return _quantize(
+        x=x,
+        scale=scale_adapted,
+        zero_point=zp_adapted,
+        q_min=q_min,
+        q_max=q_max,
+        args=args,
+        do_triton=True,
+    )
 
 
 def benchmark_cuda(func, x, scale, zero_point, q_min, q_max, args, name, warmup=False):
@@ -112,7 +130,7 @@ def run_config(quant_type, num_bits, rows, cols):
     # Triton kernel (CUDA path in _quantize)
     print("\nRunning Triton kernel (CUDA)...")
     time_triton = benchmark_cuda(
-        _quantize, x_cuda, scale_cuda, zp_cuda, q_min_cuda, q_max_cuda, args, "triton", warmup=True
+        triton_quantize_cuda, x_cuda, scale_cuda, zp_cuda, q_min_cuda, q_max_cuda, args, "triton", warmup=True
     )
     print("Triton (CUDA):")
     print(f"  Time: {time_triton*1000:.2f}ms")
@@ -132,7 +150,7 @@ def run_config(quant_type, num_bits, rows, cols):
     )
 
     # Triton kernel on CUDA
-    triton_out = _quantize(
+    triton_out = triton_quantize_cuda(
         x=x_test.clone(),
         scale=scale_test.clone(),
         zero_point=None,

--- a/benchmarks/benchmark_quantize_triton.py
+++ b/benchmarks/benchmark_quantize_triton.py
@@ -231,7 +231,7 @@ def main():
 
     # Print summary
     print("\n" + "=" * 100)
-    print("SUMMARY (both on CUDA - apples to apples)")
+    print("SUMMARY")
     print("=" * 100)
     print(f"{'Config':<8} {'Size':<15} {'PyTorch/CUDA (ms)':<18} "
           f"{'Triton/CUDA (ms)':<18} {'Speedup':<10} {'Correct':<8}")
@@ -253,7 +253,7 @@ if __name__ == "__main__":
 Example output:
 
 ====================================================================================================
-SUMMARY (both on CUDA - apples to apples)
+SUMMARY
 ====================================================================================================
 Config   Size            PyTorch/CUDA (ms)  Triton/CUDA (ms)   Speedup    Correct 
 ----------------------------------------------------------------------------------------------------

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -307,8 +307,8 @@ def _quantize_kernel(
     q_max = tl.load(q_max_ptr)
 
     if quant_type == QUANT_TYPE_INT:
-        output = tl.where(output >= 0, output + 0.5, output - 0.5)
         output = tl.clamp(output, q_min, q_max)
+        output = tl.extra.cuda.libdevice.rint(output)
     elif quant_type == QUANT_TYPE_FLOAT:
         output = tl.clamp(output, q_min, q_max)
         if num_bits == 4:

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -4,6 +4,8 @@
 from math import ceil
 
 import torch
+import triton
+import triton.language as tl
 from compressed_tensors.quantization.quant_args import (
     FP8_E4M3_DATA,
     QuantizationArgs,
@@ -152,16 +154,6 @@ def _process_group(
     reshaped_dims = (ceil(x.shape[-1] / group_size), group_size)
     x = x.unflatten(-1, reshaped_dims)
 
-    # print(f"x.shape: {x.shape}")
-    # print(f"scale.shape: {scale.shape}")
-    # print(f"zero_point.shape: {zero_point.shape if zero_point is not None else None}")
-    # print(f"q_min.shape: {q_min.shape}")
-    # print(f"q_max.shape: {q_max.shape}")
-    # print(f"global_scale.shape: {global_scale.shape if global_scale is not None else None}")
-    # print(f"x strides: {x.stride()}")
-    # print(f"scale strides: {scale.stride()}")
-    # print(f"zero_point strides: {zero_point.stride() if zero_point is not None else None}")
-
     output = _apply_quantize_op(
         x,
         scale.unsqueeze(-1),
@@ -222,9 +214,6 @@ def _quantize_dequantize(
     return dequant * scale
 
 
-import triton
-import triton.language as tl
-
 # Quantization type constants for Triton kernel
 QUANT_TYPE_INT = tl.constexpr(0)
 QUANT_TYPE_FLOAT = tl.constexpr(1)
@@ -235,13 +224,13 @@ def _round_to_fp4(x):
     """
     Round float values to the nearest E2M1 representable value.
     FP4 values: 0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0 (and their negatives)
-    
+
     Matches the thresholds in the Python ``cast_to_fp4`` exactly.
     Based on vllm's nvfp4_emulation_utils.py implementation.
     """
     sign = tl.where(x < 0.0, -1.0, 1.0)
     abs_x = tl.abs(x)
-    
+
     # Map to FP4 representable values based on thresholds
     # Start with default 0.0, then overwrite from highest to lowest threshold
     result = tl.where(abs_x > 5.0, 6.0, 0.0)
@@ -251,7 +240,7 @@ def _round_to_fp4(x):
     result = tl.where((abs_x > 1.25) & (abs_x < 1.75), 1.5, result)
     result = tl.where((abs_x >= 0.75) & (abs_x <= 1.25), 1.0, result)
     result = tl.where((abs_x > 0.25) & (abs_x < 0.75), 0.5, result)
-    
+
     return result * sign
 
 
@@ -267,10 +256,8 @@ def _quantize_kernel(
     num_rows,
     num_cols,
     group_size,
-    # quant_type: QUANT_TYPE_INT or QUANT_TYPE_FLOAT
-    quant_type: tl.constexpr,
-    # num_bits: for FLOAT quantization (4 or 8)
-    num_bits: tl.constexpr,
+    quant_type: tl.constexpr,  # QUANT_TYPE_INT or QUANT_TYPE_FLOAT
+    num_bits: tl.constexpr,  # 4 or 8
     BLOCK_SIZE_R: tl.constexpr,
     BLOCK_SIZE_C: tl.constexpr,
 ):
@@ -286,17 +273,17 @@ def _quantize_kernel(
     masks = masks_r[:, None] & masks_c[None, :]
 
     scale_offsets_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
-    scale_offsets_c = (pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C )) // group_size
-    scale_offsets = (num_cols // group_size) * scale_offsets_r[:, None] + scale_offsets_c[None, :]
+    scale_offsets_c = (pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C)) // group_size
+    scale_offsets = (num_cols // group_size) * scale_offsets_r[
+        :, None
+    ] + scale_offsets_c[None, :]
     scale_masks_r = scale_offsets_r < num_rows
     scale_masks_c = scale_offsets_c < num_cols // group_size
     scale_masks = scale_masks_r[:, None] & scale_masks_c[None, :]
 
     result_offsets_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
     result_offsets_c = pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C)
-    result_offsets = (
-        num_cols * result_offsets_r[:, None] + result_offsets_c[None, :]
-    )
+    result_offsets = num_cols * result_offsets_r[:, None] + result_offsets_c[None, :]
 
     result_masks_r = result_offsets_r < num_rows
     result_masks_c = result_offsets_c < num_cols
@@ -314,24 +301,20 @@ def _quantize_kernel(
     if zero_point_ptr is not None:
         zero_point = tl.load(zero_point_ptr + scale_offsets, scale_masks, 0.0)
         output += zero_point
-    
+
     # clamp and round (equivalent to round_to_quantized_type_args)
     q_min = tl.load(q_min_ptr)
     q_max = tl.load(q_max_ptr)
-    
+
     if quant_type == QUANT_TYPE_INT:
-        # INT quantization: round half away from zero, then clamp
-        # Based on vllm's triton_reshape_and_cache_flash.py approach
         output = tl.where(output >= 0, output + 0.5, output - 0.5)
         output = tl.clamp(output, q_min, q_max)
     elif quant_type == QUANT_TYPE_FLOAT:
-        # FLOAT quantization: clamp first, then round to representable values
         output = tl.clamp(output, q_min, q_max)
         if num_bits == 4:
-            # FP4 E2M1 rounding (based on vllm's nvfp4_emulation_utils.py)
             output = _round_to_fp4(output)
         # Note: FP8 would require hardware support or casting, not implemented here
-        
+
     tl.store(output_ptr + result_offsets, output, result_masks)
 
 
@@ -347,8 +330,8 @@ def _quantize(
     global_scale: torch.Tensor | None = None,
 ) -> torch.Tensor:
 
-    # Triton only works with CUDA tensors
-    do_triton: bool = x.is_cuda
+    # Triton only works with CUDA and XPU tensors
+    do_triton: bool = x.is_cuda or x.is_xpu
 
     if not do_triton:
         # if a global scale is optionally provided, use it
@@ -369,10 +352,7 @@ def _quantize(
         return quantized_ground
 
     original_shape = x.shape
-    
-    # Handle both 2D and 3D tensors:
-    # - 3D [rows, groups, group_size]: group_size = shape[2]
-    # - 2D [rows, cols]: treat as single group, group_size = cols
+
     if x.ndim == 3:
         group_size = x.shape[2]
         x = x.reshape(x.shape[0], -1)
@@ -382,8 +362,6 @@ def _quantize(
     elif x.ndim == 2:
         group_size = x.shape[1]  # Entire row is one "group"
         num_rows = x.shape[0]
-        # Kernel expects scale shape [num_rows, num_groups] where num_groups = 1 for 2D
-        # Expand scale to [num_rows, 1] so kernel can index by row
         if scale.ndim == 0:
             scale = scale.expand(num_rows, 1).contiguous()
         elif scale.ndim == 1:
@@ -404,30 +382,37 @@ def _quantize(
     block_size_c: int = 32
     num_rows = x.shape[0]
     num_cols = x.shape[1]
-    grid = lambda META: (
-        triton.cdiv(num_rows, META["BLOCK_SIZE_R"]),
-        triton.cdiv(num_cols, META["BLOCK_SIZE_C"]),
-    )
+
+    def grid(META):
+        return (
+            triton.cdiv(num_rows, META["BLOCK_SIZE_R"]),
+            triton.cdiv(num_cols, META["BLOCK_SIZE_C"]),
+        )
+
     quantized_value = torch.empty_like(x)
 
     # Determine quantization type
-    quant_type = QUANT_TYPE_INT if args.type == QuantizationType.INT else QUANT_TYPE_FLOAT
+    quant_type = (
+        QUANT_TYPE_INT if args.type == QuantizationType.INT else QUANT_TYPE_FLOAT
+    )
     num_bits = args.num_bits
-    
-    _quantize_kernel[grid](quantized_value,
-                           x,
-                           scale,
-                           zero_point,
-                           q_min,
-                           q_max,
-                           global_scale,
-                           num_rows,
-                           num_cols,
-                           group_size,
-                           quant_type=quant_type,
-                           num_bits=num_bits,
-                           BLOCK_SIZE_R=block_size_r,
-                           BLOCK_SIZE_C=block_size_c)
+
+    _quantize_kernel[grid](
+        quantized_value,
+        x,
+        scale,
+        zero_point,
+        q_min,
+        q_max,
+        global_scale,
+        num_rows,
+        num_cols,
+        group_size,
+        quant_type=quant_type,
+        num_bits=num_bits,
+        BLOCK_SIZE_R=block_size_r,
+        BLOCK_SIZE_C=block_size_c,
+    )
 
     quantized_value = quantized_value.reshape(original_shape)
 

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -5,7 +5,9 @@ from math import ceil
 
 import torch
 from compressed_tensors.quantization.quant_args import (
+    FP8_E4M3_DATA,
     QuantizationArgs,
+    QuantizationType,
     round_to_quantized_type_args,
 )
 from compressed_tensors.quantization.utils import maybe_pad_tensor_for_block_quant
@@ -150,6 +152,16 @@ def _process_group(
     reshaped_dims = (ceil(x.shape[-1] / group_size), group_size)
     x = x.unflatten(-1, reshaped_dims)
 
+    # print(f"x.shape: {x.shape}")
+    # print(f"scale.shape: {scale.shape}")
+    # print(f"zero_point.shape: {zero_point.shape if zero_point is not None else None}")
+    # print(f"q_min.shape: {q_min.shape}")
+    # print(f"q_max.shape: {q_max.shape}")
+    # print(f"global_scale.shape: {global_scale.shape if global_scale is not None else None}")
+    # print(f"x strides: {x.stride()}")
+    # print(f"scale strides: {scale.stride()}")
+    # print(f"zero_point strides: {zero_point.stride() if zero_point is not None else None}")
+
     output = _apply_quantize_op(
         x,
         scale.unsqueeze(-1),
@@ -210,6 +222,119 @@ def _quantize_dequantize(
     return dequant * scale
 
 
+import triton
+import triton.language as tl
+
+# Quantization type constants for Triton kernel
+QUANT_TYPE_INT = tl.constexpr(0)
+QUANT_TYPE_FLOAT = tl.constexpr(1)
+
+
+@triton.jit
+def _round_to_fp4(x):
+    """
+    Round float values to the nearest E2M1 representable value.
+    FP4 values: 0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0 (and their negatives)
+    
+    Matches the thresholds in the Python ``cast_to_fp4`` exactly.
+    Based on vllm's nvfp4_emulation_utils.py implementation.
+    """
+    sign = tl.where(x < 0.0, -1.0, 1.0)
+    abs_x = tl.abs(x)
+    
+    # Map to FP4 representable values based on thresholds
+    # Start with default 0.0, then overwrite from highest to lowest threshold
+    result = tl.where(abs_x > 5.0, 6.0, 0.0)
+    result = tl.where((abs_x >= 3.5) & (abs_x <= 5.0), 4.0, result)
+    result = tl.where((abs_x > 2.5) & (abs_x < 3.5), 3.0, result)
+    result = tl.where((abs_x >= 1.75) & (abs_x <= 2.5), 2.0, result)
+    result = tl.where((abs_x > 1.25) & (abs_x < 1.75), 1.5, result)
+    result = tl.where((abs_x >= 0.75) & (abs_x <= 1.25), 1.0, result)
+    result = tl.where((abs_x > 0.25) & (abs_x < 0.75), 0.5, result)
+    
+    return result * sign
+
+
+@triton.jit
+def _quantize_kernel(
+    output_ptr: tl.tensor,
+    input_ptr: tl.tensor,
+    scale_ptr: tl.tensor,
+    zero_point_ptr: tl.tensor,
+    q_min_ptr: tl.tensor,
+    q_max_ptr: tl.tensor,
+    global_scale_ptr: tl.tensor,
+    num_rows,
+    num_cols,
+    group_size,
+    # quant_type: QUANT_TYPE_INT or QUANT_TYPE_FLOAT
+    quant_type: tl.constexpr,
+    # num_bits: for FLOAT quantization (4 or 8)
+    num_bits: tl.constexpr,
+    BLOCK_SIZE_R: tl.constexpr,
+    BLOCK_SIZE_C: tl.constexpr,
+):
+    # Set up the pids.
+    pid_r = tl.program_id(axis=0)
+    pid_c = tl.program_id(axis=1)
+    offsets_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
+    offsets_c = pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C)
+    offsets = num_cols * offsets_r[:, None] + offsets_c[None, :]
+
+    masks_r = offsets_r < num_rows
+    masks_c = offsets_c < num_cols
+    masks = masks_r[:, None] & masks_c[None, :]
+
+    scale_offsets_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
+    scale_offsets_c = (pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C )) // group_size
+    scale_offsets = (num_cols // group_size) * scale_offsets_r[:, None] + scale_offsets_c[None, :]
+    scale_masks_r = scale_offsets_r < num_rows
+    scale_masks_c = scale_offsets_c < num_cols // group_size
+    scale_masks = scale_masks_r[:, None] & scale_masks_c[None, :]
+
+    result_offsets_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
+    result_offsets_c = pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C)
+    result_offsets = (
+        num_cols * result_offsets_r[:, None] + result_offsets_c[None, :]
+    )
+
+    result_masks_r = result_offsets_r < num_rows
+    result_masks_c = result_offsets_c < num_cols
+    result_masks = result_masks_r[:, None] & result_masks_c[None, :]
+
+    input = tl.load(input_ptr + offsets, masks, 0.0)
+    scale = tl.load(scale_ptr + scale_offsets, scale_masks, 0.0)
+
+    if global_scale_ptr is not None:
+        global_scale = tl.load(global_scale_ptr)
+        scale = scale / global_scale.to(scale.dtype)
+
+    output = input / scale
+
+    if zero_point_ptr is not None:
+        zero_point = tl.load(zero_point_ptr + scale_offsets, scale_masks, 0.0)
+        output += zero_point
+    
+    # clamp and round (equivalent to round_to_quantized_type_args)
+    q_min = tl.load(q_min_ptr)
+    q_max = tl.load(q_max_ptr)
+    
+    if quant_type == QUANT_TYPE_INT:
+        # INT quantization: round half away from zero, then clamp
+        # Based on vllm's triton_reshape_and_cache_flash.py approach
+        output = tl.where(output >= 0, output + 0.5, output - 0.5)
+        output = tl.clamp(output, q_min, q_max)
+    elif quant_type == QUANT_TYPE_FLOAT:
+        # FLOAT quantization: clamp first, then round to representable values
+        output = tl.clamp(output, q_min, q_max)
+        if num_bits == 4:
+            # FP4 E2M1 rounding (based on vllm's nvfp4_emulation_utils.py)
+            output = _round_to_fp4(output)
+        # Note: FP8 would require hardware support or casting, not implemented here
+        
+    tl.store(output_ptr + result_offsets, output, result_masks)
+
+
 @torch.no_grad()
 def _quantize(
     x: torch.Tensor,
@@ -221,20 +346,96 @@ def _quantize(
     dtype: torch.dtype | None = None,
     global_scale: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    # if a global scale is optionally provided, use it
-    # to further scale the local `scale` parameter
-    if global_scale is not None:
-        scale = scale / global_scale
 
-    scaled = x / scale
+    # Triton only works with CUDA tensors
+    do_triton: bool = x.is_cuda
 
-    if zero_point is not None:
-        scaled += zero_point.to(x.dtype)
+    if not do_triton:
+        # if a global scale is optionally provided, use it
+        # to further scale the local `scale` parameter
+        scale_ground = scale.clone()
+        if global_scale is not None:
+            scale_ground = scale / global_scale
 
-    # clamp and round
-    quantized_value = round_to_quantized_type_args(
-        tensor=scaled, args=args, min=q_min, max=q_max
+        scaled = x / scale_ground
+        if zero_point is not None:
+            scaled += zero_point.to(x.dtype)
+        quantized_ground = round_to_quantized_type_args(
+            tensor=scaled, args=args, min=q_min, max=q_max
+        )
+        # quantized_ground = scaled
+        if dtype is not None:
+            quantized_ground = quantized_ground.to(dtype)
+        return quantized_ground
+
+    original_shape = x.shape
+    
+    # Handle both 2D and 3D tensors:
+    # - 3D [rows, groups, group_size]: group_size = shape[2]
+    # - 2D [rows, cols]: treat as single group, group_size = cols
+    if x.ndim == 3:
+        group_size = x.shape[2]
+        x = x.reshape(x.shape[0], -1)
+        scale = scale.reshape(scale.shape[0], -1)
+        if zero_point is not None:
+            zero_point = zero_point.reshape(zero_point.shape[0], -1)
+    elif x.ndim == 2:
+        group_size = x.shape[1]  # Entire row is one "group"
+        num_rows = x.shape[0]
+        # Kernel expects scale shape [num_rows, num_groups] where num_groups = 1 for 2D
+        # Expand scale to [num_rows, 1] so kernel can index by row
+        if scale.ndim == 0:
+            scale = scale.expand(num_rows, 1).contiguous()
+        elif scale.ndim == 1:
+            scale = scale.unsqueeze(1).expand(num_rows, 1).contiguous()
+        elif scale.shape[0] == 1:
+            scale = scale.expand(num_rows, -1).contiguous()
+        if zero_point is not None:
+            if zero_point.ndim == 0:
+                zero_point = zero_point.expand(num_rows, 1).contiguous()
+            elif zero_point.ndim == 1:
+                zero_point = zero_point.unsqueeze(1).expand(num_rows, 1).contiguous()
+            elif zero_point.shape[0] == 1:
+                zero_point = zero_point.expand(num_rows, -1).contiguous()
+    else:
+        raise ValueError(f"Expected 2D or 3D tensor, got {x.ndim}D")
+
+    block_size_r: int = 32
+    block_size_c: int = 32
+    num_rows = x.shape[0]
+    num_cols = x.shape[1]
+    grid = lambda META: (
+        triton.cdiv(num_rows, META["BLOCK_SIZE_R"]),
+        triton.cdiv(num_cols, META["BLOCK_SIZE_C"]),
     )
+    quantized_value = torch.empty_like(x)
+
+    # Determine quantization type
+    quant_type = QUANT_TYPE_INT if args.type == QuantizationType.INT else QUANT_TYPE_FLOAT
+    num_bits = args.num_bits
+    
+    _quantize_kernel[grid](quantized_value,
+                           x,
+                           scale,
+                           zero_point,
+                           q_min,
+                           q_max,
+                           global_scale,
+                           num_rows,
+                           num_cols,
+                           group_size,
+                           quant_type=quant_type,
+                           num_bits=num_bits,
+                           BLOCK_SIZE_R=block_size_r,
+                           BLOCK_SIZE_C=block_size_c)
+
+    quantized_value = quantized_value.reshape(original_shape)
+
+    # Rounding is done inside _quantize_kernel for INT and FP4 types.
+    # For FP8, apply rounding via dtype cast (not supported in Triton kernel).
+    if args.type == QuantizationType.FLOAT and args.num_bits == 8:
+        original_dtype = quantized_value.dtype
+        quantized_value = quantized_value.to(FP8_E4M3_DATA.dtype).to(original_dtype)
 
     if dtype is not None:
         quantized_value = quantized_value.to(dtype)

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -353,7 +353,14 @@ def _quantize(
 
     original_shape = x.shape
 
-    if x.ndim == 3:
+    if x.ndim == 4:
+        n_rb, n_cb, bh, bw = x.shape
+        group_size = bh * bw  # Each block is one "group"
+        x = x.reshape(n_rb * n_cb, bh * bw)
+        scale = scale.reshape(n_rb * n_cb, 1)
+        if zero_point is not None:
+            zero_point = zero_point.reshape(n_rb * n_cb, 1)
+    elif x.ndim == 3:
         group_size = x.shape[2]
         x = x.reshape(x.shape[0], -1)
         scale = scale.reshape(scale.shape[0], -1)
@@ -376,7 +383,7 @@ def _quantize(
             elif zero_point.shape[0] == 1:
                 zero_point = zero_point.expand(num_rows, -1).contiguous()
     else:
-        raise ValueError(f"Expected 2D or 3D tensor, got {x.ndim}D")
+        raise ValueError(f"Expected 2D, 3D, or 4D tensor, got {x.ndim}D")
 
     block_size_r: int = 32
     block_size_c: int = 32

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -344,6 +344,11 @@ def _is_fp8_supported(device: torch.device) -> bool:
 def adapt_scale_and_zp_for_triton(
     scale: torch.Tensor, zero_point: torch.Tensor | None, num_rows: int
 ) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """
+    Adapt scale and zero point for Triton kernel.
+    Thid is required when we use group strategies, so that Triton
+    can read the correct scale and zero point for each group.
+    """
     if scale.ndim == 0:
         scale = scale.expand(num_rows, 1).contiguous()
     elif scale.ndim == 1:

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -244,82 +244,87 @@ def _quantize_dequantize(
 QUANT_TYPE_INT = tl.constexpr(0)
 QUANT_TYPE_FLOAT = tl.constexpr(1)
 
+if _triton_available:
 
-@triton.jit
-def _quantize_kernel(
-    output_ptr: tl.tensor,
-    input_ptr: tl.tensor,
-    scale_ptr: tl.tensor,
-    zero_point_ptr: tl.tensor,
-    q_min_ptr: tl.tensor,
-    q_max_ptr: tl.tensor,
-    global_scale_ptr: tl.tensor,
-    num_rows,
-    num_cols,
-    group_size,
-    quant_type: tl.constexpr,  # QUANT_TYPE_INT or QUANT_TYPE_FLOAT
-    num_bits: tl.constexpr,  # 4 or 8
-    BLOCK_SIZE_R: tl.constexpr,
-    BLOCK_SIZE_C: tl.constexpr,
-):
-    # Set up the pids.
-    pid_r = tl.program_id(axis=0)
-    pid_c = tl.program_id(axis=1)
-    offsets_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
-    offsets_c = pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C)
-    offsets = num_cols * offsets_r[:, None] + offsets_c[None, :]
+    @triton.jit
+    def _quantize_kernel(
+        output_ptr: tl.tensor,
+        input_ptr: tl.tensor,
+        scale_ptr: tl.tensor,
+        zero_point_ptr: tl.tensor,
+        q_min_ptr: tl.tensor,
+        q_max_ptr: tl.tensor,
+        global_scale_ptr: tl.tensor,
+        num_rows,
+        num_cols,
+        group_size,
+        quant_type: tl.constexpr,  # QUANT_TYPE_INT or QUANT_TYPE_FLOAT
+        num_bits: tl.constexpr,  # 4 or 8
+        BLOCK_SIZE_R: tl.constexpr,
+        BLOCK_SIZE_C: tl.constexpr,
+    ):
+        # Set up the pids.
+        pid_r = tl.program_id(axis=0)
+        pid_c = tl.program_id(axis=1)
+        offsets_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
+        offsets_c = pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C)
+        offsets = num_cols * offsets_r[:, None] + offsets_c[None, :]
 
-    masks_r = offsets_r < num_rows
-    masks_c = offsets_c < num_cols
-    masks = masks_r[:, None] & masks_c[None, :]
+        masks_r = offsets_r < num_rows
+        masks_c = offsets_c < num_cols
+        masks = masks_r[:, None] & masks_c[None, :]
 
-    scale_offsets_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
-    scale_offsets_c = (pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C)) // group_size
-    scale_offsets = (num_cols // group_size) * scale_offsets_r[
-        :, None
-    ] + scale_offsets_c[None, :]
-    scale_masks_r = scale_offsets_r < num_rows
-    scale_masks_c = scale_offsets_c < num_cols // group_size
-    scale_masks = scale_masks_r[:, None] & scale_masks_c[None, :]
+        scale_offsets_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
+        scale_offsets_c = (
+            pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C)
+        ) // group_size
+        scale_offsets = (num_cols // group_size) * scale_offsets_r[
+            :, None
+        ] + scale_offsets_c[None, :]
+        scale_masks_r = scale_offsets_r < num_rows
+        scale_masks_c = scale_offsets_c < num_cols // group_size
+        scale_masks = scale_masks_r[:, None] & scale_masks_c[None, :]
 
-    result_offsets_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
-    result_offsets_c = pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C)
-    result_offsets = num_cols * result_offsets_r[:, None] + result_offsets_c[None, :]
+        result_offsets_r = pid_r * BLOCK_SIZE_R + tl.arange(0, BLOCK_SIZE_R)
+        result_offsets_c = pid_c * BLOCK_SIZE_C + tl.arange(0, BLOCK_SIZE_C)
+        result_offsets = (
+            num_cols * result_offsets_r[:, None] + result_offsets_c[None, :]
+        )
 
-    result_masks_r = result_offsets_r < num_rows
-    result_masks_c = result_offsets_c < num_cols
-    result_masks = result_masks_r[:, None] & result_masks_c[None, :]
+        result_masks_r = result_offsets_r < num_rows
+        result_masks_c = result_offsets_c < num_cols
+        result_masks = result_masks_r[:, None] & result_masks_c[None, :]
 
-    input = tl.load(input_ptr + offsets, masks, 0.0)
-    scale = tl.load(scale_ptr + scale_offsets, scale_masks, 0.0)
+        input = tl.load(input_ptr + offsets, masks, 0.0)
+        scale = tl.load(scale_ptr + scale_offsets, scale_masks, 0.0)
 
-    if global_scale_ptr is not None:
-        global_scale = tl.load(global_scale_ptr)
-        scale = scale / global_scale.to(scale.dtype)
+        if global_scale_ptr is not None:
+            global_scale = tl.load(global_scale_ptr)
+            scale = scale / global_scale.to(scale.dtype)
 
-    output = input / scale
+        output = input / scale
 
-    if zero_point_ptr is not None:
-        zero_point = tl.load(zero_point_ptr + scale_offsets, scale_masks, 0.0)
-        output += zero_point
+        if zero_point_ptr is not None:
+            zero_point = tl.load(zero_point_ptr + scale_offsets, scale_masks, 0.0)
+            output += zero_point
 
-    # clamp and round (equivalent to round_to_quantized_type_args)
-    q_min = tl.load(q_min_ptr)
-    q_max = tl.load(q_max_ptr)
+        # clamp and round (equivalent to round_to_quantized_type_args)
+        q_min = tl.load(q_min_ptr)
+        q_max = tl.load(q_max_ptr)
 
-    if quant_type == QUANT_TYPE_INT:
-        output = tl.clamp(output, q_min, q_max)
-        output = tl.extra.cuda.libdevice.rint(output)
-    elif quant_type == QUANT_TYPE_FLOAT:
-        output = tl.clamp(output, q_min, q_max)
-        if num_bits == 4:
-            # Convert to bfloat16 for FP4 rounding (matches CPU path)
-            orig_dtype = output.dtype
-            output = _round_to_fp4(output.to(tl.bfloat16)).to(orig_dtype)
-        elif num_bits == 8:
-            output = output.to(tl.float8e4nv).to(output.dtype)
+        if quant_type == QUANT_TYPE_INT:
+            output = tl.clamp(output, q_min, q_max)
+            output = tl.extra.cuda.libdevice.rint(output)
+        elif quant_type == QUANT_TYPE_FLOAT:
+            output = tl.clamp(output, q_min, q_max)
+            if num_bits == 4:
+                # Convert to bfloat16 for FP4 rounding (matches CPU path)
+                orig_dtype = output.dtype
+                output = _round_to_fp4(output.to(tl.bfloat16)).to(orig_dtype)
+            elif num_bits == 8:
+                output = output.to(tl.float8e4nv).to(output.dtype)
 
-    tl.store(output_ptr + result_offsets, output, result_masks)
+        tl.store(output_ptr + result_offsets, output, result_masks)
 
 
 def _needs_fp8(*tensors, args: QuantizationArgs) -> bool:
@@ -378,7 +383,7 @@ def _quantize(
     do_triton: bool = False,
 ) -> torch.Tensor:
 
-    if not do_triton:
+    if not _triton_available or not do_triton:
         # if a global scale is optionally provided, use it
         # to further scale the local `scale` parameter
         if global_scale is not None:

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -4,15 +4,24 @@
 from math import ceil
 
 import torch
-import triton
-import triton.language as tl
+
+
+try:
+    import triton
+    import triton.language as tl
+
+    _triton_available = True
+except ImportError:
+    _triton_available = False
+
 from compressed_tensors.quantization.quant_args import (
-    FP8_E4M3_DATA,
     QuantizationArgs,
+    QuantizationStrategy,
     QuantizationType,
     round_to_quantized_type_args,
 )
 from compressed_tensors.quantization.utils import maybe_pad_tensor_for_block_quant
+from compressed_tensors.quantization.utils.fp4_utils import _round_to_fp4
 
 
 def _apply_quantize_op(
@@ -220,31 +229,6 @@ QUANT_TYPE_FLOAT = tl.constexpr(1)
 
 
 @triton.jit
-def _round_to_fp4(x):
-    """
-    Round float values to the nearest E2M1 representable value.
-    FP4 values: 0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0 (and their negatives)
-
-    Matches the thresholds in the Python ``cast_to_fp4`` exactly.
-    Based on vllm's nvfp4_emulation_utils.py implementation.
-    """
-    sign = tl.where(x < 0.0, -1.0, 1.0)
-    abs_x = tl.abs(x)
-
-    # Map to FP4 representable values based on thresholds
-    # Start with default 0.0, then overwrite from highest to lowest threshold
-    result = tl.where(abs_x > 5.0, 6.0, 0.0)
-    result = tl.where((abs_x >= 3.5) & (abs_x <= 5.0), 4.0, result)
-    result = tl.where((abs_x > 2.5) & (abs_x < 3.5), 3.0, result)
-    result = tl.where((abs_x >= 1.75) & (abs_x <= 2.5), 2.0, result)
-    result = tl.where((abs_x > 1.25) & (abs_x < 1.75), 1.5, result)
-    result = tl.where((abs_x >= 0.75) & (abs_x <= 1.25), 1.0, result)
-    result = tl.where((abs_x > 0.25) & (abs_x < 0.75), 0.5, result)
-
-    return result * sign
-
-
-@triton.jit
 def _quantize_kernel(
     output_ptr: tl.tensor,
     input_ptr: tl.tensor,
@@ -312,10 +296,51 @@ def _quantize_kernel(
     elif quant_type == QUANT_TYPE_FLOAT:
         output = tl.clamp(output, q_min, q_max)
         if num_bits == 4:
-            output = _round_to_fp4(output)
-        # Note: FP8 would require hardware support or casting, not implemented here
+            # Convert to bfloat16 for FP4 rounding (matches CPU path)
+            orig_dtype = output.dtype
+            output = _round_to_fp4(output.to(tl.bfloat16)).to(orig_dtype)
+        elif num_bits == 8:
+            output = output.to(tl.float8e4nv).to(output.dtype)
 
     tl.store(output_ptr + result_offsets, output, result_masks)
+
+
+def _needs_fp8(*tensors, args: QuantizationArgs) -> bool:
+    """Check if operation involves FP8 (dtype or quantization type)."""
+    fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
+    has_fp8_tensor = any(t is not None and t.dtype in fp8_dtypes for t in tensors)
+    is_fp8_quant = args.type == QuantizationType.FLOAT and args.num_bits == 8
+    return has_fp8_tensor or is_fp8_quant
+
+
+def _is_fp8_supported(device: torch.device) -> bool:
+    """Check if device supports FP8 natively."""
+    if device.type == "cuda":
+        major, _ = torch.get_device_module().get_device_capability(device)
+        return major >= 9  # SM90+ (Hopper/Ada)
+    elif device.type == "xpu":
+        # Intel XPU: conservatively disable FP8 in Triton
+        return False
+    return False
+
+
+def adapt_scale_and_zp_for_triton(
+    scale: torch.Tensor, zero_point: torch.Tensor | None, num_rows: int
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    if scale.ndim == 0:
+        scale = scale.expand(num_rows, 1).contiguous()
+    elif scale.ndim == 1:
+        scale = scale.unsqueeze(1).expand(num_rows, 1).contiguous()
+    elif scale.shape[0] == 1:
+        scale = scale.expand(num_rows, -1).contiguous()
+    if zero_point is not None:
+        if zero_point.ndim == 0:
+            zero_point = zero_point.expand(num_rows, 1).contiguous()
+        elif zero_point.ndim == 1:
+            zero_point = zero_point.unsqueeze(1).expand(num_rows, 1).contiguous()
+        elif zero_point.shape[0] == 1:
+            zero_point = zero_point.expand(num_rows, -1).contiguous()
+    return scale, zero_point
 
 
 @torch.no_grad()
@@ -331,16 +356,18 @@ def _quantize(
 ) -> torch.Tensor:
 
     # Triton only works with CUDA and XPU tensors
-    do_triton: bool = x.is_cuda or x.is_xpu
+    is_gpu = x.is_cuda or x.is_xpu
+    is_fp8 = _needs_fp8(x, scale, zero_point, global_scale, args=args)
+    fp8_hw_ok = _is_fp8_supported(x.device) if is_fp8 else True
+    do_triton: bool = is_gpu and (not is_fp8 or fp8_hw_ok)
 
     if not do_triton:
         # if a global scale is optionally provided, use it
         # to further scale the local `scale` parameter
-        scale_ground = scale.clone()
         if global_scale is not None:
-            scale_ground = scale / global_scale
+            scale /= global_scale
 
-        scaled = x / scale_ground
+        scaled = x / scale
         if zero_point is not None:
             scaled += zero_point.to(x.dtype)
         quantized_ground = round_to_quantized_type_args(
@@ -353,42 +380,31 @@ def _quantize(
 
     original_shape = x.shape
 
-    if x.ndim == 4:
+    if args.strategy == QuantizationStrategy.BLOCK:
+        # Block quantization - 4D input
         n_rb, n_cb, bh, bw = x.shape
-        group_size = bh * bw  # Each block is one "group"
-        x = x.reshape(n_rb * n_cb, bh * bw)
-        scale = scale.reshape(n_rb * n_cb, 1)
-        if zero_point is not None:
-            zero_point = zero_point.reshape(n_rb * n_cb, 1)
-    elif x.ndim == 3:
+        group_size = bh * bw
+        num_rows = n_rb * n_cb
+        num_cols = bh * bw
+    elif args.strategy in (
+        QuantizationStrategy.GROUP,
+        QuantizationStrategy.TENSOR_GROUP,
+    ):
+        # Group quantization - 3D input (batch, num_groups, group_size)
         group_size = x.shape[2]
-        x = x.reshape(x.shape[0], -1)
-        scale = scale.reshape(scale.shape[0], -1)
-        if zero_point is not None:
-            zero_point = zero_point.reshape(zero_point.shape[0], -1)
-    elif x.ndim == 2:
-        group_size = x.shape[1]  # Entire row is one "group"
         num_rows = x.shape[0]
-        if scale.ndim == 0:
-            scale = scale.expand(num_rows, 1).contiguous()
-        elif scale.ndim == 1:
-            scale = scale.unsqueeze(1).expand(num_rows, 1).contiguous()
-        elif scale.shape[0] == 1:
-            scale = scale.expand(num_rows, -1).contiguous()
-        if zero_point is not None:
-            if zero_point.ndim == 0:
-                zero_point = zero_point.expand(num_rows, 1).contiguous()
-            elif zero_point.ndim == 1:
-                zero_point = zero_point.unsqueeze(1).expand(num_rows, 1).contiguous()
-            elif zero_point.shape[0] == 1:
-                zero_point = zero_point.expand(num_rows, -1).contiguous()
+        num_cols = x.shape[1] * x.shape[2]
+    elif args.strategy in (QuantizationStrategy.TENSOR, QuantizationStrategy.CHANNEL):
+        # Tensor/Channel quantization - 2D input
+        group_size = x.shape[1]
+        num_rows = x.shape[0]
+        num_cols = x.shape[1]
+        scale, zero_point = adapt_scale_and_zp_for_triton(scale, zero_point, num_rows)
     else:
-        raise ValueError(f"Expected 2D, 3D, or 4D tensor, got {x.ndim}D")
+        raise ValueError(f"Unsupported quantization strategy: {args.strategy}")
 
     block_size_r: int = 32
     block_size_c: int = 32
-    num_rows = x.shape[0]
-    num_cols = x.shape[1]
 
     def grid(META):
         return (
@@ -422,12 +438,6 @@ def _quantize(
     )
 
     quantized_value = quantized_value.reshape(original_shape)
-
-    # Rounding is done inside _quantize_kernel for INT and FP4 types.
-    # For FP8, apply rounding via dtype cast (not supported in Triton kernel).
-    if args.type == QuantizationType.FLOAT and args.num_bits == 8:
-        original_dtype = quantized_value.dtype
-        quantized_value = quantized_value.to(FP8_E4M3_DATA.dtype).to(original_dtype)
 
     if dtype is not None:
         quantized_value = quantized_value.to(dtype)

--- a/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
+++ b/src/compressed_tensors/quantization/lifecycle/forward_helpers.py
@@ -48,6 +48,22 @@ def _apply_quantize_op(
             global_scale=global_scale,
         )
     elif do_quantize:
+        # Determine if Triton should be used
+        is_gpu = x.is_cuda or x.is_xpu
+        is_fp8 = _needs_fp8(x, scale, zero_point, global_scale, args=args)
+        fp8_hw_ok = _is_fp8_supported(x.device) if is_fp8 else True
+        do_triton: bool = is_gpu and (not is_fp8 or fp8_hw_ok)
+
+        # Adapt scale/zp for Triton if needed
+        if do_triton and args.strategy in (
+            QuantizationStrategy.TENSOR,
+            QuantizationStrategy.CHANNEL,
+        ):
+            num_rows = x.shape[0]
+            scale, zero_point = adapt_scale_and_zp_for_triton(
+                scale, zero_point, num_rows
+            )
+
         return _quantize(
             x=x,
             scale=scale,
@@ -57,6 +73,7 @@ def _apply_quantize_op(
             args=args,
             dtype=dtype,
             global_scale=global_scale,
+            do_triton=do_triton,
         )
     else:
         return _dequantize(
@@ -353,13 +370,8 @@ def _quantize(
     args: QuantizationArgs,
     dtype: torch.dtype | None = None,
     global_scale: torch.Tensor | None = None,
+    do_triton: bool = False,
 ) -> torch.Tensor:
-
-    # Triton only works with CUDA and XPU tensors
-    is_gpu = x.is_cuda or x.is_xpu
-    is_fp8 = _needs_fp8(x, scale, zero_point, global_scale, args=args)
-    fp8_hw_ok = _is_fp8_supported(x.device) if is_fp8 else True
-    do_triton: bool = is_gpu and (not is_fp8 or fp8_hw_ok)
 
     if not do_triton:
         # if a global scale is optionally provided, use it
@@ -399,7 +411,6 @@ def _quantize(
         group_size = x.shape[1]
         num_rows = x.shape[0]
         num_cols = x.shape[1]
-        scale, zero_point = adapt_scale_and_zp_for_triton(scale, zero_point, num_rows)
     else:
         raise ValueError(f"Unsupported quantization strategy: {args.strategy}")
 

--- a/src/compressed_tensors/quantization/utils/fp4_utils.py
+++ b/src/compressed_tensors/quantization/utils/fp4_utils.py
@@ -19,20 +19,14 @@ __all__ = ["cast_to_fp4_triton", "cast_to_fp4_torch"]
 if _triton_available:
 
     @triton.jit
-    def _cast_to_fp4_kernel(
-        input_ptr,
-        output_ptr,
-        n,
-        BLOCK_SIZE: tl.constexpr,
-    ):
-        pid = tl.program_id(axis=0)
-        block_start = pid * BLOCK_SIZE
-        offsets = block_start + tl.arange(0, BLOCK_SIZE)
-        mask = offsets < n
+    def _round_to_fp4(x):
+        """
+        Round float values to the nearest E2M1 representable value.
+        FP4 values: 0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0 (and their negatives)
 
-        x = tl.load(input_ptr + offsets, mask=mask, other=0.0)
-        x = x.to(tl.bfloat16)
-
+        Matches the thresholds in the Python ``cast_to_fp4`` exactly.
+        Based on vllm's nvfp4_emulation_utils.py implementation.
+        """
         sign_bit = x.to(tl.int16, bitcast=True) & (-32768)
         abs_x = tl.abs(x)
 
@@ -48,6 +42,24 @@ if _triton_available:
         result = (result.to(tl.int16, bitcast=True) | sign_bit).to(
             tl.bfloat16, bitcast=True
         )
+        return result
+
+    @triton.jit
+    def _cast_to_fp4_kernel(
+        input_ptr,
+        output_ptr,
+        n,
+        BLOCK_SIZE: tl.constexpr,
+    ):
+        pid = tl.program_id(axis=0)
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n
+
+        x = tl.load(input_ptr + offsets, mask=mask, other=0.0)
+        x = x.to(tl.bfloat16)
+
+        result = _round_to_fp4(x)
         tl.store(output_ptr + offsets, result, mask=mask)
 
 

--- a/tests/test_compressors/test_fp4_optimizations.py
+++ b/tests/test_compressors/test_fp4_optimizations.py
@@ -62,7 +62,7 @@ def test_pack_fp4_to_uint8(device, test_input):
 @pytest.mark.parametrize("device", ["cuda"])
 def test_pack_fp4_to_uint8_float32_input(device):
     """Test pack_fp4_to_uint8 accepts float32 inputs in the valid FP4 set."""
-    if device == "cuda" and not torch.cuda.is_available():
+    if device == "cuda" and not torch.accelerator.is_available():
         pytest.skip("CUDA not available")
 
     from compressed_tensors.compressors.nvfp4.helpers import pack_fp4_to_uint8

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -671,7 +671,9 @@ def test_quantize_dequantize_matches_sequential(
         global_scale=global_scale,
     )
 
-    atol = 1e-5
+    # For int types, there are edge cases where a <1e-5 difference gets
+    # rounded to a different integer on CPU and GPU.
+    atol = 1.0 if type == "int" else 1e-4
 
     assert torch.allclose(sequential_out, fused_out, atol=atol), (
         f"Mismatch: max diff = "
@@ -745,7 +747,11 @@ def test_quantize_triton_matches_cpu(num_bits, type, symmetric, global_scale):
     # Compare results (bring CUDA output back to CPU)
     cuda_out_cpu = cuda_out.cpu()
 
-    assert torch.allclose(cpu_out, cuda_out_cpu, atol=1e-5), (
+    # For int types, there are edge cases where a <1e-5 difference gets
+    # rounded to a different integer on CPU and GPU.
+    atol = 1.0 if type == "int" else 1e-5
+
+    assert torch.allclose(cpu_out, cuda_out_cpu, atol=atol), (
         f"Mismatch between CPU and Triton paths: max diff = "
         f"{(cpu_out - cuda_out_cpu).abs().max().item()}"
     )

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -624,7 +624,7 @@ def test_quantize_dequantize_matches_sequential(
 ):
     """Verify that the fused _quantize_dequantize produces identical output
     to calling _quantize then _dequantize sequentially."""
-    if device == "cuda" and not torch.cuda.is_available():
+    if device == "cuda" and not torch.accelerator.is_available():
         pytest.skip("CUDA not available")
     if device == "cpu" and type == "float" and num_bits == 4:
         pytest.skip("FP4 on CPU is slow, only test on CUDA")

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -606,33 +606,42 @@ def test_process_quantization_block_non_divisible_values(
     ), f"Values mismatch for 0.5: got min={out_val.min()}, max={out_val.max()}"
 
 
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
 @pytest.mark.parametrize(
     "num_bits,type,symmetric,global_scale",
     [
         (8, "int", True, None),
         (8, "int", False, None),
         (4, "int", True, None),
+        (4, "float", True, None),  # FP4
         (8, "float", True, None),
         (8, "float", True, torch.tensor([2.0])),
         (8, "int", False, torch.tensor([2.0])),
     ],
 )
 def test_quantize_dequantize_matches_sequential(
-    num_bits, type, symmetric, global_scale
+    num_bits, type, symmetric, global_scale, device
 ):
     """Verify that the fused _quantize_dequantize produces identical output
     to calling _quantize then _dequantize sequentially."""
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    if device == "cpu" and type == "float" and num_bits == 4:
+        pytest.skip("FP4 on CPU is slow, only test on CUDA")
+    
     args = QuantizationArgs(
         num_bits=num_bits,
         type=type,
         symmetric=symmetric,
         strategy=QuantizationStrategy.TENSOR,
     )
-    q_min, q_max = calculate_range(args, torch.device("cpu"))
+    q_min, q_max = calculate_range(args, torch.device(device))
 
-    x = torch.randn(512, 1024)
-    scale = torch.rand(1) * 0.01 + 0.001
-    zero_point = None if symmetric else torch.tensor([3.0])
+    x = torch.randn(512, 1024, device=device)
+    scale = (torch.rand(1) * 0.01 + 0.001).to(device)
+    zero_point = None if symmetric else torch.tensor([3.0], device=device)
+    if global_scale is not None:
+        global_scale = global_scale.to(device)
 
     # sequential: quantize then dequantize
     q = _quantize(
@@ -662,6 +671,14 @@ def test_quantize_dequantize_matches_sequential(
         global_scale=global_scale,
     )
 
-    assert torch.equal(
-        sequential_out, fused_out
-    ), f"Mismatch: max diff = {(sequential_out - fused_out).abs().max().item()}"
+    # Tolerance depends on quantization type:
+    # - INT: small differences due to rounding mode (round-half-away-from-zero vs round-half-to-even)
+    # - FLOAT: small tolerance for numerical precision
+    if type == "int":
+        atol = 0.01  # Rounding mode differences
+    else:
+        atol = 1e-5  # FLOAT types should match closely
+    
+    assert torch.allclose(
+        sequential_out, fused_out, atol=atol
+    ), f"Mismatch: max diff = {(sequential_out - fused_out).abs().max().item()}, atol={atol}"

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -671,13 +671,81 @@ def test_quantize_dequantize_matches_sequential(
         global_scale=global_scale,
     )
 
-    # Tolerance depends on quantization type
-    if type == "int":
-        atol = 0.01
-    else:
-        atol = 1e-5
+    atol = 1e-5
 
     assert torch.allclose(sequential_out, fused_out, atol=atol), (
         f"Mismatch: max diff = "
         f"{(sequential_out - fused_out).abs().max().item()}, atol={atol}"
+    )
+
+
+@pytest.mark.parametrize(
+    "num_bits,type,symmetric,global_scale",
+    [
+        (8, "int", True, None),
+        (8, "int", False, None),
+        (4, "int", True, None),
+        (4, "float", True, None),  # FP4
+        (8, "float", True, None),
+        (8, "float", True, torch.tensor([2.0])),
+        (8, "int", False, torch.tensor([2.0])),
+    ],
+)
+def test_quantize_triton_matches_cpu(num_bits, type, symmetric, global_scale):
+    """Verify that the Triton kernel (CUDA) produces identical output
+    to the non-Triton (CPU) codepath for _quantize."""
+    if not torch.accelerator.is_available():
+        pytest.skip("CUDA not available")
+
+    args = QuantizationArgs(
+        num_bits=num_bits,
+        type=type,
+        symmetric=symmetric,
+        strategy=QuantizationStrategy.TENSOR,
+    )
+
+    # Create input on CPU first
+    x_cpu = torch.randn(512, 1024)
+    scale_cpu = torch.rand(1) * 0.01 + 0.001
+    zero_point_cpu = None if symmetric else torch.tensor([3.0])
+    global_scale_cpu = global_scale.clone() if global_scale is not None else None
+
+    q_min_cpu, q_max_cpu = calculate_range(args, torch.device("cpu"))
+
+    # Run CPU (non-Triton) path
+    cpu_out = _quantize(
+        x=x_cpu,
+        scale=scale_cpu,
+        zero_point=zero_point_cpu,
+        q_min=q_min_cpu,
+        q_max=q_max_cpu,
+        args=args,
+        global_scale=global_scale_cpu,
+    )
+
+    # Copy to CUDA and run Triton path
+    x_cuda = x_cpu.cuda()
+    scale_cuda = scale_cpu.cuda()
+    zero_point_cuda = zero_point_cpu.cuda() if zero_point_cpu is not None else None
+    global_scale_cuda = (
+        global_scale_cpu.cuda() if global_scale_cpu is not None else None
+    )
+    q_min_cuda, q_max_cuda = calculate_range(args, torch.device("cuda"))
+
+    cuda_out = _quantize(
+        x=x_cuda,
+        scale=scale_cuda,
+        zero_point=zero_point_cuda,
+        q_min=q_min_cuda,
+        q_max=q_max_cuda,
+        args=args,
+        global_scale=global_scale_cuda,
+    )
+
+    # Compare results (bring CUDA output back to CPU)
+    cuda_out_cpu = cuda_out.cpu()
+
+    assert torch.allclose(cpu_out, cuda_out_cpu, atol=1e-5), (
+        f"Mismatch between CPU and Triton paths: max diff = "
+        f"{(cpu_out - cuda_out_cpu).abs().max().item()}"
     )

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -628,7 +628,7 @@ def test_quantize_dequantize_matches_sequential(
         pytest.skip("CUDA not available")
     if device == "cpu" and type == "float" and num_bits == 4:
         pytest.skip("FP4 on CPU is slow, only test on CUDA")
-    
+
     args = QuantizationArgs(
         num_bits=num_bits,
         type=type,
@@ -671,14 +671,13 @@ def test_quantize_dequantize_matches_sequential(
         global_scale=global_scale,
     )
 
-    # Tolerance depends on quantization type:
-    # - INT: small differences due to rounding mode (round-half-away-from-zero vs round-half-to-even)
-    # - FLOAT: small tolerance for numerical precision
+    # Tolerance depends on quantization type
     if type == "int":
-        atol = 0.01  # Rounding mode differences
+        atol = 0.01
     else:
-        atol = 1e-5  # FLOAT types should match closely
-    
-    assert torch.allclose(
-        sequential_out, fused_out, atol=atol
-    ), f"Mismatch: max diff = {(sequential_out - fused_out).abs().max().item()}, atol={atol}"
+        atol = 1e-5
+
+    assert torch.allclose(sequential_out, fused_out, atol=atol), (
+        f"Mismatch: max diff = "
+        f"{(sequential_out - fused_out).abs().max().item()}, atol={atol}"
+    )

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -671,13 +671,14 @@ def test_quantize_dequantize_matches_sequential(
         global_scale=global_scale,
     )
 
-    # For int types, there are edge cases where a <1e-5 difference gets
-    # rounded to a different integer on CPU and GPU.
-    atol = 1.0 if type == "int" else 1e-4
+    if type == "int":
+        atol, rtol = 1.0, 0  # allow +/-1 due to rounding corner cases
+    else:
+        atol, rtol = 1e-5, 0.05
 
-    assert torch.allclose(sequential_out, fused_out, atol=atol), (
-        f"Mismatch: max diff = "
-        f"{(sequential_out - fused_out).abs().max().item()}, atol={atol}"
+    assert torch.allclose(sequential_out, fused_out, atol=atol, rtol=rtol), (
+        f"Mismatch: max diff = {(sequential_out - fused_out).abs().max().item()}, "
+        f"atol={atol}, rtol={rtol}"
     )
 
 

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -674,7 +674,7 @@ def test_quantize_dequantize_matches_sequential(
     if type == "int":
         atol, rtol = 1.0, 0  # allow +/-1 due to rounding corner cases
     else:
-        atol, rtol = 1e-5, 0.05
+        atol, rtol = 1e-5, 0.15
 
     assert torch.allclose(sequential_out, fused_out, atol=atol, rtol=rtol), (
         f"Mismatch: max diff = {(sequential_out - fused_out).abs().max().item()}, "
@@ -750,9 +750,12 @@ def test_quantize_triton_matches_cpu(num_bits, type, symmetric, global_scale):
 
     # For int types, there are edge cases where a <1e-5 difference gets
     # rounded to a different integer on CPU and GPU.
-    atol = 1.0 if type == "int" else 1e-5
+    if type == "int":
+        atol, rtol = 1.0, 0
+    else:
+        atol, rtol = 1e-5, 0.15
 
-    assert torch.allclose(cpu_out, cuda_out_cpu, atol=atol), (
+    assert torch.allclose(cpu_out, cuda_out_cpu, atol=atol, rtol=rtol), (
         f"Mismatch between CPU and Triton paths: max diff = "
         f"{(cpu_out - cuda_out_cpu).abs().max().item()}"
     )

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -13,8 +13,11 @@ from compressed_tensors.quantization.lifecycle.forward import (
 )
 from compressed_tensors.quantization.lifecycle.forward_helpers import (
     _dequantize,
+    _is_fp8_supported,
+    _needs_fp8,
     _quantize,
     _quantize_dequantize,
+    adapt_scale_and_zp_for_triton,
 )
 from compressed_tensors.quantization.lifecycle.initialize import (
     initialize_module_for_quantization,
@@ -676,23 +679,40 @@ def test_quantize_dequantize_matches_sequential(
     if global_scale is not None:
         global_scale = global_scale.to(device)
 
-    scale_ground_quant = scale.clone()
+    # Determine if Triton should be used
+    is_gpu = x.is_cuda or x.is_xpu
+    is_fp8 = _needs_fp8(x, scale, zero_point, global_scale, args=args)
+    fp8_hw_ok = _is_fp8_supported(x.device) if is_fp8 else True
+    do_triton = is_gpu and (not is_fp8 or fp8_hw_ok)
+
+    # Keep original scale/zp for dequantize
     scale_ground_dequant = scale.clone()
+    zero_point_dequant = zero_point.clone() if zero_point is not None else None
+
+    # Adapt scale/zp for Triton if needed (for _quantize only)
+    scale_quant = scale.clone()
+    zero_point_quant = zero_point.clone() if zero_point is not None else None
+    if do_triton and group_size is None:  # TENSOR strategy
+        num_rows = x.shape[0]
+        scale_quant, zero_point_quant = adapt_scale_and_zp_for_triton(
+            scale_quant, zero_point_quant, num_rows
+        )
 
     # sequential: quantize then dequantize
     q = _quantize(
         x=x,
-        scale=scale_ground_quant,
-        zero_point=zero_point,
+        scale=scale_quant,
+        zero_point=zero_point_quant,
         q_min=q_min,
         q_max=q_max,
         args=args,
         global_scale=global_scale,
+        do_triton=do_triton,
     )
     sequential_out = _dequantize(
         x_q=q,
         scale=scale_ground_dequant,
-        zero_point=zero_point,
+        zero_point=zero_point_dequant,
         global_scale=global_scale,
     )
 
@@ -794,6 +814,13 @@ def test_quantize_triton_matches_cpu(
     )
     q_min_cuda, q_max_cuda = calculate_range(args, torch.device("cuda"))
 
+    # Adapt scale/zp for Triton if TENSOR strategy
+    if group_size is None:  # TENSOR strategy
+        num_rows = x_cuda.shape[0]
+        scale_cuda, zero_point_cuda = adapt_scale_and_zp_for_triton(
+            scale_cuda, zero_point_cuda, num_rows
+        )
+
     # Run CPU (non-Triton) path
     cpu_out = _quantize(
         x=x_cpu,
@@ -803,6 +830,7 @@ def test_quantize_triton_matches_cpu(
         q_max=q_max_cpu,
         args=args,
         global_scale=global_scale_cpu,
+        do_triton=False,
     )
 
     cuda_out = _quantize(
@@ -813,6 +841,7 @@ def test_quantize_triton_matches_cpu(
         q_max=q_max_cuda,
         args=args,
         global_scale=global_scale_cuda,
+        do_triton=True,
     )
 
     # Compare results (bring CUDA output back to CPU)

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -606,7 +606,7 @@ def test_process_quantization_block_non_divisible_values(
     ), f"Values mismatch for 0.5: got min={out_val.min()}, max={out_val.max()}"
 
 
-@pytest.mark.parametrize("device", ["cpu", "cuda"])
+@pytest.mark.parametrize("device", ["cpu", "cuda", "meta"])
 @pytest.mark.parametrize(
     "num_bits,type,symmetric,global_scale,group_size",
     [
@@ -706,6 +706,9 @@ def test_quantize_dequantize_matches_sequential(
         args=args,
         global_scale=global_scale,
     )
+
+    if device == "meta":
+        return  # Meta tensors have no data; can only verify code doesn't crash
 
     if type == "int":
         atol, rtol = 1.0, 0  # allow +/-1 due to rounding corner cases

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -858,3 +858,134 @@ def test_quantize_triton_matches_cpu(
         f"Mismatch between CPU and Triton paths: max diff = "
         f"{(cpu_out - cuda_out_cpu).abs().max().item()}"
     )
+
+
+@pytest.mark.parametrize(
+    "num_bits,type,symmetric,global_scale,group_size",
+    [
+        # Tensor-level quantization (group_size=None)
+        (8, "int", True, None, None),
+        (8, "int", False, None, None),
+        (4, "int", True, None, None),
+        (4, "float", True, None, None),  # FP4
+        (8, "float", True, None, None),
+        (8, "float", True, torch.tensor([2.0]), None),
+        (8, "int", False, torch.tensor([2.0]), None),
+        # Group quantization
+        (8, "int", True, None, 128),
+        (8, "int", False, None, 128),
+        (4, "int", True, None, 128),
+        (4, "float", True, None, 128),  # FP4
+        (8, "float", True, None, 128),
+        (8, "float", True, torch.tensor([2.0]), 128),
+        (8, "int", False, torch.tensor([2.0]), 128),
+        (8, "int", True, None, 64),
+        (8, "int", False, None, 256),
+    ],
+)
+def test_quantize_triton_matches_cpu_non_contiguous(
+    num_bits, type, symmetric, global_scale, group_size
+):
+    """Verify that the Triton kernel (CUDA) produces identical output
+    to the non-Triton (CPU) codepath for _quantize with non-contiguous tensors."""
+    if not torch.accelerator.is_available():
+        pytest.skip("CUDA not available")
+
+    num_rows = 512
+    num_cols = 1024
+
+    if group_size is None:
+        strategy = QuantizationStrategy.TENSOR
+        args = QuantizationArgs(
+            num_bits=num_bits,
+            type=type,
+            symmetric=symmetric,
+            strategy=strategy,
+        )
+        # Create non-contiguous tensor via transpose
+        x_base = torch.randn(num_cols, num_rows)
+        x_cpu = x_base.t()
+        assert not x_cpu.is_contiguous(), "Test requires non-contiguous tensor"
+        scale_cpu = torch.rand(1) * 0.01 + 0.001
+        zero_point_cpu = None if symmetric else torch.tensor([3.0])
+    else:
+        strategy = QuantizationStrategy.GROUP
+        num_groups = num_cols // group_size
+        args = QuantizationArgs(
+            num_bits=num_bits,
+            type=type,
+            symmetric=symmetric,
+            strategy=strategy,
+            group_size=group_size,
+        )
+        # Create non-contiguous tensor via transpose of first two dimensions
+        x_base = torch.randn(num_groups, num_rows, group_size)
+        x_cpu = x_base.permute(1, 0, 2)
+        assert not x_cpu.is_contiguous(), "Test requires non-contiguous tensor"
+        # Also make scale non-contiguous
+        scale_base = torch.rand(num_groups, num_rows, 1) * 0.01 + 0.001
+        scale_cpu = scale_base.permute(1, 0, 2)
+        assert not scale_cpu.is_contiguous(), "Test requires non-contiguous scale"
+        zero_point_cpu = (
+            None
+            if symmetric
+            else (torch.zeros(num_groups, num_rows, 1) + 3.0).permute(1, 0, 2)
+        )
+        if zero_point_cpu is not None:
+            assert (
+                not zero_point_cpu.is_contiguous()
+            ), "Test requires non-contiguous zero_point"
+
+    global_scale_cpu = global_scale.clone() if global_scale is not None else None
+    q_min_cpu, q_max_cpu = calculate_range(args, torch.device("cpu"))
+
+    x_cuda = x_cpu.cuda()
+    scale_cuda = scale_cpu.cuda()
+    zero_point_cuda = zero_point_cpu.cuda() if zero_point_cpu is not None else None
+    global_scale_cuda = (
+        global_scale_cpu.cuda() if global_scale_cpu is not None else None
+    )
+    q_min_cuda, q_max_cuda = calculate_range(args, torch.device("cuda"))
+
+    assert not x_cuda.is_contiguous(), "CUDA tensor should be non-contiguous"
+
+    # Adapt scale/zp for Triton if TENSOR strategy
+    if group_size is None:
+        num_rows = x_cuda.shape[0]
+        scale_cuda, zero_point_cuda = adapt_scale_and_zp_for_triton(
+            scale_cuda, zero_point_cuda, num_rows
+        )
+
+    cpu_out = _quantize(
+        x=x_cpu,
+        scale=scale_cpu,
+        zero_point=zero_point_cpu,
+        q_min=q_min_cpu,
+        q_max=q_max_cpu,
+        args=args,
+        global_scale=global_scale_cpu,
+        do_triton=False,
+    )
+
+    cuda_out = _quantize(
+        x=x_cuda,
+        scale=scale_cuda,
+        zero_point=zero_point_cuda,
+        q_min=q_min_cuda,
+        q_max=q_max_cuda,
+        args=args,
+        global_scale=global_scale_cuda,
+        do_triton=True,
+    )
+
+    cuda_out_cpu = cuda_out.cpu()
+
+    if type == "int":
+        atol, rtol = 1.0, 0
+    else:
+        atol, rtol = 1e-5, 0.15
+
+    assert torch.allclose(cpu_out, cuda_out_cpu, atol=atol, rtol=rtol), (
+        f"Mismatch between CPU and Triton paths (non-contiguous): max diff = "
+        f"{(cpu_out - cuda_out_cpu).abs().max().item()}"
+    )

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -608,19 +608,30 @@ def test_process_quantization_block_non_divisible_values(
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
 @pytest.mark.parametrize(
-    "num_bits,type,symmetric,global_scale",
+    "num_bits,type,symmetric,global_scale,group_size",
     [
-        (8, "int", True, None),
-        (8, "int", False, None),
-        (4, "int", True, None),
-        (4, "float", True, None),  # FP4
-        (8, "float", True, None),
-        (8, "float", True, torch.tensor([2.0])),
-        (8, "int", False, torch.tensor([2.0])),
+        # Tensor-level quantization (group_size=None)
+        (8, "int", True, None, None),
+        (8, "int", False, None, None),
+        (4, "int", True, None, None),
+        (4, "float", True, None, None),  # FP4
+        (8, "float", True, None, None),
+        (8, "float", True, torch.tensor([2.0]), None),
+        (8, "int", False, torch.tensor([2.0]), None),
+        # Group quantization
+        (8, "int", True, None, 128),
+        (8, "int", False, None, 128),
+        (4, "int", True, None, 128),
+        (4, "float", True, None, 128),  # FP4
+        (8, "float", True, None, 128),
+        (8, "float", True, torch.tensor([2.0]), 128),
+        (8, "int", False, torch.tensor([2.0]), 128),
+        (8, "int", True, None, 64),
+        (8, "int", False, None, 256),
     ],
 )
 def test_quantize_dequantize_matches_sequential(
-    num_bits, type, symmetric, global_scale, device
+    num_bits, type, symmetric, global_scale, group_size, device
 ):
     """Verify that the fused _quantize_dequantize produces identical output
     to calling _quantize then _dequantize sequentially."""
@@ -629,17 +640,39 @@ def test_quantize_dequantize_matches_sequential(
     if device == "cpu" and type == "float" and num_bits == 4:
         pytest.skip("FP4 on CPU is slow, only test on CUDA")
 
-    args = QuantizationArgs(
-        num_bits=num_bits,
-        type=type,
-        symmetric=symmetric,
-        strategy=QuantizationStrategy.TENSOR,
-    )
-    q_min, q_max = calculate_range(args, torch.device(device))
+    num_rows = 512
+    num_cols = 1024
 
-    x = torch.randn(512, 1024, device=device)
-    scale = (torch.rand(1) * 0.01 + 0.001).to(device)
-    zero_point = None if symmetric else torch.tensor([3.0], device=device)
+    if group_size is None:
+        strategy = QuantizationStrategy.TENSOR
+        args = QuantizationArgs(
+            num_bits=num_bits,
+            type=type,
+            symmetric=symmetric,
+            strategy=strategy,
+        )
+        x = torch.randn(num_rows, num_cols, device=device)
+        scale = (torch.rand(1) * 0.01 + 0.001).to(device)
+        zero_point = None if symmetric else torch.tensor([3.0], device=device)
+    else:
+        strategy = QuantizationStrategy.GROUP
+        num_groups = num_cols // group_size
+        args = QuantizationArgs(
+            num_bits=num_bits,
+            type=type,
+            symmetric=symmetric,
+            strategy=strategy,
+            group_size=group_size,
+        )
+        x = torch.randn(num_rows, num_groups, group_size, device=device)
+        scale = torch.rand(num_rows, num_groups, 1, device=device) * 0.01 + 0.001
+        zero_point = (
+            None
+            if symmetric
+            else torch.zeros(num_rows, num_groups, 1, device=device) + 3.0
+        )
+
+    q_min, q_max = calculate_range(args, torch.device(device))
     if global_scale is not None:
         global_scale = global_scale.to(device)
 
@@ -683,36 +716,67 @@ def test_quantize_dequantize_matches_sequential(
 
 
 @pytest.mark.parametrize(
-    "num_bits,type,symmetric,global_scale",
+    "num_bits,type,symmetric,global_scale,group_size",
     [
-        (8, "int", True, None),
-        (8, "int", False, None),
-        (4, "int", True, None),
-        (4, "float", True, None),  # FP4
-        (8, "float", True, None),
-        (8, "float", True, torch.tensor([2.0])),
-        (8, "int", False, torch.tensor([2.0])),
+        # Tensor-level quantization (group_size=None)
+        (8, "int", True, None, None),
+        (8, "int", False, None, None),
+        (4, "int", True, None, None),
+        (4, "float", True, None, None),  # FP4
+        (8, "float", True, None, None),
+        (8, "float", True, torch.tensor([2.0]), None),
+        (8, "int", False, torch.tensor([2.0]), None),
+        # Group quantization
+        (8, "int", True, None, 128),
+        (8, "int", False, None, 128),
+        (4, "int", True, None, 128),
+        (4, "float", True, None, 128),  # FP4
+        (8, "float", True, None, 128),
+        (8, "float", True, torch.tensor([2.0]), 128),
+        (8, "int", False, torch.tensor([2.0]), 128),
+        (8, "int", True, None, 64),
+        (8, "int", False, None, 256),
     ],
 )
-def test_quantize_triton_matches_cpu(num_bits, type, symmetric, global_scale):
+def test_quantize_triton_matches_cpu(
+    num_bits, type, symmetric, global_scale, group_size
+):
     """Verify that the Triton kernel (CUDA) produces identical output
     to the non-Triton (CPU) codepath for _quantize."""
     if not torch.accelerator.is_available():
         pytest.skip("CUDA not available")
 
-    args = QuantizationArgs(
-        num_bits=num_bits,
-        type=type,
-        symmetric=symmetric,
-        strategy=QuantizationStrategy.TENSOR,
-    )
+    num_rows = 512
+    num_cols = 1024
 
-    # Create input on CPU first
-    x_cpu = torch.randn(512, 1024)
-    scale_cpu = torch.rand(1) * 0.01 + 0.001
-    zero_point_cpu = None if symmetric else torch.tensor([3.0])
+    if group_size is None:
+        strategy = QuantizationStrategy.TENSOR
+        args = QuantizationArgs(
+            num_bits=num_bits,
+            type=type,
+            symmetric=symmetric,
+            strategy=strategy,
+        )
+        x_cpu = torch.randn(num_rows, num_cols)
+        scale_cpu = torch.rand(1) * 0.01 + 0.001
+        zero_point_cpu = None if symmetric else torch.tensor([3.0])
+    else:
+        strategy = QuantizationStrategy.GROUP
+        num_groups = num_cols // group_size
+        args = QuantizationArgs(
+            num_bits=num_bits,
+            type=type,
+            symmetric=symmetric,
+            strategy=strategy,
+            group_size=group_size,
+        )
+        x_cpu = torch.randn(num_rows, num_groups, group_size)
+        scale_cpu = torch.rand(num_rows, num_groups, 1) * 0.01 + 0.001
+        zero_point_cpu = (
+            None if symmetric else torch.zeros(num_rows, num_groups, 1) + 3.0
+        )
+
     global_scale_cpu = global_scale.clone() if global_scale is not None else None
-
     q_min_cpu, q_max_cpu = calculate_range(args, torch.device("cpu"))
 
     # Run CPU (non-Triton) path

--- a/tests/test_quantization/lifecycle/test_forward.py
+++ b/tests/test_quantization/lifecycle/test_forward.py
@@ -676,10 +676,13 @@ def test_quantize_dequantize_matches_sequential(
     if global_scale is not None:
         global_scale = global_scale.to(device)
 
+    scale_ground_quant = scale.clone()
+    scale_ground_dequant = scale.clone()
+
     # sequential: quantize then dequantize
     q = _quantize(
         x=x,
-        scale=scale,
+        scale=scale_ground_quant,
         zero_point=zero_point,
         q_min=q_min,
         q_max=q_max,
@@ -688,7 +691,7 @@ def test_quantize_dequantize_matches_sequential(
     )
     sequential_out = _dequantize(
         x_q=q,
-        scale=scale,
+        scale=scale_ground_dequant,
         zero_point=zero_point,
         global_scale=global_scale,
     )
@@ -779,6 +782,15 @@ def test_quantize_triton_matches_cpu(
     global_scale_cpu = global_scale.clone() if global_scale is not None else None
     q_min_cpu, q_max_cpu = calculate_range(args, torch.device("cpu"))
 
+    # Copy to CUDA and run Triton path
+    x_cuda = x_cpu.cuda()
+    scale_cuda = scale_cpu.cuda()
+    zero_point_cuda = zero_point_cpu.cuda() if zero_point_cpu is not None else None
+    global_scale_cuda = (
+        global_scale_cpu.cuda() if global_scale_cpu is not None else None
+    )
+    q_min_cuda, q_max_cuda = calculate_range(args, torch.device("cuda"))
+
     # Run CPU (non-Triton) path
     cpu_out = _quantize(
         x=x_cpu,
@@ -789,15 +801,6 @@ def test_quantize_triton_matches_cpu(
         args=args,
         global_scale=global_scale_cpu,
     )
-
-    # Copy to CUDA and run Triton path
-    x_cuda = x_cpu.cuda()
-    scale_cuda = scale_cpu.cuda()
-    zero_point_cuda = zero_point_cpu.cuda() if zero_point_cpu is not None else None
-    global_scale_cuda = (
-        global_scale_cpu.cuda() if global_scale_cpu is not None else None
-    )
-    q_min_cuda, q_max_cuda = calculate_range(args, torch.device("cuda"))
 
     cuda_out = _quantize(
         x=x_cuda,


### PR DESCRIPTION
Implement quantization in Triton.

### Testing:
Run `pytest tests/test_quantization/lifecycle/test_forward.py -k test_quantize_dequantize_matches_sequential`.

### Evaluation:
With `benchmarks/benchmark_quantize_triton.py`:
```
====================================================================================================
Config   Size            PyTorch/CUDA (ms)  Triton/CUDA (ms)   Speedup    Correct 
----------------------------------------------------------------------------------------------------
int4     4096x4096                 0.99 ms            0.43 ms    2.31x    Yes     
int4     4096x11008                0.98 ms            0.52 ms    1.89x    Yes     
int4     8192x8192                 1.34 ms            0.57 ms    2.34x    Yes     
int8     4096x4096                 0.88 ms            0.43 ms    2.06x    Yes     
int8     4096x11008                1.11 ms            0.52 ms    2.15x    Yes     
int8     8192x8192                 1.39 ms            0.58 ms    2.41x    Yes     
fp4      4096x4096                 1.19 ms            0.45 ms    2.67x    Yes     
fp4      4096x11008                1.38 ms            0.53 ms    2.63x    Yes     
fp4      8192x8192                 1.43 ms            0.59 ms    2.42x    Yes     
fp8      4096x4096                 0.83 ms            0.53 ms    1.56x    Yes     
fp8      4096x11008                1.27 ms            1.10 ms    1.15x    Yes     
fp8      8192x8192                 1.61 ms            1.51 ms    1.07x    Yes    
```
