### PR TITLE
`save_mtp_tensors_to_checkpoint` graceful failure

### DIFF
--- a/src/compressed_tensors/distributed/utils.py
+++ b/src/compressed_tensors/distributed/utils.py
@@ -75,12 +75,15 @@ def init_dist():
     else:
         backend = "gloo"
 
+    import datetime
+
     dist.init_process_group(
         backend=backend,
         init_method="env://",
         rank=rank,
         world_size=world_size,
         device_id=device,
+        timeout=datetime.timedelta(hours=3),
     )
     dist.barrier()
 

--- a/src/compressed_tensors/distributed/utils.py
+++ b/src/compressed_tensors/distributed/utils.py
@@ -75,15 +75,12 @@ def init_dist():
     else:
         backend = "gloo"
 
-    import datetime
-
     dist.init_process_group(
         backend=backend,
         init_method="env://",
         rank=rank,
         world_size=world_size,
         device_id=device,
-        timeout=datetime.timedelta(hours=3),
     )
     dist.barrier()
 

--- a/src/compressed_tensors/utils/mtp.py
+++ b/src/compressed_tensors/utils/mtp.py
@@ -11,6 +11,7 @@ from compressed_tensors.utils.safetensors_load import (
     get_weight_mappings,
     update_safetensors_index,
 )
+from loguru import logger
 
 
 __all__ = ["save_mtp_tensors_to_checkpoint"]
@@ -49,6 +50,9 @@ def save_mtp_tensors_to_checkpoint(
     mtp_tensors = _fetch_and_save_prefix_tensors(
         source_model, mtp_prefix, dest_dir, shard_name
     )
+    if len(mtp_tensors) <= 0:
+        logger.warning(f"Could not find MTP weights with prefix {mtp_prefix}")
+        return
 
     # Build weight_map from existing index or single-shard file, then add MTP entries.
     # update_safetensors_index will create the index file if it doesn't exist yet.
@@ -79,3 +83,5 @@ def save_mtp_tensors_to_checkpoint(
                 config[QUANTIZATION_CONFIG_NAME] = quant_config
                 with open(config_path, "w") as f:
                     json.dump(config, f, indent=2)
+
+    logger.warning(f"Copied MTP weights from {source_model} to {dest_dir}")

--- a/src/compressed_tensors/utils/mtp.py
+++ b/src/compressed_tensors/utils/mtp.py
@@ -84,4 +84,4 @@ def save_mtp_tensors_to_checkpoint(
                 with open(config_path, "w") as f:
                     json.dump(config, f, indent=2)
 
-    logger.warning(f"Copied MTP weights from {source_model} to {dest_dir}")
+    logger.info(f"Copied MTP weights from {source_model} to {dest_dir}")

--- a/src/compressed_tensors/utils/safetensors_load.py
+++ b/src/compressed_tensors/utils/safetensors_load.py
@@ -540,7 +540,7 @@ def is_quantization_param(name: str) -> bool:
 
 def _fetch_and_save_prefix_tensors(
     source_model: str, prefix: str, dest_dir: str, shard_name: str
-) -> dict:
+) -> dict[str, torch.Tensor]:
     """
     Extracts all tensors whose keys start with `prefix` from `source_model`
     and saves them as a new shard in `dest_dir`. This is useful when saving
@@ -553,7 +553,6 @@ def _fetch_and_save_prefix_tensors(
     :param dest_dir: destination directory to write the shard into
     :param shard_name: filename for the new shard
     :return: dict mapping tensor key to tensor
-
     """
     model_files = get_checkpoint_files(source_model)
     weight_map = get_weight_map(model_files)
@@ -569,8 +568,6 @@ def _fetch_and_save_prefix_tensors(
             with safe_open(filepath, framework="pt", device="cpu") as f:
                 tensors[key] = f.get_tensor(key)
 
-    if len(tensors) <= 0:
-        raise ValueError(f"No tensors with prefix '{prefix}' found in {source_model}")
-
-    save_file(tensors, os.path.join(dest_dir, shard_name))
+    if len(tensors) > 0:
+        save_file(tensors, os.path.join(dest_dir, shard_name))
     return tensors

--- a/tests/test_utils/test_save_mtp_tensors.py
+++ b/tests/test_utils/test_save_mtp_tensors.py
@@ -219,10 +219,10 @@ class TestSaveMtpTensorsToCheckpoint:
         assert index["weight_map"].get("model.layer0.weight") == SAFE_WEIGHTS_NAME
         assert index["weight_map"].get("mtp.layer0.weight") == "model_mtp.safetensors"
 
-    def test_no_mtp_tensors_raises(self, dest_dir_with_index, tmp_path):
+    def test_no_mtp_tensors_no_op(self, dest_dir_with_index, tmp_path):
         """
-        Verify that a ValueError is raised when the source checkpoint has no
-        tensors matching the MTP prefix, preventing a silent empty-shard write.
+        Verify that when the source checkpoint has no tensors matching the MTP
+        prefix, the function logs a warning and returns without writing any shard.
         """
         src = tmp_path / "src_no_mtp"
         src.mkdir()
@@ -230,8 +230,8 @@ class TestSaveMtpTensorsToCheckpoint:
             str(src / SAFE_WEIGHTS_NAME), {"model.weight": torch.randn(4, 4)}
         )
 
-        with pytest.raises(ValueError, match="No tensors with prefix"):
-            save_mtp_tensors_to_checkpoint(str(src), str(dest_dir_with_index))
+        save_mtp_tensors_to_checkpoint(str(src), str(dest_dir_with_index))
+        assert not os.path.exists(str(dest_dir_with_index / "model_mtp.safetensors"))
 
     def test_missing_dest_files_raises(self, source_dir, tmp_path):
         """


### PR DESCRIPTION
## Purpose ##
* Since `save_mtp_tensors_to_checkpoint` will be used at the very end for saving models, it's best to gracefully fail if, for any reason, there are no mtp weights under the mtp prefix. Some models indeed do not use the mtp prefix
