### PR TITLE
Allow quantization initialization on compressed modules

### DIFF
--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -43,6 +43,30 @@ __all__ = [
 _LOGGER = logging.getLogger(__name__)
 
 
+def _observed_weight_meta(module: Module) -> tuple[torch.Size, torch.dtype]:
+    """Return the module weight's (shape, dtype) without materializing it.
+
+    Falls back to the compressed ``weight_shape``/``weight_scale`` metadata when the
+    module has no dense ``weight`` (e.g. loaded with ``run_compressed=True``), so
+    quantization params can be initialized on a still-compressed module.
+    """
+    if hasattr(module, "weight"):
+        with disable_onloading():
+            weight = module.weight
+        return weight.shape, weight.dtype
+
+    weight_shape = getattr(module, "weight_shape", None)
+    if weight_shape is None:
+        raise AttributeError(
+            f"{type(module).__name__} has neither 'weight' nor 'weight_shape'; "
+            "cannot initialize quantization params"
+        )
+    shape = torch.Size(int(dim) for dim in weight_shape.tolist())
+    weight_scale = getattr(module, "weight_scale", None)
+    dtype = weight_scale.dtype if weight_scale is not None else torch.bfloat16
+    return shape, dtype
+
+
 def initialize_module_for_quantization(
     module: Module,
     scheme: QuantizationScheme | None = None,
@@ -68,22 +92,25 @@ def initialize_module_for_quantization(
     if scheme is None:
         return
 
+    # Capture weight shape/dtype before clearing qparams: on a compressed module the
+    # metadata lives in ``weight_shape``, which ``clear_all_qparams`` would remove.
+    is_linear = isinstance(module, (torch.nn.Linear, torch.nn.Embedding))
+    if is_linear:
+        observed_shape, observed_dtype = _observed_weight_meta(module)
+
     QuantizationMetadata.clear_all_qparams(module)
 
     if is_attention_module(module):
         initialize_attn_qparams(module, scheme, force_zero_point)
 
-    elif isinstance(module, (torch.nn.Linear, torch.nn.Embedding)):
-        with disable_onloading():
-            weight = module.weight
-
+    elif is_linear:
         if scheme.input_activations is not None:
             initialize_qparams(
                 module,
                 "input",
                 scheme.input_activations,
-                observed_shape=weight.shape[-1:],
-                observed_dtype=weight.dtype,
+                observed_shape=observed_shape[-1:],
+                observed_dtype=observed_dtype,
                 force_zero_point=force_zero_point,
             )
 
@@ -92,8 +119,8 @@ def initialize_module_for_quantization(
                 module,
                 "weight",
                 scheme.weights,
-                observed_shape=weight.shape,
-                observed_dtype=weight.dtype,
+                observed_shape=observed_shape,
+                observed_dtype=observed_dtype,
                 force_zero_point=force_zero_point,
             )
 
@@ -102,8 +129,8 @@ def initialize_module_for_quantization(
                 module,
                 "output",
                 scheme.output_activations,
-                observed_shape=weight.shape[:-1],
-                observed_dtype=weight.dtype,
+                observed_shape=observed_shape[:-1],
+                observed_dtype=observed_dtype,
                 force_zero_point=force_zero_point,
             )
 

--- a/src/compressed_tensors/quantization/lifecycle/initialize.py
+++ b/src/compressed_tensors/quantization/lifecycle/initialize.py
@@ -95,10 +95,20 @@ def initialize_module_for_quantization(
     # Capture weight shape/dtype before clearing qparams: on a compressed module the
     # metadata lives in ``weight_shape``, which ``clear_all_qparams`` would remove.
     is_linear = isinstance(module, (torch.nn.Linear, torch.nn.Embedding))
+    saved_weight_shape = None
     if is_linear:
         observed_shape, observed_dtype = _observed_weight_meta(module)
+        if not hasattr(module, "weight"):
+            # still compressed: weight_shape is needed to decompress later
+            saved_weight_shape = getattr(module, "weight_shape", None)
 
     QuantizationMetadata.clear_all_qparams(module)
+
+    if saved_weight_shape is not None:
+        if isinstance(saved_weight_shape, torch.nn.Parameter):
+            module.register_parameter("weight_shape", saved_weight_shape)
+        else:
+            module.weight_shape = saved_weight_shape
 
     if is_attention_module(module):
         initialize_attn_qparams(module, scheme, force_zero_point)

--- a/tests/test_quantization/lifecycle/test_initialize.py
+++ b/tests/test_quantization/lifecycle/test_initialize.py
@@ -242,3 +242,30 @@ def test_initialize_quantization_parameters(weights, input_activations):
             assert getattr(layer, f"{q_param_name}_g_idx").shape == (
                 layer.weight.shape[1],
             )
+
+
+def test_initialize_tolerates_compressed_module():
+    from compressed_tensors.compressors import compress_module
+    from compressed_tensors.quantization import (
+        QuantizationArgs,
+        QuantizationScheme,
+        QuantizationStatus,
+    )
+
+    lin = torch.nn.Linear(128, 256, bias=False).to(torch.bfloat16)
+    scheme = QuantizationScheme(
+        targets=["Linear"],
+        weights=QuantizationArgs(num_bits=4, group_size=64, symmetric=True),
+    )
+    lin.quantization_scheme = scheme
+    initialize_module_for_quantization(lin, scheme)
+    lin.quantization_status = QuantizationStatus.FROZEN
+    compress_module(lin)
+    assert not hasattr(lin, "weight")
+
+    out_features = int(lin.weight_shape[0].item())  # captured before re-init clears it
+
+    # must not raise, and must create a correctly-shaped weight_scale
+    initialize_module_for_quantization(lin, scheme)
+    assert hasattr(lin, "weight_scale")
+    assert lin.weight_scale.shape[0] == out_features


### PR DESCRIPTION
> [!NOTE]
> **Superseded by the revised design in
> vllm-project/llm-compressor#2970.** Quantization initialization is now deferred
> until each sequential subgraph has been decompressed, so compressed modules and
> their format-specific metadata are not modified. That implementation passes against
> an unmodified compressed-tensors `main` checkout; this PR is no longer required.

## Original summary

Allow `initialize_module_for_quantization` to run on **compressed** modules — modules
that carry `weight_packed`/`weight_scale`/`weight_shape` and have no dense `.weight`
(e.g. loaded with `run_compressed=True`).

Previously init did `weight = module.weight` and read `weight.shape`/`weight.dtype` to
size scale/zero-point params, which raised `AttributeError` on a compressed module.
Additionally, `clear_all_qparams` lists `weight_shape` as a qparam and deletes it, which
would leave the module undecompressable.

## Changes

- Add `_observed_weight_meta(module)`: returns the weight `(shape, dtype)` without
  materializing it, falling back to `weight_shape` / `weight_scale` metadata when there
  is no dense `.weight`.
- Preserve and restore `weight_shape` across `clear_all_qparams` for still-compressed
  modules, so the module remains decompressable after init.

Only shape/dtype **metadata** is read — no weight data is materialized.

## Testing

```text
pytest tests/test_quantization/lifecycle/test_initialize.py
# 12 passed, 3 skipped
```

## Notes

AI assistance (Claude) was used to help implement and test this change; the human author
must review every changed line and understand the change end-to-end.
