### PR TITLE
[QuantizationConfig] drop propagation of quant config format to scheme format

### DIFF
--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -18,6 +18,7 @@ from compressed_tensors.utils.match import match_name
 from pydantic import BaseModel, ConfigDict, Field
 from torch.nn import Module
 
+
 __all__ = [
     "QuantizationStatus",
     "QuantizationConfig",

--- a/src/compressed_tensors/quantization/quant_config.py
+++ b/src/compressed_tensors/quantization/quant_config.py
@@ -18,7 +18,6 @@ from compressed_tensors.utils.match import match_name
 from pydantic import BaseModel, ConfigDict, Field
 from torch.nn import Module
 
-
 __all__ = [
     "QuantizationStatus",
     "QuantizationConfig",
@@ -177,16 +176,6 @@ class QuantizationConfig(BaseModel):
                 name=group_name,
                 targets=targets_or_scheme,
             )
-
-        # if unset, populate format on each config group
-        if self.format not in (
-            DEFAULT_QUANTIZATION_FORMAT,
-            CompressionFormat.mixed_precision,
-            CompressionFormat.dense,
-        ):
-            for scheme in self.config_groups.values():
-                if scheme.format is None:
-                    scheme.format = self.format
 
     def to_dict(self):
         # for compatibility with HFQuantizer


### PR DESCRIPTION
Resolves #795 

Summary:
To allow for oneshot on pre-quantized models, we added logic in #779 to propagate QuantizationConfig's global format down to each scheme, if no format was set on the scheme. This causes issues for downstream repos, like AutoRound's issue above. While this is ultimately because their created checkpoint has a quant config format that is incompatible with the scheme, @kylesayrs and I discussed that this propagation is unnecessary because the format can just be inferred, and because the quantization config is always created during save.

Test Plan:
- [x] Confirmed that [nightly smoke test](https://github.com/vllm-project/llm-compressor/blob/9e1fcd014aee90253b32e973a57826ad8694117d/tests/llmcompressor/entrypoints/oneshot/test_oneshot_pre_quantized.py#L66-L113) still passes, and asserts that quant format is correctly configured. I verified that this is still the case after deleting the scheme.format field from the intermediate checkpoint's config.json and re-running