### PR TITLE
[ModelCompressor] QuantizationConfig.merge, allow compress on models with pre-existing quant

### DIFF
--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -30,7 +30,6 @@ from tqdm import tqdm
 from transformers import CompressedTensorsConfig
 from transformers.file_utils import CONFIG_NAME
 
-
 __all__ = ["ModelCompressor"]
 
 
@@ -228,11 +227,8 @@ class ModelCompressor:
             # Merge
             qconfig = QuantizationConfig.model_validate(orig_qconfig_data)
             if self.quantization_config is not None:
-                for scheme in self.quantization_config.config_groups.values():
-                    qconfig.add_scheme(scheme)
-                qconfig.quantization_status = (
-                    self.quantization_config.quantization_status
-                )
+                qconfig.merge(self.quantization_config)
+
             qconfig_data = qconfig.model_dump(exclude=["quant_method"])
 
         tconfig_data = get_nested_value(orig_qconfig_data, "transform_config", None)

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -24,11 +24,12 @@ from compressed_tensors.offload import is_distributed
 from compressed_tensors.quantization import QuantizationConfig, QuantizationStatus
 from compressed_tensors.quantization.utils.helpers import is_module_quantized
 from compressed_tensors.transform import TransformConfig
-from compressed_tensors.utils import get_nested_value
+from compressed_tensors.utils import find_unique_name, get_nested_value
 from loguru import logger
 from tqdm import tqdm
 from transformers import CompressedTensorsConfig
 from transformers.file_utils import CONFIG_NAME
+
 
 __all__ = ["ModelCompressor"]
 
@@ -243,7 +244,7 @@ class ModelCompressor:
             # Merge
             if self.transform_config is not None:
                 for key, transform in self.transform_config.items():
