### PR TITLE
[offload] wrap offload calls in try/finally

### DIFF
--- a/src/compressed_tensors/offload/cache/base.py
+++ b/src/compressed_tensors/offload/cache/base.py
@@ -262,9 +262,11 @@ class OffloadCache(MutableMapping, ABC):
         if not OffloadCache.offloading_disabled:
             restore_value = OffloadCache.offloading_disabled
             OffloadCache.offloading_disabled = True
-            yield
-            OffloadCache.offloading_disabled = restore_value
-            OffloadCache.keep_onloaded_values.clear()
+            try:
+                yield
+            finally:
+                OffloadCache.offloading_disabled = restore_value
+                OffloadCache.keep_onloaded_values.clear()
         else:
             yield
 
@@ -279,7 +281,9 @@ class OffloadCache(MutableMapping, ABC):
         if not OffloadCache.onloading_disabled:
             restore_value = OffloadCache.onloading_disabled
             OffloadCache.onloading_disabled = True
-            yield
-            OffloadCache.onloading_disabled = restore_value
+            try:
+                yield
+            finally:
+                OffloadCache.onloading_disabled = restore_value
         else:
             yield


### PR DESCRIPTION
## Summary
Fix exception-unsafe context managers in OffloadCache.disable_onloading() and OffloadCache.disable_offloading() by wrapping yield in try/finally

## Problem
When an exception propagates through disable_onloading() (e.g. during trace_subgraphs), the @contextmanager generator is abandoned at the yield and the cleanup line never runs. This leaves OffloadCache.onloading_disabled = True permanently, silently breaking all subsequent weight offloading in the process — model weights stay on CPU when they should be moved to CUDA.

This was surfaced by a new test (test_linear_target_fails_trace) that intentionally raises inside a trace_subgraphs call, which internally enters disable_onloading(). The leaked global state caused test_disable_lm_head[sequential] to fail when the two test files ran together.

## Fix
Added try/finally around the yield in both disable_offloading() and disable_onloading(), matching the pattern already used by HooksMixin.disable_hooks().

## Test plan
- [x] in https://github.com/vllm-project/llm-compressor/pull/2912, `pytest tests/llmcompressor/pipelines/sequential/test_glm_moe_dsa_trace.py tests/llmcompressor/utils/test_helpers.py` previously failed, now all pass