### PR TITLE
Fix NVFP4 packing for float32 inputs

### DIFF
--- a/src/compressed_tensors/compressors/nvfp4/helpers.py
+++ b/src/compressed_tensors/compressors/nvfp4/helpers.py
@@ -125,7 +125,7 @@ def pack_fp4_to_uint8(x: torch.Tensor) -> torch.Tensor:
     if x.is_cuda or x.is_xpu:
         # Valid FP4 values are exactly representable in bf16, so this lossless
         # cast keeps Triton's 16-bit bitcast path working for float32 inputs.
-        if x.dtype == torch.float32:
+        if x.dtype not in (torch.bfloat16, torch.float16):
             x = x.to(torch.bfloat16)
         x_flat = x.contiguous().flatten()
         n_pairs = x_flat.numel() // 2

--- a/src/compressed_tensors/compressors/nvfp4/helpers.py
+++ b/src/compressed_tensors/compressors/nvfp4/helpers.py
@@ -123,6 +123,10 @@ def pack_fp4_to_uint8(x: torch.Tensor) -> torch.Tensor:
 
     # Use Triton kernel on GPU (CUDA, ROCm, XPU)
     if x.is_cuda or x.is_xpu:
+        # Valid FP4 values are exactly representable in bf16, so this lossless
+        # cast keeps Triton's 16-bit bitcast path working for float32 inputs.
+        if x.dtype == torch.float32:
+            x = x.to(torch.bfloat16)
         x_flat = x.contiguous().flatten()
         n_pairs = x_flat.numel() // 2
 

--- a/tests/test_compressors/test_fp4_optimizations.py
+++ b/tests/test_compressors/test_fp4_optimizations.py
@@ -59,6 +59,25 @@ def test_pack_fp4_to_uint8(device, test_input):
     assert torch.equal(result_current, result_reference)
 
 
+@pytest.mark.parametrize("device", ["cuda"])
+def test_pack_fp4_to_uint8_float32_input(device):
+    """Test pack_fp4_to_uint8 accepts float32 inputs in the valid FP4 set."""
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    from compressed_tensors.compressors.nvfp4.helpers import pack_fp4_to_uint8
+
+    x = torch.tensor(
+        [[0.0, -0.5, 1.0, -1.5, 2.0, -3.0, 4.0, -6.0]],
+        dtype=torch.float32,
+        device=device,
+    )
+    result_current = pack_fp4_to_uint8(x)
+    result_reference = reference_pack_fp4_to_uint8(x)
+
+    assert torch.equal(result_current, result_reference)
+
+
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
 def test_pack_fp4_non_contiguous(device):
     """Test pack_fp4_to_uint8 works correctly with non-contiguous input tensors."""


### PR DESCRIPTION
## Summary
- cast float32 tensors to bfloat16 before launching the NVFP4 Triton pack kernel
- preserve packing correctness because valid FP4 values are exactly representable in bfloat16
- add coverage for float32 GPU inputs in the FP4 packing optimization tests

## Testing
 pytest -sv tests/test_compressors/test_fp4_optimizations.py
 pytest -sv tests/test_compressors/test_fp4_quant.py