### PR TITLE
feat: cap shared memory budget by mmap descriptor limit

### DIFF
--- a/src/compressed_tensors/offload/load.py
+++ b/src/compressed_tensors/offload/load.py
@@ -62,12 +62,26 @@ def load_offloaded_model(
         elif kwargs["device_map"] == "auto_offload":
             kwargs["device_map"] = "auto"
             if "max_memory" not in kwargs:
-                kwargs["max_memory"] = _get_cpu_memory(extra_cpu_mem)
+                num_tensors, total_bytes = 0, 0
+                if is_distributed():
+                    num_tensors, total_bytes = _estimate_tensor_count(
+                        original_from_pretrained, *args, **kwargs
+                    )
+                kwargs["max_memory"] = _get_cpu_memory(
+                    extra_cpu_mem, num_tensors, total_bytes
+                )
 
         # Unless the user specifies, use our memory estimates, which take into
         # account distributed setups and extra cpu reserved memory
         elif "max_memory" not in kwargs:
-            kwargs["max_memory"] = _get_device_memory() | _get_cpu_memory(extra_cpu_mem)
+            num_tensors, total_bytes = 0, 0
+            if is_distributed():
+                num_tensors, total_bytes = _estimate_tensor_count(
+                    original_from_pretrained, *args, **kwargs
+                )
+            kwargs["max_memory"] = _get_device_memory() | _get_cpu_memory(
+                extra_cpu_mem, num_tensors, total_bytes
+            )
 
         # Unless the user specifies, use `offload_buffers` to avoid accelerate weirdness
         if not kwargs.get("offload_buffers", True):
@@ -103,21 +117,83 @@ def _get_device_memory() -> dict[int, int]:
         }
 
 
-def _get_cpu_memory(extra_cpu_mem: int) -> dict[str, int]:
+def _get_cpu_memory(
+    extra_cpu_mem: int, num_tensors: int = 0, total_model_bytes: int = 0
+) -> dict[str, int]:
     if is_distributed():
-        return {"cpu": _get_shared_memory() - extra_cpu_mem}
+        return {
+            "cpu": _get_shared_memory(num_tensors, total_model_bytes) - extra_cpu_mem
+        }
     else:
         return {"cpu": psutil.virtual_memory().available - extra_cpu_mem}
 
 
-def _get_shared_memory() -> int:
+def _get_shared_memory(num_tensors: int = 0, total_model_bytes: int = 0) -> int:
     linux_shm_path = "/dev/shm"
-    if os.path.exists(linux_shm_path):
-        total, _used, _free = shutil.disk_usage(linux_shm_path)
-        return total
-
-    else:
+    if not os.path.exists(linux_shm_path):
         logger.warning(
             "Could not find shared memory at `/dev/shm`. Please add platform suppport"
         )
         return psutil.virtual_memory().available
