### PR TITLE
Fix KV cache quantization for composite multimodal models

### DIFF
--- a/src/compressed_tensors/modeling/kvcache.py
+++ b/src/compressed_tensors/modeling/kvcache.py
@@ -119,7 +119,8 @@ def initialize_hooked_kv_cache(model: PreTrainedModel, module: Module):
     :param module: attention module to initialize with
     """
     if not hasattr(module, KV_CACHE_ATTR):
-        module.register_module(KV_CACHE_ATTR, QuantizedKVCache(model.config, module))
+        config = model.config.get_text_config(decoder=True)
+        module.register_module(KV_CACHE_ATTR, QuantizedKVCache(config, module))
         module.register_forward_pre_hook(_kv_cache_attention_hook, with_kwargs=True)
 
 

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -13,6 +13,7 @@ from compressed_tensors.offload import update_offload_parameter
 from compressed_tensors.quantization.lifecycle.initialize import (
     initialize_module_for_quantization,
     is_attention_module,
+    is_kv_cache_attention_module,
 )
 from compressed_tensors.quantization.quant_args import QuantizationArgs
 from compressed_tensors.quantization.quant_config import (
@@ -180,7 +181,7 @@ def _apply_kv_cache_scheme(
         input_activations=kv_cache_scheme,
     )
     for submodule in model.modules():
-        if is_attention_module(submodule):
+        if is_kv_cache_attention_module(submodule):
             submodule.quantization_scheme = scheme
             initialize_hooked_kv_cache(model, submodule)
             initialize_module_for_quantization(submodule, force_zero_point=False)

--- a/src/compressed_tensors/quantization/lifecycle/apply.py
+++ b/src/compressed_tensors/quantization/lifecycle/apply.py
@@ -12,8 +12,7 @@ from compressed_tensors.modeling import (
 from compressed_tensors.offload import update_offload_parameter
 from compressed_tensors.quantization.lifecycle.initialize import (
     initialize_module_for_quantization,
-    is_attention_module,
-    is_kv_cache_attention_module,
+    is_cached_attention_module,
 )
 from compressed_tensors.quantization.quant_args import QuantizationArgs
 from compressed_tensors.quantization.quant_config import (
@@ -148,7 +147,9 @@ def apply_quantization_config(
         scheme = _scheme_from_targets(target_to_scheme, matched_targets, name)
 
         # attention quantization
-        if is_attention_module(module) and is_narrow_match(model, scheme.targets, name):
+        if is_cached_attention_module(module) and is_narrow_match(
+            model, scheme.targets, name
+        ):
             module.quantization_scheme = scheme
             initialize_hooked_attention(model, module)
             initialize_module_for_quantization(
@@ -181,7 +182,7 @@ def _apply_kv_cache_scheme(
         input_activations=kv_cache_scheme,
     )
     for submodule in model.modules():
-        if is_kv_cache_attention_module(submodule):
+        if is_cached_attention_module(submodule):
             submodule.quantization_scheme = scheme
             initialize_hooked_kv_cache(model, submodule)
             initialize_module_for_quantization(submodule, force_zero_point=False)

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -273,6 +273,12 @@ def initialize_attn_qparams(
 
     # extract shapes from config
     config = kv_cache.config
+
+    if hasattr(config, "get_text_config"):
+        config = config.get_text_config(decoder=True)
+    elif hasattr(config, "text_config"):
+        config = config.text_config
+
     num_attn_heads = get_num_attn_heads(config)
     num_kv_heads = get_num_kv_heads(config)
     head_dim = get_head_dim(config)

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import inspect
 import logging
 import math
 
@@ -35,6 +36,7 @@ from torch.nn import Module, Parameter
 __all__ = [
     "initialize_module_for_quantization",
     "is_attention_module",
+    "is_kv_cache_attention_module",
     "initialize_qparams",
     "initialize_attn_qparams",
 ]
@@ -127,6 +129,18 @@ def is_attention_module(module: Module):
         or hasattr(module, "qkv_proj")
         or hasattr(module, "kv_b_proj")
     )
+
+
+def is_kv_cache_attention_module(module: Module) -> bool:
+    if not is_attention_module(module):
+        return False
+
+    try:
+        parameters = inspect.signature(module.forward).parameters
+    except (TypeError, ValueError):
+        return False
+
+    return "past_key_value" in parameters or "past_key_values" in parameters
 
 
 def initialize_qparams(

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -276,7 +276,7 @@ def initialize_attn_qparams(
 
     if hasattr(config, "get_text_config"):
         config = config.get_text_config(decoder=True)
-    elif hasattr(config, "text_config"):
+    elif getattr(config, "text_config", None) is not None:
         config = config.text_config
 
     num_attn_heads = get_num_attn_heads(config)

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import inspect
-import logging
 import math
 
 import torch
@@ -31,6 +30,7 @@ from compressed_tensors.utils import (
     get_num_kv_heads,
 )
 from compressed_tensors.utils.helpers import deprecated
+from loguru import logger
 from torch.nn import Module, Parameter
 
 
@@ -41,10 +41,6 @@ __all__ = [
     "initialize_qparams",
     "initialize_attn_qparams",
 ]
-
-
-_LOGGER = logging.getLogger(__name__)
-_signature_warning_emitted = False
 
 
 def initialize_module_for_quantization(
@@ -148,7 +144,7 @@ def is_cached_attention_module(module: Module) -> bool:
         logger.warning(
             "Unable to inspect an attention module's forward signature; "
             "skipping KV cache quantization for uninspectable modules",
-            log_once
+            log_once=True,
         )
         return False
 

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -30,19 +30,21 @@ from compressed_tensors.utils import (
     get_num_attn_heads,
     get_num_kv_heads,
 )
+from compressed_tensors.utils.helpers import deprecated
 from torch.nn import Module, Parameter
 
 
 __all__ = [
     "initialize_module_for_quantization",
     "is_attention_module",
-    "is_kv_cache_attention_module",
+    "is_cached_attention_module",
     "initialize_qparams",
     "initialize_attn_qparams",
 ]
 
 
 _LOGGER = logging.getLogger(__name__)
+_signature_warning_emitted = False
 
 
 def initialize_module_for_quantization(
@@ -72,7 +74,7 @@ def initialize_module_for_quantization(
 
     QuantizationMetadata.clear_all_qparams(module)
 
-    if is_attention_module(module):
+    if is_cached_attention_module(module):
         initialize_attn_qparams(module, scheme, force_zero_point)
 
     elif isinstance(module, (torch.nn.Linear, torch.nn.Embedding)):
@@ -122,7 +124,7 @@ def initialize_module_for_quantization(
     module.quantization_status = QuantizationStatus.INITIALIZED
 
 
-def is_attention_module(module: Module):
+def _is_attention_module(module: Module) -> bool:
     return "attention" in module.__class__.__name__.lower() and (
         hasattr(module, "k_proj")
         or hasattr(module, "v_proj")
@@ -131,13 +133,25 @@ def is_attention_module(module: Module):
     )
 
 
-def is_kv_cache_attention_module(module: Module) -> bool:
-    if not is_attention_module(module):
+@deprecated("is_cached_attention_module")
+def is_attention_module(module: Module) -> bool:
+    return _is_attention_module(module)
+
+
+def is_cached_attention_module(module: Module) -> bool:
+    if not _is_attention_module(module):
         return False
 
     try:
         parameters = inspect.signature(module.forward).parameters
     except (TypeError, ValueError):
+        global _signature_warning_emitted
+        if not _signature_warning_emitted:
+            _LOGGER.warning(
+                "Unable to inspect an attention module's forward signature; "
+                "skipping KV cache quantization for uninspectable modules"
+            )
+            _signature_warning_emitted = True
         return False
 
     return "past_key_value" in parameters or "past_key_values" in parameters
@@ -285,14 +299,8 @@ def initialize_attn_qparams(
 
     _validate_attention_scheme(scheme)
 
-    # extract shapes from config
+    # extract shapes from decoder config
     config = kv_cache.config
-
-    if hasattr(config, "get_text_config"):
-        config = config.get_text_config(decoder=True)
-    elif getattr(config, "text_config", None) is not None:
-        config = config.text_config
-
     num_attn_heads = get_num_attn_heads(config)
     num_kv_heads = get_num_kv_heads(config)
     head_dim = get_head_dim(config)

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -145,13 +145,11 @@ def is_cached_attention_module(module: Module) -> bool:
     try:
         parameters = inspect.signature(module.forward).parameters
     except (TypeError, ValueError):
-        global _signature_warning_emitted
-        if not _signature_warning_emitted:
-            _LOGGER.warning(
-                "Unable to inspect an attention module's forward signature; "
-                "skipping KV cache quantization for uninspectable modules"
-            )
-            _signature_warning_emitted = True
+        logger.warning(
+            "Unable to inspect an attention module's forward signature; "
+            "skipping KV cache quantization for uninspectable modules",
+            log_once
+        )
         return False
 
     return "past_key_value" in parameters or "past_key_values" in parameters

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -205,7 +205,7 @@ class QuantizationConfig(BaseModel):
         """
         from compressed_tensors.modeling import IMPL_ATTR
         from compressed_tensors.quantization.lifecycle.initialize import (
-            is_attention_module,
+            is_cached_attention_module,
         )
 
         # set of all quantization schemes