-                    unique_key = _find_unique_name(key, self.transform_config.keys())
+                    unique_key = find_unique_name(key, self.transform_config.keys())
                     tconfig_data[unique_key] = transform
 
         config_data[QUANTIZATION_CONFIG_NAME] = {
@@ -284,24 +285,3 @@ class ModelCompressor:
         if hasattr(model, "ct_decompress_hook"):
             model.ct_decompress_hook.remove()
             delattr(model, "ct_decompress_hook")
-
-
-def _find_unique_name(name, existing_names):
-    """
-    Returns a unique name. If the input name exists in existing_names,
-    appends an incrementing suffix (e.g., name_1, name_2).
-    """
-    # Convert to a set for O(1) fast lookups
-    used_set = set(existing_names)
-
-    if name not in used_set:
-        return name
-
-    counter = 1
-    new_name = f"{name}_{counter}"
-
-    while new_name in used_set:
-        counter += 1
-        new_name = f"{name}_{counter}"
-
-    return new_name

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -146,7 +146,11 @@ class ModelCompressor:
         modules = [
             module
             for _, module in model.named_modules(remove_duplicate=True)
-            if is_module_quantized(module)
+            if (
+                is_module_quantized(module)
+                and getattr(module, "quantization_status", None)
+                != QuantizationStatus.COMPRESSED
+            )
         ]
 
         # Compress modules using distributed or sequential
@@ -208,34 +212,16 @@ class ModelCompressor:
         else:
             config_data = {}
 
-        orig_qconfig_data = config_data.get(QUANTIZATION_CONFIG_NAME, None)
-
-        if orig_qconfig_data is None:
-            qconfig = self.quantization_config
-        elif self.quantization_config is not None:
-            qconfig = QuantizationConfig.model_validate(orig_qconfig_data)
-            qconfig.merge(self.quantization_config)
-        else:
-            qconfig = QuantizationConfig.model_validate(orig_qconfig_data)
-
         qconfig_data = (
-            qconfig.model_dump(exclude=["quant_method"]) if qconfig is not None else {}
+            self.quantization_config.model_dump(exclude=["quant_method"])
+            if self.quantization_config is not None
+            else {}
         )
-
-        orig_tconfig_data = (
-            orig_qconfig_data.get("transform_config", None)
-            if orig_qconfig_data is not None
-            else None
+        tconfig_data = (
+            self.transform_config.model_dump()
+            if self.transform_config is not None
+            else {}
         )
-        if orig_tconfig_data is None:
-            tconfig = self.transform_config
-        elif self.transform_config is not None:
-            tconfig = TransformConfig.model_validate(orig_tconfig_data)
-            tconfig.merge(self.transform_config)
-        else:
-            tconfig = TransformConfig.model_validate(orig_tconfig_data)
-
-        tconfig_data = tconfig.model_dump() if tconfig is not None else {}
 
         config_data[QUANTIZATION_CONFIG_NAME] = {
             COMPRESSION_VERSION_NAME: compressed_tensors.__version__,

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -24,7 +24,6 @@ from compressed_tensors.offload import is_distributed
 from compressed_tensors.quantization import QuantizationConfig, QuantizationStatus
 from compressed_tensors.quantization.utils.helpers import is_module_quantized
 from compressed_tensors.transform import TransformConfig
-
 from loguru import logger
 from tqdm import tqdm
 from transformers import CompressedTensorsConfig
@@ -220,9 +219,7 @@ class ModelCompressor:
             qconfig = QuantizationConfig.model_validate(orig_qconfig_data)
 
         qconfig_data = (
-            qconfig.model_dump(exclude=["quant_method"])
-            if qconfig is not None
-            else {}
+            qconfig.model_dump(exclude=["quant_method"]) if qconfig is not None else {}
         )
 
         orig_tconfig_data = (

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -30,6 +30,7 @@ from tqdm import tqdm
 from transformers import CompressedTensorsConfig
 from transformers.file_utils import CONFIG_NAME
 
+
 __all__ = ["ModelCompressor"]
 
 

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -30,7 +30,6 @@ from tqdm import tqdm
 from transformers import CompressedTensorsConfig
 from transformers.file_utils import CONFIG_NAME
 
-
 __all__ = ["ModelCompressor"]
 
 
@@ -246,9 +245,9 @@ class ModelCompressor:
         else:
             # Merge
             if self.transform_config is not None:
-                for key, transform in self.transform_config.items():
-                    unique_key = find_unique_name(key, self.transform_config.keys())
-                    tconfig_data[unique_key] = transform
+                for key, transform in self.transform_config.config_groups.items():
+                    unique_key = find_unique_name(key, tconfig_data.keys())
+                    tconfig_data[unique_key] = transform.model_dump()
 
         config_data[QUANTIZATION_CONFIG_NAME] = {
             COMPRESSION_VERSION_NAME: compressed_tensors.__version__,

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -24,7 +24,7 @@ from compressed_tensors.offload import is_distributed
 from compressed_tensors.quantization import QuantizationConfig, QuantizationStatus
 from compressed_tensors.quantization.utils.helpers import is_module_quantized
 from compressed_tensors.transform import TransformConfig
-from compressed_tensors.utils import find_unique_name, get_nested_value
+
 from loguru import logger
 from tqdm import tqdm
 from transformers import CompressedTensorsConfig
@@ -209,43 +209,36 @@ class ModelCompressor:
         else:
             config_data = {}
 
-        orig_qconfig_data = (
-            get_nested_value(config_data, QUANTIZATION_CONFIG_NAME, None)
-            or get_nested_value(config_data, f"config.{QUANTIZATION_CONFIG_NAME}", None)
-            or get_nested_value(
-                config_data, f"text_config.{QUANTIZATION_CONFIG_NAME}", None
-            )
-        )
+        orig_qconfig_data = config_data.get(QUANTIZATION_CONFIG_NAME, None)
 
         if orig_qconfig_data is None:
-            # Create
-            qconfig_data = (
-                self.quantization_config.model_dump(exclude=["quant_method"])
-                if self.quantization_config is not None
-                else {}
-            )
-        else:
-            # Merge
+            qconfig = self.quantization_config
+        elif self.quantization_config is not None:
             qconfig = QuantizationConfig.model_validate(orig_qconfig_data)
-            if self.quantization_config is not None:
-                qconfig.merge(self.quantization_config)
-
-            qconfig_data = qconfig.model_dump(exclude=["quant_method"])
-
-        tconfig_data = get_nested_value(orig_qconfig_data, "transform_config", None)
-        if tconfig_data is None:
-            # Create
-            tconfig_data = (
-                self.transform_config.model_dump()
-                if self.transform_config is not None
-                else {}
-            )
+            qconfig.merge(self.quantization_config)
         else:
-            # Merge
-            if self.transform_config is not None:
-                for key, transform in self.transform_config.config_groups.items():
-                    unique_key = find_unique_name(key, tconfig_data.keys())
-                    tconfig_data[unique_key] = transform.model_dump()
+            qconfig = QuantizationConfig.model_validate(orig_qconfig_data)
+
+        qconfig_data = (
+            qconfig.model_dump(exclude=["quant_method"])
+            if qconfig is not None
+            else {}
+        )
+
+        orig_tconfig_data = (
+            orig_qconfig_data.get("transform_config", None)
+            if orig_qconfig_data is not None
+            else None
+        )
+        if orig_tconfig_data is None:
+            tconfig = self.transform_config
+        elif self.transform_config is not None:
+            tconfig = TransformConfig.model_validate(orig_tconfig_data)
+            tconfig.merge(self.transform_config)
+        else:
+            tconfig = TransformConfig.model_validate(orig_tconfig_data)
+
+        tconfig_data = tconfig.model_dump() if tconfig is not None else {}
 
         config_data[QUANTIZATION_CONFIG_NAME] = {
             COMPRESSION_VERSION_NAME: compressed_tensors.__version__,

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -30,7 +30,6 @@ from tqdm import tqdm
 from transformers import CompressedTensorsConfig
 from transformers.file_utils import CONFIG_NAME
 
-
 __all__ = ["ModelCompressor"]
 
 
@@ -232,7 +231,7 @@ class ModelCompressor:
                     qconfig.add_scheme(config_group)
             qconfig_data = qconfig.model_dump(exclude=["quant_method"])
 
-        tconfig_data = get_nested_value(qconfig_data, "transform_config", None)
+        tconfig_data = get_nested_value(orig_qconfig_data, "transform_config", None)
         if tconfig_data is None:
             # Create
             tconfig_data = (

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -135,11 +135,18 @@ class ModelCompressor:
             else None
         )
 
-    def compress_model(self, model: torch.nn.Module) -> None:
+    def compress_model(
+        self, model: torch.nn.Module, skip_compressed: bool = False
+    ) -> None:
         """
         Compress the model's parameters in memory
 
         :param model: model whose parameters should be compressed in place
+        :param skip_compressed: skip any modules that already have quantization status
+            QuantizationStatus.COMPRESSED. This flag is necessary because compress_model
+            is called both during load-up in transformers and during save_pretrained.
+            During load, all modules need to be compressed, whereas during save modules
+            already compressed should be excluded.
         """
         # Collect all quantized modules
         desc = "Compressing model"
@@ -148,8 +155,11 @@ class ModelCompressor:
             for _, module in model.named_modules(remove_duplicate=True)
             if (
                 is_module_quantized(module)
-                and getattr(module, "quantization_status", None)
-                != QuantizationStatus.COMPRESSED
+                and (
+                    not (skip_compressed)
+                    or getattr(module, "quantization_status", None)
+                    != QuantizationStatus.COMPRESSED
+                )
             )
         ]
 

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -24,11 +24,11 @@ from compressed_tensors.offload import is_distributed
 from compressed_tensors.quantization import QuantizationConfig, QuantizationStatus
 from compressed_tensors.quantization.utils.helpers import is_module_quantized
 from compressed_tensors.transform import TransformConfig
+from compressed_tensors.utils import get_nested_value
 from loguru import logger
 from tqdm import tqdm
 from transformers import CompressedTensorsConfig
 from transformers.file_utils import CONFIG_NAME
-
 
 __all__ = ["ModelCompressor"]
 
@@ -208,16 +208,43 @@ class ModelCompressor:
         else:
             config_data = {}
 
-        qconfig_data = (
-            self.quantization_config.model_dump(exclude=["quant_method"])
-            if self.quantization_config is not None
-            else {}
+        orig_qconfig_data = (
+            get_nested_value(config_data, QUANTIZATION_CONFIG_NAME, None)
+            or get_nested_value(config_data, f"config.{QUANTIZATION_CONFIG_NAME}", None)
+            or get_nested_value(
+                config_data, f"text_config.{QUANTIZATION_CONFIG_NAME}", None
+            )
         )
-        tconfig_data = (
-            self.transform_config.model_dump()
-            if self.transform_config is not None
-            else {}
-        )
+
+        if orig_qconfig_data is None:
+            # Create
+            qconfig_data = (
+                self.quantization_config.model_dump(exclude=["quant_method"])
+                if self.quantization_config is not None
+                else {}
+            )
+        else:
+            # Merge
+            qconfig = QuantizationConfig.model_validate(orig_qconfig_data)
+            if self.quantization_config is not None:
+                for config_group in self.quantization_config.config_groups.values():
+                    qconfig.add_scheme(config_group)
+            qconfig_data = qconfig.model_dump(exclude=["quant_method"])
+
+        tconfig_data = get_nested_value(qconfig_data, "transform_config", None)
+        if tconfig_data is None:
+            # Create
+            tconfig_data = (
+                self.transform_config.model_dump()
+                if self.transform_config is not None
+                else {}
+            )
+        else:
+            # Merge
+            if self.transform_config is not None:
+                for key, transform in self.transform_config:
+                    unique_key = _find_unique_name(key, self.transform_config.keys())
+                    tconfig_data[unique_key] = transform
 
         config_data[QUANTIZATION_CONFIG_NAME] = {
             COMPRESSION_VERSION_NAME: compressed_tensors.__version__,
@@ -226,7 +253,6 @@ class ModelCompressor:
             TRANSFORM_CONFIG_NAME: tconfig_data,
             **qconfig_data,
         }
-
         with open(config_file_path, "w") as config_file:
             json.dump(config_data, config_file, indent=2, sort_keys=True)
 
@@ -258,3 +284,24 @@ class ModelCompressor:
         if hasattr(model, "ct_decompress_hook"):
             model.ct_decompress_hook.remove()
             delattr(model, "ct_decompress_hook")
+
+
+def _find_unique_name(name, existing_names):
+    """
+    Returns a unique name. If the input name exists in existing_names,
+    appends an incrementing suffix (e.g., name_1, name_2).
+    """
+    # Convert to a set for O(1) fast lookups
+    used_set = set(existing_names)
+
+    if name not in used_set:
+        return name
+
+    counter = 1
+    new_name = f"{name}_{counter}"
+
+    while new_name in used_set:
+        counter += 1
+        new_name = f"{name}_{counter}"
+
+    return new_name

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -242,7 +242,7 @@ class ModelCompressor:
         else:
             # Merge
             if self.transform_config is not None:
-                for key, transform in self.transform_config:
+                for key, transform in self.transform_config.items():
                     unique_key = _find_unique_name(key, self.transform_config.keys())
                     tconfig_data[unique_key] = transform
 

--- a/src/compressed_tensors/compressors/model_compressors/model_compressor.py
+++ b/src/compressed_tensors/compressors/model_compressors/model_compressor.py
@@ -30,7 +30,6 @@ from tqdm import tqdm
 from transformers import CompressedTensorsConfig
 from transformers.file_utils import CONFIG_NAME
 
-
 __all__ = ["ModelCompressor"]
 
 
@@ -228,8 +227,11 @@ class ModelCompressor:
             # Merge
             qconfig = QuantizationConfig.model_validate(orig_qconfig_data)
             if self.quantization_config is not None:
-                for config_group in self.quantization_config.config_groups.values():
-                    qconfig.add_scheme(config_group)
+                for scheme in self.quantization_config.config_groups.values():
+                    qconfig.add_scheme(scheme)
+                qconfig.quantization_status = (
+                    self.quantization_config.quantization_status
+                )
             qconfig_data = qconfig.model_dump(exclude=["quant_method"])
 
         tconfig_data = get_nested_value(orig_qconfig_data, "transform_config", None)

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -19,6 +19,7 @@ from compressed_tensors.utils.match import match_name
 from pydantic import BaseModel, ConfigDict, Field
 from torch.nn import Module
 
+
 __all__ = [
     "QuantizationStatus",
     "QuantizationConfig",

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -15,7 +15,6 @@ from compressed_tensors.quantization.utils import is_module_quantized
 from pydantic import BaseModel, ConfigDict, Field
 from torch.nn import Module
 
-
 __all__ = [
     "QuantizationStatus",
     "QuantizationConfig",
@@ -299,6 +298,23 @@ class QuantizationConfig(BaseModel):
                     return True
 
         return False
+
+    def add_scheme(self, scheme: QuantizationScheme) -> None:
+        """
+        Add new scheme to quantization config
+
+        If a new quant format is added, the global format will be set to
+        "mixed-precision".
+        """
+        scheme_name = f"config_group_{len(self.config_groups)}"
+
+        self.config_groups[scheme_name] = scheme
+        unique_formats = set(scheme.format for scheme in self.config_groups.values())
+        self.format = (
+            next(iter(unique_formats))
+            if len(unique_formats) == 1
+            else CompressionFormat.mixed_precision.value
+        )
 
     # TODO set `extra="forbid"` when upstream transformers is compatible
     model_config = ConfigDict(extra="ignore")

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -9,7 +9,6 @@ from typing import Annotated, Any
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization.quant_args import DynamicType, QuantizationArgs
 from compressed_tensors.quantization.quant_scheme import (
-    CompressionFormat,
     QuantizationScheme,
     preset_name_to_scheme,
 )

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -9,6 +9,7 @@ from typing import Annotated, Any
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization.quant_args import DynamicType, QuantizationArgs
 from compressed_tensors.quantization.quant_scheme import (
+    CompressionFormat,
     QuantizationScheme,
     preset_name_to_scheme,
 )
@@ -17,7 +18,6 @@ from compressed_tensors.utils import find_unique_name
 from compressed_tensors.utils.match import match_name
 from pydantic import BaseModel, ConfigDict, Field
 from torch.nn import Module
-
 
 __all__ = [
     "QuantizationStatus",
@@ -177,6 +177,12 @@ class QuantizationConfig(BaseModel):
                 name=group_name,
                 targets=targets_or_scheme,
             )
+
+        # if unset, populate format on each config group
+        if self.format != CompressionFormat.mixed_precision:
+            for scheme in self.config_groups.values():
+                if scheme.format is None:
+                    scheme.format = self.format
 
     def to_dict(self):
         # for compatibility with HFQuantizer

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -15,6 +15,7 @@ from compressed_tensors.quantization.utils import is_module_quantized
 from pydantic import BaseModel, ConfigDict, Field
 from torch.nn import Module
 
+
 __all__ = [
     "QuantizationStatus",
     "QuantizationConfig",

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -18,7 +18,6 @@ from compressed_tensors.utils.match import match_name
 from pydantic import BaseModel, ConfigDict, Field
 from torch.nn import Module
 
-
 __all__ = [
     "QuantizationStatus",
     "QuantizationConfig",
@@ -179,7 +178,11 @@ class QuantizationConfig(BaseModel):
             )
 
         # if unset, populate format on each config group
-        if self.format != CompressionFormat.mixed_precision:
+        if self.format not in (
+            DEFAULT_QUANTIZATION_FORMAT,
+            CompressionFormat.mixed_precision,
+            CompressionFormat.dense,
+        ):
             for scheme in self.config_groups.values():
                 if scheme.format is None:
                     scheme.format = self.format

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import warnings
 from collections import defaultdict
 from enum import Enum
 from typing import Annotated, Any
-import warnings
 
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization.quant_args import DynamicType, QuantizationArgs
@@ -17,6 +17,7 @@ from compressed_tensors.utils import find_unique_name
 from compressed_tensors.utils.match import match_name
 from pydantic import BaseModel, ConfigDict, Field
 from torch.nn import Module
+
 
 __all__ = [
     "QuantizationStatus",

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -12,6 +12,7 @@ from compressed_tensors.quantization.quant_scheme import (
     preset_name_to_scheme,
 )
 from compressed_tensors.quantization.utils import is_module_quantized
+from compressed_tensors.utils import find_unique_name
 from pydantic import BaseModel, ConfigDict, Field
 from torch.nn import Module
 
@@ -307,7 +308,7 @@ class QuantizationConfig(BaseModel):
         If a new quant format is added, the global format will be set to
         "mixed-precision".
         """
-        scheme_name = f"config_group_{len(self.config_groups)}"
+        scheme_name = find_unique_name("config_group", self.config_groups.keys())
 
         self.config_groups[scheme_name] = scheme
         unique_formats = set(scheme.format for scheme in self.config_groups.values())

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -4,6 +4,7 @@
 from collections import defaultdict
 from enum import Enum
 from typing import Annotated, Any
+import warnings
 
 from compressed_tensors.config import CompressionFormat
 from compressed_tensors.quantization.quant_args import DynamicType, QuantizationArgs
@@ -13,9 +14,9 @@ from compressed_tensors.quantization.quant_scheme import (
 )
 from compressed_tensors.quantization.utils import is_module_quantized
 from compressed_tensors.utils import find_unique_name
+from compressed_tensors.utils.match import match_name
 from pydantic import BaseModel, ConfigDict, Field
 from torch.nn import Module
-
 
 __all__ = [
     "QuantizationStatus",
@@ -301,22 +302,60 @@ class QuantizationConfig(BaseModel):
 
         return False
 
-    def add_scheme(self, scheme: QuantizationScheme) -> None:
+    def merge(self, config: "QuantizationConfig") -> None:
         """
-        Add new scheme to quantization config
+        Merge another QuantizationConfig into self, modifying in-place. The current
+        quant config (self) will take precedence over the second quant config,
+        i.e. the config groups will be appended rather than inserted before. Python's
+        json stdlib and pydantic both respect order when serializing/deserializing.
+
+        Because QuantizationConfig has a global ignore list while targets are scoped to
+        a given scheme, merging is not a straightforward task. A warning will be raised
+        when this function is called to indicate that invalid quantization configs are
+        possible when using this method, particularly when complex ignore lists are
+        used. For best results, use complex targets lists over complex ignore lists.
 
         If a new quant format is added, the global format will be set to
         "mixed-precision".
-        """
-        scheme_name = find_unique_name("config_group", self.config_groups.keys())
 
-        self.config_groups[scheme_name] = scheme
+        The QuantizationStatus will be set to whichever is largest.
+
+        Excluding regexes, any names in the ignore list that are targeted in the new
+        quant config will be pruned.
+
+        :param config: QuantizationConfig to merge into self.
+        """
+        warnings.warn(
+            "Attempting to merge quantization configs. This is not a straightforward "
+            "task and can lead to quantization configs that fail to load. For best "
+            "results, use complex targets lists instead of complex ingore lists"
+        )
+
+        pruned_ignore_list = []
+        for ign in self.ignore:
+            if ign.startswith("re:") or any(
+                match_name(ign, target)
+                for scheme in config.config_groups.values()
+                for target in scheme.targets
+            ):
+                continue
+            pruned_ignore_list.append(ign)
+        self.ignore = pruned_ignore_list
+
+        for scheme_name, scheme in config.config_groups.items():
+            new_scheme_name = find_unique_name(scheme_name, self.config_groups.keys())
+
+            self.config_groups[new_scheme_name] = scheme
+
         unique_formats = set(scheme.format for scheme in self.config_groups.values())
         self.format = (
             next(iter(unique_formats))
             if len(unique_formats) == 1
             else CompressionFormat.mixed_precision.value
         )
+
+        if config.quantization_status > self.quantization_status:
+            self.quantization_status = config.quantization_status
 
     # TODO set `extra="forbid"` when upstream transformers is compatible
     model_config = ConfigDict(extra="ignore")

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -18,6 +18,7 @@ from compressed_tensors.utils.match import match_name
 from pydantic import BaseModel, ConfigDict, Field
 from torch.nn import Module
 
+
 __all__ = [
     "QuantizationStatus",
     "QuantizationConfig",

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -333,7 +333,10 @@ class QuantizationConfig(BaseModel):
 
         pruned_ignore_list = []
         for ign in self.ignore:
-            if ign.startswith("re:") or any(
+            if ign.startswith("re:"):
+                pruned_ignore_list.append(ign)
+                continue
+            if any(
                 match_name(ign, target)
                 for scheme in config.config_groups.values()
                 for target in scheme.targets

--- a/src/compressed_tensors/transform/transform_config.py
+++ b/src/compressed_tensors/transform/transform_config.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from compressed_tensors.transform import TransformScheme
+from compressed_tensors.utils import find_unique_name
 from pydantic import BaseModel, ConfigDict
 
 
@@ -20,3 +21,12 @@ class TransformConfig(BaseModel):
     config_groups: dict[str, TransformScheme]
 
     model_config = ConfigDict(extra="forbid")
+
+    def merge(self, other: "TransformConfig") -> None:
+        """
+        Merge another TransformConfig into self in-place. Config groups from
+        ``other`` are appended with unique keys to avoid collisions.
+        """
+        for key, transform in other.config_groups.items():
+            unique_key = find_unique_name(key, self.config_groups.keys())
+            self.config_groups[unique_key] = transform

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -506,19 +506,27 @@ def is_accelerator_type(device_type: str) -> bool:
 def find_unique_name(name, existing_names):
     """
     Returns a unique name. If the input name exists in existing_names,
-    appends an incrementing suffix (e.g., f"{name}_0", f"{name}_1").
+    strips any trailing ``_N`` suffix to find the base and increments the
+    counter until the name is unique (e.g., ``group_0`` -> ``group_1``).
     """
-    # Convert to a set for O(1) fast lookups
+    import re
+
     used_set = set(existing_names)
 
     if name not in used_set:
         return name
 
-    counter = 0
-    new_name = f"{name}_{counter}"
+    m = re.match(r"^(.+?)_(\d+)$", name)
+    if m:
+        base, start = m.group(1), int(m.group(2))
+    else:
+        base, start = name, 0
+
+    counter = start + 1
+    new_name = f"{base}_{counter}"
 
     while new_name in used_set:
         counter += 1
-        new_name = f"{name}_{counter}"
+        new_name = f"{base}_{counter}"
 
     return new_name

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -41,6 +41,7 @@ __all__ = [
     "get_num_kv_heads",
     "get_head_dim",
     "is_accelerator_type",
+    "find_unique_name",
 ]
 
 FSDP_WRAPPER_NAME = "_fsdp_wrapped_module"
@@ -500,3 +501,24 @@ def is_accelerator_type(device_type: str) -> bool:
     if not torch.accelerator.is_available():
         return False
     return device_type == torch.accelerator.current_accelerator().type
+
+
+def find_unique_name(name, existing_names):
+    """
+    Returns a unique name. If the input name exists in existing_names,
+    appends an incrementing suffix (e.g., name_1, name_2).
+    """
+    # Convert to a set for O(1) fast lookups
+    used_set = set(existing_names)
+
+    if name not in used_set:
+        return name
+
+    counter = 1
+    new_name = f"{name}_{counter}"
+
+    while new_name in used_set:
+        counter += 1
+        new_name = f"{name}_{counter}"
+
+    return new_name

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -4,13 +4,14 @@
 import contextlib
 import warnings
 from collections.abc import Callable, Iterable, Mapping
-from functools import wraps, reduce
+from functools import reduce, wraps
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import numpy
 import torch
 from transformers import AutoConfig, PretrainedConfig
+
 
 T = TypeVar("T", bound="Callable")  # used by `deprecated`
 

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -12,7 +12,6 @@ import numpy
 import torch
 from transformers import AutoConfig, PretrainedConfig
 
-
 T = TypeVar("T", bound="Callable")  # used by `deprecated`
 
 
@@ -505,16 +504,13 @@ def is_accelerator_type(device_type: str) -> bool:
 
 def find_unique_name(name, existing_names):
     """
-    Returns a unique name. If the input name exists in existing_names,
-    appends an incrementing suffix (e.g., name_1, name_2).
+    Returns a unique name suffixed with an integer that does not exist in
+    existing_names, appends an incrementing suffix (e.g., name_0, name_1).
     """
     # Convert to a set for O(1) fast lookups
     used_set = set(existing_names)
 
-    if name not in used_set:
-        return name
-
-    counter = 1
+    counter = 0
     new_name = f"{name}_{counter}"
 
     while new_name in used_set:

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -504,11 +504,14 @@ def is_accelerator_type(device_type: str) -> bool:
 
 def find_unique_name(name, existing_names):
     """
-    Returns a unique name suffixed with an integer that does not exist in
-    existing_names, appends an incrementing suffix (e.g., name_0, name_1).
+    Returns a unique name. If the input name exists in existing_names,
+    appends an incrementing suffix (e.g., f"{name}_0", f"{name}_1").
     """
     # Convert to a set for O(1) fast lookups
     used_set = set(existing_names)
+
+    if name not in used_set:
+        return name
 
     counter = 0
     new_name = f"{name}_{counter}"

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -12,6 +12,7 @@ import numpy
 import torch
 from transformers import AutoConfig, PretrainedConfig
 
+
 T = TypeVar("T", bound="Callable")  # used by `deprecated`
 
 

--- a/src/compressed_tensors/utils/helpers.py
+++ b/src/compressed_tensors/utils/helpers.py
@@ -4,14 +4,13 @@
 import contextlib
 import warnings
 from collections.abc import Callable, Iterable, Mapping
-from functools import wraps
+from functools import wraps, reduce
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import numpy
 import torch
 from transformers import AutoConfig, PretrainedConfig
-
 
 T = TypeVar("T", bound="Callable")  # used by `deprecated`
 
@@ -26,6 +25,7 @@ __all__ = [
     "tensor_follows_mask_structure",
     "replace_module",
     "is_compressed_tensors_config",
+    "get_nested_value",
     "getattr_chain",
     "deprecated",
     "Aliasable",
@@ -132,6 +132,16 @@ def is_compressed_tensors_config(compression_config: Any) -> bool:
         return isinstance(compression_config, CompressedTensorsConfig)
     except ImportError:
         return False
+
+
+def get_nested_value(data_dict, path, default=None):
+    """
+    Retrieves a deeply nested value using a dotted string path.
+    """
+    try:
+        return reduce(lambda d, key: d[key], path.split("."), data_dict)
+    except (KeyError, TypeError):
+        return default
 
 
 def getattr_chain(obj: Any, chain_str: str, *args, **kwargs) -> Any:

--- a/tests/test_compressors/test_fp4_optimizations.py
+++ b/tests/test_compressors/test_fp4_optimizations.py
@@ -62,7 +62,7 @@ def test_pack_fp4_to_uint8(device, test_input):
 @pytest.mark.parametrize("device", ["cuda"])
 def test_pack_fp4_to_uint8_float32_input(device):
     """Test pack_fp4_to_uint8 accepts float32 inputs in the valid FP4 set."""
-    if device == "cuda" and not torch.cuda.is_available():
+    if device == "cuda" and not torch.accelerator.is_available():
         pytest.skip("CUDA not available")
 
     from compressed_tensors.compressors.nvfp4.helpers import pack_fp4_to_uint8

--- a/tests/test_quantization/test_quant_config.py
+++ b/tests/test_quantization/test_quant_config.py
@@ -6,10 +6,10 @@ import torch
 from compressed_tensors.quantization import (
     DEFAULT_QUANTIZATION_FORMAT,
     DEFAULT_QUANTIZATION_METHOD,
+    QuantizationArgs,
     QuantizationConfig,
     QuantizationScheme,
     QuantizationStatus,
-    QuantizationArgs,
 )
 from compressed_tensors.quantization.quant_config import (
     _map_to_checkpoint_names,

--- a/tests/test_quantization/test_quant_config.py
+++ b/tests/test_quantization/test_quant_config.py
@@ -183,7 +183,7 @@ def test_quantization_config_merge():
                 weights=QuantizationArgs(num_bits=4, symmetric=True, group_size=128),
             )
         },
-        ignore=["lm_head", "model.layers.0.mlp.gate_proj"],
+        ignore=["lm_head", "model.layers.0.mlp.gate_proj", "re:.*mtp.*"],
         quantization_status=QuantizationStatus.INITIALIZED,
     )
 
@@ -205,6 +205,7 @@ def test_quantization_config_merge():
     assert ordered_schemes[0].targets[0] == "re:.*self_attn.*"
     assert ordered_schemes[1].targets[0] == "re:.*mlp.*"
 
-    assert set(config.ignore) == set(["lm_head"])
+    # should strip out "model.layers.0.mlp.gate_proj" from ignore
+    assert set(config.ignore) == set(["lm_head", "re:.*mtp.*"])
 
     assert config.quantization_status == QuantizationStatus.COMPRESSED

--- a/tests/test_quantization/test_quant_config.py
+++ b/tests/test_quantization/test_quant_config.py
@@ -9,6 +9,7 @@ from compressed_tensors.quantization import (
     QuantizationConfig,
     QuantizationScheme,
     QuantizationStatus,
+    QuantizationArgs,
 )
 from compressed_tensors.quantization.quant_config import (
     _map_to_checkpoint_names,
@@ -71,7 +72,6 @@ def test_load_scheme_from_preset(scheme_name: str):
 
 def test_to_dict():
     """Test serialization of QuantizationConfig including format"""
-    from compressed_tensors.quantization import QuantizationArgs
 
     config_groups = {
         "group_1": QuantizationScheme(
@@ -173,3 +173,38 @@ def test_get_vllm_module_type():
     assert get_vllm_module_type("JetMoeTopKGating") == "Linear"
     assert get_vllm_module_type("Qwen3NextGatedDeltaNet") == "Linear"
     assert get_vllm_module_type("JetMoeTopKGating") == "Linear"
+
+
+def test_quantization_config_merge():
+    config = QuantizationConfig(
+        config_groups={
+            "config_group_0": QuantizationScheme(
+                targets=["re:.*self_attn.*"],
+                weights=QuantizationArgs(num_bits=4, symmetric=True, group_size=128),
+            )
+        },
+        ignore=["lm_head", "model.layers.0.mlp.gate_proj"],
+        quantization_status=QuantizationStatus.INITIALIZED,
+    )
+
+    new_config = QuantizationConfig(
+        config_groups={
+            "config_group_0": QuantizationScheme(
+                targets=["re:.*mlp.*"],
+                weights=QuantizationArgs(num_bits=8, symmetric=False, group_size=128),
+            )
+        },
+        ignore=["lm_head"],
+        quantization_status=QuantizationStatus.COMPRESSED,
+    )
+
+    config.merge(new_config)
+
+    ordered_schemes = list(config.config_groups.values())
+    assert len(ordered_schemes) == 2
+    assert ordered_schemes[0].targets[0] == "re:.*self_attn.*"
+    assert ordered_schemes[1].targets[0] == "re:.*mlp.*"
+
+    assert set(config.ignore) == set(["lm_head"])
+
+    assert config.quantization_status == QuantizationStatus.COMPRESSED

--- a/tests/test_utils/test_helpers.py
+++ b/tests/test_utils/test_helpers.py
@@ -1,9 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import pytest
 from types import SimpleNamespace
 
-from compressed_tensors import ParameterizedDefaultDict, patch_attr, patch_attrs
+from compressed_tensors import (
+    ParameterizedDefaultDict,
+    patch_attr,
+    patch_attrs,
+    get_nested_value,
+)
 
 
 def test_patch_attr():
@@ -54,3 +60,18 @@ def test_parameterized_default_dict():
     sum_dict = ParameterizedDefaultDict(sum_vals)
     assert sum_dict[0, 1] == 1
     assert sum_dict[5, 7] == 12
+
+
+@pytest.mark.parametrize(
+    "key,default,expected_value",
+    [
+        ("c.d", -4, 4),
+        ("c.e", -4, -4),
+        ("b", -4, 1),
+        ("d", -4, -4),
+    ],
+)
+def test_get_nested_value(key, default, expected_value):
+    a = {"b": 1, "c": {"d": 4}}
+
+    assert get_nested_value(a, key, default) == expected_value

--- a/tests/test_utils/test_helpers.py
+++ b/tests/test_utils/test_helpers.py
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import pytest
 from types import SimpleNamespace
 
+import pytest
 from compressed_tensors import (
     ParameterizedDefaultDict,
+    get_nested_value,
     patch_attr,
     patch_attrs,
-    get_nested_value,
 )
 
 


### PR DESCRIPTION
Corequisite:
* https://github.com/vllm-project/llm-compressor/pull/2909

Currently, `ModelCompressor.update_config` creates a quantization config from scratch, rather than merging it in with a quantization config that might have been saved to the original checkpoint. This PR adds that functionality, in accordance with comments here -- https://github.com/vllm-project/llm-compressor/pull/2909#issuecomment-4960302599. User is currently circumventing by manually merging quantization configs.

Test plan:
- [x] unit tests
- [x] smoke tests for stacked oneshot added in https://github.com/vllm-project/llm-compressor/pull/2909

Related to https://github.com/vllm-project/llm-compressor/issues/2907