+
+    shm_bytes = shutil.disk_usage(linux_shm_path).total
+
+    if num_tensors > 0:
+        max_map_count = _get_max_map_count()
+        if max_map_count is not None:
+            curr_maps = _get_current_map_count()
+            available_maps = max(0, max_map_count - curr_maps)
+            avg_tensor_bytes = total_model_bytes // num_tensors
+            mmap_byte_budget = available_maps * avg_tensor_bytes
+
+            if mmap_byte_budget < shm_bytes:
+                logger.info(
+                    f"Capping shared memory from {shm_bytes} to {mmap_byte_budget} "
+                    f"bytes based on mmap limit {max_map_count}."
+                )
+            shm_bytes = min(shm_bytes, mmap_byte_budget)
+
+    return shm_bytes
+
+
+def _get_max_map_count() -> int | None:
+    try:
+        with open("/proc/sys/vm/max_map_count") as f:
+            return int(f.read().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _get_current_map_count() -> int:
+    try:
+        with open("/proc/self/maps") as f:
+            return sum(1 for _ in f)
+    except OSError:
+        return 0
+
+
+def _estimate_tensor_count(
+    original_from_pretrained, *args, **kwargs
+) -> tuple[int, int]:
+    """helper to load model on meta device to count tensors + total bytes"""
+    meta_kwargs = {
+        k: v
+        for k, v in kwargs.items()
+        if k not in ("device_map", "max_memory", "offload_folder")
+    }
+    meta_kwargs.setdefault("tie_word_embeddings", False)
+    try:
+        meta_model = original_from_pretrained(*args, device_map="meta", **meta_kwargs)
+    except Exception:
+        logger.warning("Meta device preload failed, skipping capacity estimate.")
+        return 0, 0
+
+    num_tensors = sum(1 for _ in meta_model.parameters()) + sum(
+        1 for _ in meta_model.buffers()
+    )
+    total_bytes = sum(param.nbytes for param in meta_model.parameters()) + sum(
+        buffer.nbytes for buffer in meta_model.buffers()
+    )
+    del meta_model
+
+    return num_tensors, total_bytes

--- a/src/compressed_tensors/offload/load.py
+++ b/src/compressed_tensors/offload/load.py
@@ -194,6 +194,4 @@ def _estimate_tensor_count(
     total_bytes = sum(param.nbytes for param in meta_model.parameters()) + sum(
         buffer.nbytes for buffer in meta_model.buffers()
     )
-    del meta_model
-
     return num_tensors, total_bytes

--- a/tests/test_offload/test_load.py
+++ b/tests/test_offload/test_load.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
 from unittest.mock import MagicMock, patch
 
+import compressed_tensors.offload.load as load_module
 import pytest
 import torch
 from compressed_tensors.offload import (
@@ -138,3 +140,57 @@ def test_patch_forwards_positional_args(mock_from_accelerate):
     assert received["path"] == "org/model"
     assert received["kwargs"]["device_map"] == "cpu"
     assert received["kwargs"]["torch_dtype"] == "auto"
+
+
+@pytest.mark.unit
+def test_mmap_cap_reduces_shared_memory():
+    """Tight mmap limit reduces _get_shared_memory return value."""
+    with (
+        patch.object(load_module, "_get_max_map_count", return_value=100),
+        patch.object(load_module, "_get_current_map_count", return_value=50),
+    ):
+        # 500 tensors, 1024 bytes each = 512KB total
+        # Available maps = 100 - 50 = 50
+        # Avg tensor = 512000 / 500 = 1024 bytes
+        # mmap budget = 50 * 1024 = 51200
+        result = load_module._get_shared_memory(
+            num_tensors=500, total_model_bytes=512000
+        )
+        assert result == 51200
+
+
+@pytest.mark.unit
+def test_mmap_cap_no_reduction_when_limit_high():
+    """When mmap limit is very high, byte capacity is the bottleneck."""
+    with (
+        patch.object(load_module, "_get_max_map_count", return_value=10_000_000),
+        patch.object(load_module, "_get_current_map_count", return_value=500),
+    ):
+        result = load_module._get_shared_memory(
+            num_tensors=5000, total_model_bytes=5_000_000_000
+        )
+        # Should be the /dev/shm byte size, not reduced by mmap
+        import shutil
+
+        if os.path.exists("/dev/shm"):
+            expected = shutil.disk_usage("/dev/shm").total
+            assert result == expected
+
+
+@pytest.mark.unit
+def test_mmap_cap_graceful_on_non_linux():
+    """When /proc files aren't available, skip the mmap cap entirely."""
+    with patch.object(load_module, "_get_max_map_count", return_value=None):
+        # Should not crash, should return full /dev/shm size
+        result = load_module._get_shared_memory(
+            num_tensors=5000, total_model_bytes=5_000_000_000
+        )
+        assert result > 0
+
+
+@pytest.mark.unit
+def test_mmap_cap_skipped_without_tensor_info():
+    """When no tensor info provided, behave like before (bytes only)."""
+    result_no_info = load_module._get_shared_memory()
+    result_zero = load_module._get_shared_memory(num_tensors=0, total_model_bytes=0)
+    assert result_no_info == result_zero


### PR DESCRIPTION
Addresses #796 


When using `init_dist()` + `device_map="auto_offload"`, the CPU memory budget is set to the byte capacity of `/dev/shm`.  This only tells one half of the story, as there are two factors that play a role: bytes and mmap descriptor count (`vm.max_map_count`). 

Large models exhaust the mmap limit before running out of bytes, causing:

`RuntimeError: unable to mmap 98368 bytes from file </torch_...>: Cannot allocate memory`

This PR caps `max_memory["cpu"]` by `min(shm_bytes, mmap_byte_budget)`, where the mmap byte budget is derived from the kernel's remaining mmap slots and average tensor size.

## Reproduction

On a single H100 node (`vm.max_map_count=262144`), I confirmed the crash by monkey-patching `share_memory_()` with a low call limit:

```python
original_share = torch.Tensor.share_memory_
call_count = 0

def limited_share(self):
    global call_count
    call_count += 1
    if call_count > 10:
        raise RuntimeError("unable to mmap 98368 bytes from file </torch_mock>: Cannot allocate memory")
    return original_share(self)

torch.Tensor.share_memory_ = limited_share
```

This reproduced the exact RuntimeError from the issue. After applying the fix (with _get_max_map_count patched to a tight value), the model loaded successfully by pushing excess layers to disk instead of crashing. This was the best I could do with resources I had currently, as I don't have sudo to change the direct `max_map_count` value.

## Changes

- Add `_get_max_map_count()` / `_get_current_map_count()` helpers to read Linux mmap limits
- Add `_estimate_tensor_count()`:  meta-device preload to count model tensors and total bytes (zero real memory)
- Modify `_get_shared_memory()` to cap by mmap budget when tensor info is available
- Thread tensor info through `_get_cpu_memory()` and both `from_pretrained()` branches

 Map count is a point-in-time snapshot: `/proc/self/maps` is read once before loading. Between that read and the actual `.share_memory_()` calls, CUDA init or other libraries could consume additional maps, so the estimate is best-effort.

## Test plan

- [x] Reproduced the crash
- [x] Verified fix prevents crash (capping log message confirmed)
- [x] 4 unit tests: mmap cap reduces budget, no reduction when limit high, graceful on non-Linux, backward compat with no tensor info