@@ -228,15 +228,14 @@ class QuantizationConfig(BaseModel):
 
         for name, submodule in model.named_modules():
             layer_type: str = get_vllm_module_type(type(submodule).__name__)
+            is_cached_attention = is_cached_attention_module(submodule)
 
             # add config group if quantized non-attention or attention quant
             has_config_group = is_module_quantized(submodule) and (
-                not is_attention_module(submodule) or hasattr(submodule, IMPL_ATTR)
+                not is_cached_attention or hasattr(submodule, IMPL_ATTR)
             )
             # only add kvcache if quant attention (which always implies kvcache)
-            has_kv_cache = is_module_quantized(submodule) and is_attention_module(
-                submodule
-            )
+            has_kv_cache = is_module_quantized(submodule) and is_cached_attention
 
             if has_config_group:
                 # add to running set of schemes/layer_type_names

--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -490,15 +490,23 @@ def test_apply_kv_cache_skips_non_cache_attention():
     class CompositeModel(torch.nn.Module):
         def __init__(self):
             super().__init__()
-            self.config = SimpleNamespace(
-                text_config=SimpleNamespace(
-                    num_attention_heads=2,
-                    num_key_value_heads=1,
-                    head_dim=2,
-                )
-            )
+            self.config = CompositeConfig()
             self.text_attention = TextAttention()
             self.vision_attention = VisionAttention()
+
+    class CompositeConfig:
+        def __init__(self):
+            self.text_config = SimpleNamespace(
+                num_attention_heads=2,
+                num_key_value_heads=1,
+                head_dim=2,
+            )
+            self.vision_config = SimpleNamespace(model_type="vision")
+            self.decoder = None
+
+        def get_text_config(self, decoder=False):
+            self.decoder = decoder
+            return self.text_config
 
     model = CompositeModel()
     args = QuantizationArgs(
@@ -512,7 +520,10 @@ def test_apply_kv_cache_skips_non_cache_attention():
 
     apply_quantization_config(model, config)
 
+    assert model.config.decoder is True
+    assert model.config.vision_config.model_type == "vision"
     assert hasattr(model.text_attention, "kv_cache")
+    assert model.text_attention.kv_cache.config is model.config.text_config
     assert hasattr(model.text_attention, "k_scale")
     assert hasattr(model.text_attention, "v_scale")
     assert not hasattr(model.vision_attention, "quantization_scheme")

--- a/tests/test_quantization/lifecycle/test_apply.py
+++ b/tests/test_quantization/lifecycle/test_apply.py
@@ -3,6 +3,7 @@
 
 import re
 import shutil
+from types import SimpleNamespace
 from typing import Optional
 from unittest.mock import MagicMock
 
@@ -467,6 +468,57 @@ def test_apply_kv_cache():
         assert getattr(layer.self_attn, "quantization_scheme").input_activations == args
         assert hasattr(layer.self_attn, "k_scale")
         assert hasattr(layer.self_attn, "v_scale")
+
+
+def test_apply_kv_cache_skips_non_cache_attention():
+    class TextAttention(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.k_proj = torch.nn.Linear(4, 4)
+
+        def forward(self, hidden_states, past_key_value=None):
+            return hidden_states
+
+    class VisionAttention(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.k_proj = torch.nn.Linear(4, 4)
+
+        def forward(self, hidden_states, **kwargs):
+            return hidden_states
+
+    class CompositeModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.config = SimpleNamespace(
+                text_config=SimpleNamespace(
+                    num_attention_heads=2,
+                    num_key_value_heads=1,
+                    head_dim=2,
+                )
+            )
+            self.text_attention = TextAttention()
+            self.vision_attention = VisionAttention()
+
+    model = CompositeModel()
+    args = QuantizationArgs(
+        num_bits=8,
+        type=QuantizationType.FLOAT,
+        strategy=QuantizationStrategy.TENSOR,
+        scale_dtype=FP8_E4M3_DATA.dtype,
+        zp_dtype=torch.float,
+    )
+    config = QuantizationConfig(config_groups={}, kv_cache_scheme=args)
+
+    apply_quantization_config(model, config)
+
+    assert hasattr(model.text_attention, "kv_cache")
+    assert hasattr(model.text_attention, "k_scale")
+    assert hasattr(model.text_attention, "v_scale")
+    assert not hasattr(model.vision_attention, "quantization_scheme")
+    assert not hasattr(model.vision_attention, "kv_cache")
+    assert not hasattr(model.vision_attention, "k_scale")
+    assert not hasattr(model.vision_attention, "v_scale")
 
 
 def test_apply_attention():

--- a/tests/test_quantization/lifecycle/test_initialize.py
+++ b/tests/test_quantization/lifecycle/test_initialize.py
@@ -3,7 +3,9 @@
 
 import math
 from types import SimpleNamespace
+from unittest.mock import Mock
 
+import compressed_tensors.quantization.lifecycle.initialize as initialize_lifecycle
 import pytest
 import torch
 from compressed_tensors.offload import set_onload_device
@@ -18,7 +20,8 @@ from compressed_tensors.quantization import (
 from compressed_tensors.quantization.lifecycle.initialize import (
     initialize_attn_qparams,
     initialize_module_for_quantization,
-    is_kv_cache_attention_module,
+    is_attention_module,
+    is_cached_attention_module,
 )
 from tests.testing_utils import requires_gpu
 from torch.nn import Linear
@@ -59,23 +62,6 @@ class EncoderAttention(torch.nn.Module):
         return hidden_states
 
 
-class MockKVCache(torch.nn.Module):
-    def __init__(self, config):
-        super().__init__()
-        self.config = config
-
-
-class CompositeConfig:
-    def __init__(self, text_config):
-        self.text_config = text_config
-        self.vision_config = SimpleNamespace(model_type="vision")
-        self.decoder = None
-
-    def get_text_config(self, decoder=False):
-        self.decoder = decoder
-        return self.text_config
-
-
 @pytest.fixture
 def layer():
     return Linear(4, 4)
@@ -89,51 +75,39 @@ def layer():
         (EncoderAttention, False),
     ],
 )
-def test_is_kv_cache_attention_module(attention_cls, expected):
-    assert is_kv_cache_attention_module(attention_cls()) is expected
+def test_is_cached_attention_module(attention_cls, expected):
+    assert is_cached_attention_module(attention_cls()) is expected
 
 
-def test_initialize_attn_qparams_uses_decoder_text_config():
-    text_config = SimpleNamespace(
-        num_attention_heads=8,
-        num_key_value_heads=2,
-        head_dim=16,
+def test_is_attention_module_is_deprecated():
+    with pytest.warns(DeprecationWarning, match="is_cached_attention_module"):
+        assert is_attention_module(CacheAwareAttention()) is True
+
+
+def test_is_cached_attention_module_warns_once(monkeypatch):
+    warning = Mock()
+    monkeypatch.setattr(
+        initialize_lifecycle.inspect,
+        "signature",
+        Mock(side_effect=ValueError("signature unavailable")),
     )
-    config = CompositeConfig(text_config)
+    monkeypatch.setattr(initialize_lifecycle._LOGGER, "warning", warning)
+    monkeypatch.setattr(initialize_lifecycle, "_signature_warning_emitted", False)
 
-    attention = _initialize_attn_qparams(config)
+    assert is_cached_attention_module(CacheAwareAttention()) is False
+    assert is_cached_attention_module(CacheAwareAttention()) is False
 
-    assert config.decoder is True
-    assert getattr(attention, "kv_cache").config is config
-    assert config.text_config is text_config
-    assert config.vision_config.model_type == "vision"
-    assert attention.k_scale.shape == (2, 1, 1)
-    assert attention.v_scale.shape == (2, 1, 1)
+    warning.assert_called_once()
 
 
-def test_initialize_attn_qparams_falls_back_to_text_config():
-    text_config = SimpleNamespace(
-        num_attention_heads=8,
-        num_key_value_heads=2,
-        head_dim=16,
-    )
+class MockKVCache(torch.nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+
+
+def test_initialize_attn_qparams_uses_kv_cache_config():
     config = SimpleNamespace(
-        text_config=text_config,
-        vision_config=SimpleNamespace(model_type="vision"),
-    )
-
-    attention = _initialize_attn_qparams(config)
-
-    assert getattr(attention, "kv_cache").config is config
-    assert config.text_config is text_config
-    assert config.vision_config.model_type == "vision"
-    assert attention.k_scale.shape == (2, 1, 1)
-    assert attention.v_scale.shape == (2, 1, 1)
-
-
-def test_initialize_attn_qparams_ignores_none_text_config():
-    config = SimpleNamespace(
-        text_config=None,
         num_attention_heads=8,
         num_key_value_heads=2,
         head_dim=16,

--- a/tests/test_quantization/lifecycle/test_initialize.py
+++ b/tests/test_quantization/lifecycle/test_initialize.py
@@ -95,7 +95,7 @@ def test_is_cached_attention_module_warns_once(monkeypatch):
     monkeypatch.setattr(initialize_lifecycle, "_signature_warning_emitted", False)
 
     assert is_cached_attention_module(CacheAwareAttention()) is False
-    assert is_cached_attention_module(CacheAwareAttention()) is False
+    assert is_cached_attention_module(PluralCacheAwareAttention()) is False
 
     warning.assert_called_once()
 

--- a/tests/test_quantization/lifecycle/test_initialize.py
+++ b/tests/test_quantization/lifecycle/test_initialize.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import math
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -15,7 +16,9 @@ from compressed_tensors.quantization import (
     QuantizationStrategy,
 )
 from compressed_tensors.quantization.lifecycle.initialize import (
+    initialize_attn_qparams,
     initialize_module_for_quantization,
+    is_kv_cache_attention_module,
 )
 from tests.testing_utils import requires_gpu
 from torch.nn import Linear
@@ -29,9 +32,130 @@ Q_PARAM_NAMES = {
 }
 
 
+class CacheAwareAttention(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.k_proj = torch.nn.Linear(4, 4)
+
+    def forward(self, hidden_states, past_key_value=None):
+        return hidden_states
+
+
+class PluralCacheAwareAttention(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.k_proj = torch.nn.Linear(4, 4)
+
+    def forward(self, hidden_states, past_key_values=None):
+        return hidden_states
+
+
+class EncoderAttention(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.k_proj = torch.nn.Linear(4, 4)
+
+    def forward(self, hidden_states, **kwargs):
+        return hidden_states
+
+
+class MockKVCache(torch.nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+
+
+class CompositeConfig:
+    def __init__(self, text_config):
+        self.text_config = text_config
+        self.vision_config = SimpleNamespace(model_type="vision")
+        self.decoder = None
+
+    def get_text_config(self, decoder=False):
+        self.decoder = decoder
+        return self.text_config
+
+
 @pytest.fixture
 def layer():
     return Linear(4, 4)
+
+
+@pytest.mark.parametrize(
+    "attention_cls, expected",
+    [
+        (CacheAwareAttention, True),
+        (PluralCacheAwareAttention, True),
+        (EncoderAttention, False),
+    ],
+)
+def test_is_kv_cache_attention_module(attention_cls, expected):
+    assert is_kv_cache_attention_module(attention_cls()) is expected
+
+
+def test_initialize_attn_qparams_uses_decoder_text_config():
+    text_config = SimpleNamespace(
+        num_attention_heads=8,
+        num_key_value_heads=2,
+        head_dim=16,
+    )
+    config = CompositeConfig(text_config)
+
+    attention = _initialize_attn_qparams(config)
+
+    assert config.decoder is True
+    assert getattr(attention, "kv_cache").config is config
+    assert config.text_config is text_config
+    assert config.vision_config.model_type == "vision"
+    assert attention.k_scale.shape == (2, 1, 1)
+    assert attention.v_scale.shape == (2, 1, 1)
+
+
+def test_initialize_attn_qparams_falls_back_to_text_config():
+    text_config = SimpleNamespace(
+        num_attention_heads=8,
+        num_key_value_heads=2,
+        head_dim=16,
+    )
+    config = SimpleNamespace(
+        text_config=text_config,
+        vision_config=SimpleNamespace(model_type="vision"),
+    )
+
+    attention = _initialize_attn_qparams(config)
+
+    assert getattr(attention, "kv_cache").config is config
+    assert config.text_config is text_config
+    assert config.vision_config.model_type == "vision"
+    assert attention.k_scale.shape == (2, 1, 1)
+    assert attention.v_scale.shape == (2, 1, 1)
+
+
+def test_initialize_attn_qparams_ignores_none_text_config():
+    config = SimpleNamespace(
+        text_config=None,
+        num_attention_heads=8,
+        num_key_value_heads=2,
+        head_dim=16,
+    )
+
+    attention = _initialize_attn_qparams(config)
+
+    assert getattr(attention, "kv_cache").config is config
+    assert attention.k_scale.shape == (2, 1, 1)
+    assert attention.v_scale.shape == (2, 1, 1)
+
+
+def _initialize_attn_qparams(config):
+    attention = CacheAwareAttention()
+    attention.kv_cache = MockKVCache(config)
+    scheme = QuantizationScheme(
+        targets=["CacheAwareAttention"],
+        input_activations=QuantizationArgs(strategy=QuantizationStrategy.ATTN_HEAD),
+    )
+
+    initialize_attn_qparams(attention, scheme, force_zero_point=False)
+    return attention
 
 
 @pytest.mark.parametrize(

--- a/tests/test_quantization/lifecycle/test_initialize.py
+++ b/tests/test_quantization/lifecycle/test_initialize.py
@@ -84,20 +84,25 @@ def test_is_attention_module_is_deprecated():
         assert is_attention_module(CacheAwareAttention()) is True
 
 
-def test_is_cached_attention_module_warns_once(monkeypatch):
+@pytest.mark.parametrize("error_type", [TypeError, ValueError])
+def test_is_cached_attention_module_warns_and_returns_false_when_uninspectable(
+    monkeypatch, error_type
+):
     warning = Mock()
     monkeypatch.setattr(
         initialize_lifecycle.inspect,
         "signature",
-        Mock(side_effect=ValueError("signature unavailable")),
+        Mock(side_effect=error_type("signature unavailable")),
     )
-    monkeypatch.setattr(initialize_lifecycle._LOGGER, "warning", warning)
-    monkeypatch.setattr(initialize_lifecycle, "_signature_warning_emitted", False)
+    monkeypatch.setattr(initialize_lifecycle.logger, "warning", warning)
 
     assert is_cached_attention_module(CacheAwareAttention()) is False
-    assert is_cached_attention_module(PluralCacheAwareAttention()) is False
 
-    warning.assert_called_once()
+    warning.assert_called_once_with(
+        "Unable to inspect an attention module's forward signature; "
+        "skipping KV cache quantization for uninspectable modules",
+        log_once=True,
+    )
 
 
 class MockKVCache(torch.nn.Module):


### PR DESCRIPTION
## Summary

Fix KV cache quantization for composite multimodal model configurations such as `Gemma4Config`.

## Problem

Composite models may keep attention shape attributes under a nested text configuration rather than the top-level model config. In addition, generic attention detection also matches vision and audio attention modules that do not use an autoregressive KV cache.

This can either fail KV cache quantization initialization or create `k_scale` / `v_scale` parameters for non-cache attention modules that vLLM cannot load.

## Solution

- Resolve the decoder text configuration with `model.config.get_text_config(decoder=True)` when initializing `QuantizedKVCache`.
- Detect cached attention modules by requiring `past_key_value` or `past_key_values` in the module's `forward()` signature.
- Apply KV cache and attention quantization only to cached attention modules, excluding vision and encoder attention.
- Deprecate `is_attention_module()` in favor of `is_cached_attention_module()`.
- Emit a one-time warning and skip the module when its `forward()` signature cannot be inspected.

The model's original top-level configuration is not modified, so nested configurations such as `vision_config` remain intact.

## Testing

- `pytest -q tests/test_quantization/lifecycle tests/test_modeling/test_attention_and_cache.py`
  - `88 passed, 4 skipped`
- `make quality`
  - passed
- Quantized `google/gemma-4-31B-it-qat-q4_0-unquantized` to NVFP4 with FP8 KV cache using `llm-compressor`.
- Confirmed that the output model is saved with `quantization_status: compressed`.
- Confirmed that `text_config` and `vision_config` remain present and that the top-level model type remains `gemma4`.